### PR TITLE
SentryとTowerを連携する

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -2771,6 +2771,7 @@ dependencies = [
  "sentry-core",
  "sentry-debug-images",
  "sentry-panic",
+ "sentry-tower",
  "sentry-tracing",
  "tokio",
  "ureq",
@@ -2854,6 +2855,20 @@ checksum = "c4dfe8371c9b2e126a8b64f6fefa54cef716ff2a50e63b5558a48b899265bccd"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
+]
+
+[[package]]
+name = "sentry-tower"
+version = "0.31.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01c59d3325570b637cc844fef4e7cd9b3f997ffe4e5e83d5ccb85759c9df3bf2"
+dependencies = [
+ "http",
+ "pin-project",
+ "sentry-core",
+ "tower-layer",
+ "tower-service",
+ "url",
 ]
 
 [[package]]

--- a/server/entrypoint/Cargo.toml
+++ b/server/entrypoint/Cargo.toml
@@ -20,7 +20,7 @@ tower-http = { version = "0.4.1", features = ["cors"] }
 tracing-subscriber = "0.3.17"
 tokio = { version = "1.28.2", features = ["full"] }
 # default featureは推移的にnative-tls featureを有効しているため、native-tls (LinuxではOpenSSL) を連れてくる。これをオプトアウトするためにrustlsを使う。
-sentry = { version = "0.31.5", default-features = false, features = ["backtrace", "contexts", "panic", "anyhow", "reqwest", "profiling", "tracing", "debug-images", "rustls"] }
+sentry = { version = "0.31.5", default-features = false, features = ["backtrace", "contexts", "panic", "anyhow", "reqwest", "profiling", "tracing", "debug-images", "rustls", "tower", "tower-http"] }
 
 [dev-dependencies.cargo-husky]
 version = "1"


### PR DESCRIPTION
ref: https://crates.io/crates/sentry-tower
ref: https://docs.sentry.io/platforms/rust/performance/instrumentation/automatic-instrumentation/#http-instrumentation
ref: https://github.com/getsentry/symbolicator/blob/master/crates/symbolicator/Cargo.toml
ref: https://github.com/getsentry/symbolicator/blob/master/crates/symbolicator/src/endpoints/mod.rs