### PR TITLE
Announcing Rust 1.69.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.68.2
+          toolchain: 1.69.0
           target: x86_64-unknown-linux-musl
           components: clippy, rustfmt
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.68.2"
+channel = "1.69.0"
 components = [ "rustfmt", "clippy", "cargo" ]
 profile = "minimal"


### PR DESCRIPTION
https://blog.rust-lang.org/2023/04/20/Rust-1.69.0.html