### PR TITLE
feat: Announcing Rust 1.70.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.69.0"
+channel = "1.70.0"
 components = [ "rustfmt", "clippy", "cargo" ]
 profile = "minimal"


### PR DESCRIPTION
https://blog.rust-lang.org/2023/06/01/Rust-1.70.0.html