### PR TITLE
ユーザー認証(一部)を実装

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -634,7 +634,10 @@ name = "common"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "envy",
+ "once_cell",
  "proptest",
+ "serde",
 ]
 
 [[package]]
@@ -868,16 +871,13 @@ dependencies = [
  "anyhow",
  "axum",
  "cargo-husky",
- "envy",
+ "common",
  "hyper",
  "migration",
- "once_cell",
  "presentation",
  "resource",
  "sentry",
- "serde",
  "tokio",
- "tower",
  "tower-http",
  "tracing",
  "tracing-subscriber",
@@ -2078,6 +2078,7 @@ name = "presentation"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "common",
  "domain",
  "errors",
  "resource",

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -295,6 +295,7 @@ dependencies = [
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
+ "headers",
  "http",
  "http-body",
  "hyper",
@@ -360,6 +361,12 @@ dependencies = [
  "quote 1.0.28",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
@@ -1212,6 +1219,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "312f66718a2d7789ffef4f4b7b213138ed9f1eb3aa1d0d82fc99f88fb3ffd26f"
 dependencies = [
  "hashbrown 0.14.0",
+]
+
+[[package]]
+name = "headers"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
+dependencies = [
+ "base64 0.13.1",
+ "bitflags 1.3.2",
+ "bytes",
+ "headers-core",
+ "http",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+dependencies = [
+ "http",
 ]
 
 [[package]]
@@ -2302,7 +2334,7 @@ version = "0.11.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
 dependencies = [
- "base64",
+ "base64 0.21.2",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -2515,7 +2547,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
- "base64",
+ "base64 0.21.2",
 ]
 
 [[package]]
@@ -3711,7 +3743,7 @@ version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b11c96ac7ee530603dcdf68ed1557050f374ce55a5a07193ebf8cbc9f8927e9"
 dependencies = [
- "base64",
+ "base64 0.21.2",
  "log",
  "once_cell",
  "rustls 0.21.2",

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -878,6 +878,7 @@ dependencies = [
  "resource",
  "sentry",
  "tokio",
+ "tower",
  "tower-http",
  "tracing",
  "tracing-subscriber",
@@ -2085,7 +2086,7 @@ dependencies = [
  "serde_json",
  "tracing",
  "usecase",
- "uuid 1.3.4",
+ "uuid 1.4.0",
 ]
 
 [[package]]

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -2085,6 +2085,7 @@ dependencies = [
  "serde_json",
  "tracing",
  "usecase",
+ "uuid 1.3.4",
 ]
 
 [[package]]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -18,7 +18,7 @@ edition = "2021"
 publish = false
 
 [workspace.dependencies]
-axum = "0.6.18"
+axum = { version = "0.6.18", features = ["headers"] }
 serde = { version = "1.0.164", features = ["derive"] }
 anyhow = "1.0.71"
 async-trait = "0.1.68"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -35,3 +35,4 @@ serde_json = "1.0.99"
 itertools = "0.11.0"
 chrono = { version = "0.4.26" }
 futures = "0.3.28"
+uuid = "1.3.4"

--- a/server/common/Cargo.toml
+++ b/server/common/Cargo.toml
@@ -8,3 +8,6 @@ edition = "2021"
 [dependencies]
 proptest = { workspace = true }
 chrono = { workspace = true }
+once_cell = { workspace = true }
+serde = { workspace = true }
+envy = { workspace = true }

--- a/server/common/src/config.rs
+++ b/server/common/src/config.rs
@@ -1,13 +1,14 @@
 use once_cell::sync::Lazy;
+use serde::Deserialize;
 
-#[derive(serde::Deserialize, Debug)]
+#[derive(Deserialize, Debug)]
 pub struct Http {
     pub port: String,
 }
 
 pub static HTTP: Lazy<Http> = Lazy::new(|| envy::prefixed("HTTP_").from_env::<Http>().unwrap());
 
-#[derive(serde::Deserialize, Debug)]
+#[derive(Deserialize, Debug)]
 pub struct Env {
     pub name: String,
 }

--- a/server/common/src/lib.rs
+++ b/server/common/src/lib.rs
@@ -1,1 +1,2 @@
+pub mod config;
 pub mod test_utils;

--- a/server/entrypoint/Cargo.toml
+++ b/server/entrypoint/Cargo.toml
@@ -13,6 +13,7 @@ axum = { workspace = true }
 tracing = { workspace = true }
 anyhow = { workspace = true }
 hyper = { version = "0.14.27", features = ["full"] }
+tower = "0.4.13"
 tower-http = { version = "0.4.1", features = ["cors"] }
 tracing-subscriber = { version = "0.3.17", features = ["std", "registry", "env-filter"] }
 tokio = { version = "1.28.2", features = ["full"] }

--- a/server/entrypoint/Cargo.toml
+++ b/server/entrypoint/Cargo.toml
@@ -8,14 +8,11 @@ default-run = "entrypoint"
 resource = { path = "../infra/resource" }
 migration = { path = "../migration" }
 presentation = { path = "../presentation" }
+common = { path = "../common" }
 axum = { workspace = true }
-serde = { workspace = true }
-envy = { workspace = true }
 tracing = { workspace = true }
 anyhow = { workspace = true }
-once_cell = { workspace = true }
 hyper = { version = "0.14.27", features = ["full"] }
-tower = "0.4.13"
 tower-http = { version = "0.4.1", features = ["cors"] }
 tracing-subscriber = { version = "0.3.17", features = ["std", "registry", "env-filter"] }
 tokio = { version = "1.28.2", features = ["full"] }

--- a/server/entrypoint/src/main.rs
+++ b/server/entrypoint/src/main.rs
@@ -8,8 +8,8 @@ use axum::{
 };
 use common::config::{ENV, HTTP};
 use hyper::header::AUTHORIZATION;
-use presentation::auth::auth;
 use presentation::{
+    auth::auth,
     form_handler::{
         create_form_handler, delete_form_handler, form_list_handler, get_form_handler,
         update_form_handler,

--- a/server/entrypoint/src/main.rs
+++ b/server/entrypoint/src/main.rs
@@ -6,6 +6,7 @@ use axum::{
     routing::{get, post},
     Router,
 };
+use common::config::{ENV, HTTP};
 use hyper::header::AUTHORIZATION;
 use presentation::auth::auth;
 use presentation::{
@@ -21,10 +22,6 @@ use tokio::signal::unix::{signal, SignalKind};
 use tower_http::cors::{Any, CorsLayer};
 use tracing::log;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, Layer};
-
-use crate::config::{ENV, HTTP};
-
-mod config;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -76,7 +73,7 @@ async fn main() -> anyhow::Result<()> {
         .with_state(shared_repository.to_owned())
         .route("/health", get(health_check))
         .layer(layer)
-        .layer(middleware::from_fn(auth))
+        .route_layer(middleware::from_fn(auth))
         .layer(
             CorsLayer::new()
                 .allow_methods([Method::GET, Method::POST, Method::DELETE, Method::PATCH])

--- a/server/presentation/Cargo.toml
+++ b/server/presentation/Cargo.toml
@@ -8,6 +8,7 @@ resource = { path = "../infra/resource" }
 domain = { path = "../domain" }
 usecase = { path = "../usecase" }
 errors = { path = "../errors" }
+common = { path = "../common" }
 axum = { workspace = true }
 tracing = { workspace = true }
 serde_json = { workspace = true }

--- a/server/presentation/Cargo.toml
+++ b/server/presentation/Cargo.toml
@@ -12,3 +12,4 @@ common = { path = "../common" }
 axum = { workspace = true }
 tracing = { workspace = true }
 serde_json = { workspace = true }
+uuid = { workspace = true }

--- a/server/presentation/src/auth.rs
+++ b/server/presentation/src/auth.rs
@@ -6,10 +6,12 @@ use axum::{
     response::Response,
 };
 use common::config::ENV;
+use uuid::{uuid, Uuid};
 
 #[derive(Debug, Clone)]
 pub struct User {
     pub name: String,
+    pub uuid: Uuid,
 }
 
 pub async fn auth<B>(
@@ -21,6 +23,7 @@ pub async fn auth<B>(
     if ENV.name == "local" && auth.token() == "debug_user" {
         let user = User {
             name: "test_user".to_string(),
+            uuid: uuid!("478911be-3356-46c1-936e-fb14b71bf282"),
         };
         request.extensions_mut().insert(user);
         let response = next.run(request).await;

--- a/server/presentation/src/auth.rs
+++ b/server/presentation/src/auth.rs
@@ -5,11 +5,26 @@ use axum::{
     middleware::Next,
     response::Response,
 };
+use common::config::ENV;
+
+#[derive(Debug, Clone)]
+pub struct User {
+    pub name: String,
+}
 
 pub async fn auth<B>(
-    TypedHeader(_auth): TypedHeader<Authorization<Bearer>>,
-    _request: Request<B>,
-    _next: Next<B>,
+    TypedHeader(auth): TypedHeader<Authorization<Bearer>>,
+    mut request: Request<B>,
+    next: Next<B>,
 ) -> Result<Response, StatusCode> {
-    Err(StatusCode::UNAUTHORIZED)
+    if ENV.name == "local" && auth.token() == "debug_user" {
+        let user = User {
+            name: "test_user".to_string(),
+        };
+        request.extensions_mut().insert(user);
+        let response = next.run(request).await;
+        Ok(response)
+    } else {
+        Err(StatusCode::UNAUTHORIZED)
+    }
 }

--- a/server/presentation/src/auth.rs
+++ b/server/presentation/src/auth.rs
@@ -17,6 +17,7 @@ pub async fn auth<B>(
     mut request: Request<B>,
     next: Next<B>,
 ) -> Result<Response, StatusCode> {
+    //todo: フロントエンド側から何が返ってくるかがわかったらユーザー認証を実装する
     if ENV.name == "local" && auth.token() == "debug_user" {
         let user = User {
             name: "test_user".to_string(),

--- a/server/presentation/src/auth.rs
+++ b/server/presentation/src/auth.rs
@@ -1,0 +1,15 @@
+use axum::{
+    extract::TypedHeader,
+    headers::authorization::{Authorization, Bearer},
+    http::{Request, StatusCode},
+    middleware::Next,
+    response::Response,
+};
+
+pub async fn auth<B>(
+    TypedHeader(_auth): TypedHeader<Authorization<Bearer>>,
+    _request: Request<B>,
+    _next: Next<B>,
+) -> Result<Response, StatusCode> {
+    Err(StatusCode::UNAUTHORIZED)
+}

--- a/server/presentation/src/form_handler.rs
+++ b/server/presentation/src/form_handler.rs
@@ -40,15 +40,12 @@ pub async fn create_form_handler(
 }
 
 pub async fn form_list_handler(
-    Extension(user): Extension<User>,
     State(repository): State<RealInfrastructureRepository>,
     Query(offset_and_limit): Query<OffsetAndLimit>,
 ) -> impl IntoResponse {
     let form_use_case = FormUseCase {
         repository: repository.form_repository(),
     };
-
-    println!("{:?}", user);
 
     match form_use_case
         .form_list(offset_and_limit.offset, offset_and_limit.limit)

--- a/server/presentation/src/form_handler.rs
+++ b/server/presentation/src/form_handler.rs
@@ -2,7 +2,7 @@ use axum::{
     extract::{Path, Query, State},
     http::StatusCode,
     response::IntoResponse,
-    Json,
+    Extension, Json,
 };
 use domain::{
     form::models::{Form, FormId, FormUpdateTargets, OffsetAndLimit},
@@ -12,6 +12,8 @@ use errors::presentation::PresentationError::FormNotFound;
 use resource::repository::RealInfrastructureRepository;
 use serde_json::json;
 use usecase::form::FormUseCase;
+
+use crate::auth::User;
 
 pub async fn create_form_handler(
     State(repository): State<RealInfrastructureRepository>,
@@ -38,12 +40,15 @@ pub async fn create_form_handler(
 }
 
 pub async fn form_list_handler(
+    Extension(user): Extension<User>,
     State(repository): State<RealInfrastructureRepository>,
     Query(offset_and_limit): Query<OffsetAndLimit>,
 ) -> impl IntoResponse {
     let form_use_case = FormUseCase {
         repository: repository.form_repository(),
     };
+
+    println!("{:?}", user);
 
     match form_use_case
         .form_list(offset_and_limit.offset, offset_and_limit.limit)

--- a/server/presentation/src/form_handler.rs
+++ b/server/presentation/src/form_handler.rs
@@ -2,7 +2,7 @@ use axum::{
     extract::{Path, Query, State},
     http::StatusCode,
     response::IntoResponse,
-    Extension, Json,
+    Json,
 };
 use domain::{
     form::models::{Form, FormId, FormUpdateTargets, OffsetAndLimit},
@@ -12,8 +12,6 @@ use errors::presentation::PresentationError::FormNotFound;
 use resource::repository::RealInfrastructureRepository;
 use serde_json::json;
 use usecase::form::FormUseCase;
-
-use crate::auth::User;
 
 pub async fn create_form_handler(
     State(repository): State<RealInfrastructureRepository>,

--- a/server/presentation/src/lib.rs
+++ b/server/presentation/src/lib.rs
@@ -1,2 +1,3 @@
+pub mod auth;
 pub mod form_handler;
 pub mod health_check_handler;


### PR DESCRIPTION
ユーザー認証(一部)を実装しました。
開発環境でのみBearer tokenを`debug_user`にすることで認証できるようにするために、configの読み取りの実装をcommonに移動しました。
細かいユーザーに関する操作の実装などは、別PRで行います。