### PR TITLE
refactor: more clean architecture

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 
 [[package]]
 name = "addr2line"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
+checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
 dependencies = [
  "gimli",
 ]
@@ -243,7 +243,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2 1.0.63",
  "quote 1.0.29",
- "syn 2.0.22",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -260,7 +260,7 @@ checksum = "7b2d0f03b3640e3a630367e40c468cb7f309529c708ed1d88597047b0e7c6ef7"
 dependencies = [
  "proc-macro2 1.0.63",
  "quote 1.0.29",
- "syn 2.0.22",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -336,9 +336,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.67"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
+checksum = "4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12"
 dependencies = [
  "addr2line",
  "cc",
@@ -758,7 +758,7 @@ checksum = "53e0efad4403bfc52dc201159c4b842a246a14b98c64b55dfd0f2d89729dfeb8"
 dependencies = [
  "proc-macro2 1.0.63",
  "quote 1.0.29",
- "syn 2.0.22",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -770,7 +770,7 @@ dependencies = [
  "convert_case",
  "proc-macro2 1.0.63",
  "quote 1.0.29",
- "syn 2.0.22",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -786,7 +786,7 @@ dependencies = [
  "quote 1.0.29",
  "strum",
  "strum_macros",
- "syn 2.0.22",
+ "syn 2.0.23",
  "typed-builder",
 ]
 
@@ -826,6 +826,7 @@ dependencies = [
  "strum_macros",
  "test-case",
  "typed-builder",
+ "types",
 ]
 
 [[package]]
@@ -1067,7 +1068,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2 1.0.63",
  "quote 1.0.29",
- "syn 2.0.22",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -1279,15 +1280,6 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
@@ -1444,7 +1436,7 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi 0.3.1",
+ "hermit-abi",
  "libc",
  "windows-sys",
 ]
@@ -1475,9 +1467,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+checksum = "62b02a5381cc465bd3041d84623d0fa3b66738b52b8e2fc3bab8ad63ab032f4a"
 
 [[package]]
 name = "js-sys"
@@ -1612,9 +1604,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.6.2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
  "adler",
 ]
@@ -1727,9 +1719,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint-dig"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2399c9463abc5f909349d8aa9ba080e0b88b3ce2885389b60b993f39b1a56905"
+checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
 dependencies = [
  "byteorder",
  "lazy_static",
@@ -1775,19 +1767,19 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.2.6",
+ "hermit-abi",
  "libc",
 ]
 
 [[package]]
 name = "object"
-version = "0.30.4"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b4680b86d9cfafba8fc491dc9b6df26b68cf40e9e6cd73909194759a63c385"
+checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
 dependencies = [
  "memchr",
 ]
@@ -1929,9 +1921,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
+checksum = "b4b27ab7be369122c218afc2079489cdcb4b517c0a3fc386ff11e1fedfcc2b35"
 
 [[package]]
 name = "pem-rfc7468"
@@ -1950,29 +1942,29 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pin-project"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c95a7476719eab1e366eaf73d0260af3021184f18177925b07f54b30089ceead"
+checksum = "030ad2bc4db10a8944cb0d837f158bdfec4d4a4873ab701a95046770d11f8842"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
+checksum = "ec2e072ecce94ec471b13398d5402c188e76ac03cf74dd1a975161b23a3f6d9c"
 dependencies = [
  "proc-macro2 1.0.63",
  "quote 1.0.29",
- "syn 2.0.22",
+ "syn 2.0.23",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+checksum = "4c40d25201921e5ff0c862a505c6557ea88568a4e3ace775ab55e93f2f4f9d57"
 
 [[package]]
 name = "pin-utils"
@@ -2508,9 +2500,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.20"
+version = "0.37.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b96e891d04aa506a6d1f318d2771bcb1c7dfda84e126660ace067c9b474bb2c0"
+checksum = "8818fa822adcc98b18fedbb3632a6a33213c070556b5aa7c4c8cc21cff565c4c"
 dependencies = [
  "bitflags 1.3.2",
  "errno",
@@ -2546,9 +2538,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
+checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
 dependencies = [
  "base64 0.21.2",
 ]
@@ -2565,9 +2557,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
+checksum = "dc31bd9b61a32c31f9650d18add92aa83a49ba979c143eefd27fe7177b05bd5f"
 
 [[package]]
 name = "rusty-fork"
@@ -2583,9 +2575,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+checksum = "fe232bdf6be8c8de797b22184ee71118d63780ea42ac85b61d1baa6d3b782ae9"
 
 [[package]]
 name = "scopeguard"
@@ -2939,22 +2931,22 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.165"
+version = "1.0.166"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c939f902bb7d0ccc5bce4f03297e161543c2dcb30914faf032c2bd0b7a0d48fc"
+checksum = "d01b7404f9d441d3ad40e6a636a7782c377d2abdbe4fa2440e2edcc2f4f10db8"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.165"
+version = "1.0.166"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eaae920e25fffe4019b75ff65e7660e72091e59dd204cb5849bbd6a3fd343d7"
+checksum = "5dd83d6dde2b6b2d466e14d9d1acce8816dedee94f735eac6395808b3483c6d6"
 dependencies = [
  "proc-macro2 1.0.63",
  "quote 1.0.29",
- "syn 2.0.22",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -2970,10 +2962,11 @@ dependencies = [
 
 [[package]]
 name = "serde_path_to_error"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7f05c1d5476066defcdfacce1f52fc3cae3af1d3089727100c02ae92e5abbe0"
+checksum = "0b1b6471d7496b051e03f1958802a73f88b947866f5146f329e47e36554f4e55"
 dependencies = [
+ "itoa",
  "serde",
 ]
 
@@ -3215,15 +3208,15 @@ dependencies = [
 
 [[package]]
 name = "strum_macros"
-version = "0.25.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe9f3bd7d2e45dcc5e265fbb88d6513e4747d8ef9444cf01a533119bce28a157"
+checksum = "6069ca09d878a33f883cc06aaa9718ede171841d3832450354410b718b097232"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2 1.0.63",
  "quote 1.0.29",
  "rustversion",
- "syn 2.0.22",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -3278,9 +3271,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.22"
+version = "2.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2efbeae7acf4eabd6bcdcbd11c92f45231ddda7539edc7806bd1a04a03b24616"
+checksum = "59fb7d6d8281a51045d62b8eb3a7d1ce347b76f312af50cd3dc0af39c87c1737"
 dependencies = [
  "proc-macro2 1.0.63",
  "quote 1.0.29",
@@ -3387,7 +3380,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2 1.0.63",
  "quote 1.0.29",
- "syn 2.0.22",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -3481,7 +3474,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2 1.0.63",
  "quote 1.0.29",
- "syn 2.0.22",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -3606,7 +3599,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2 1.0.63",
  "quote 1.0.29",
- "syn 2.0.22",
+ "syn 2.0.23",
 ]
 
 [[package]]
@@ -3682,6 +3675,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
+name = "types"
+version = "0.1.0"
+dependencies = [
+ "deriving_via",
+ "proptest",
+ "proptest-derive",
+ "serde",
+]
+
+[[package]]
 name = "uname"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3704,9 +3707,9 @@ checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
+checksum = "22049a19f4a68748a168c0fc439f9516686aa045927ff767eca0a85101fb6e73"
 
 [[package]]
 name = "unicode-normalization"
@@ -3873,7 +3876,7 @@ dependencies = [
  "once_cell",
  "proc-macro2 1.0.63",
  "quote 1.0.29",
- "syn 2.0.22",
+ "syn 2.0.23",
  "wasm-bindgen-shared",
 ]
 
@@ -3907,7 +3910,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2 1.0.63",
  "quote 1.0.29",
- "syn 2.0.22",
+ "syn 2.0.23",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3998,9 +4001,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.0"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -810,7 +810,6 @@ dependencies = [
 name = "domain"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "async-trait",
  "chrono",
  "common",
@@ -919,6 +918,7 @@ dependencies = [
 name = "errors"
 version = "0.1.0"
 dependencies = [
+ "sea-orm",
  "strum",
  "thiserror",
 ]
@@ -1834,8 +1834,8 @@ dependencies = [
 name = "outgoing"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "domain",
+ "errors",
  "reqwest",
  "serde",
  "serde_json",
@@ -2368,6 +2368,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "chrono",
  "domain",
  "entities",
  "envy",
@@ -3775,8 +3776,8 @@ dependencies = [
 name = "usecase"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "domain",
+ "errors",
 ]
 
 [[package]]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "presentation",
     "usecase",
     "errors",
+    "types",
 ]
 
 [workspace.package]
@@ -36,3 +37,4 @@ itertools = "0.11.0"
 chrono = { version = "0.4.26" }
 futures = "0.3.28"
 uuid = "1.4.0"
+deriving_via = "1.4.1"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,16 +1,16 @@
 [workspace]
 members = [
-    "entrypoint",
     "common",
     "domain",
-    "infra/resource",
+    "entrypoint",
+    "errors",
     "infra/entities",
     "infra/outgoing",
+    "infra/resource",
     "migration",
     "presentation",
-    "usecase",
-    "errors",
     "types",
+    "usecase",
 ]
 
 [workspace.package]
@@ -38,3 +38,4 @@ chrono = { version = "0.4.26" }
 futures = "0.3.28"
 uuid = "1.4.0"
 deriving_via = "1.4.1"
+reqwest = { version = "0.11.18", default-features = false, features = ["rustls"] }

--- a/server/Makefile.toml
+++ b/server/Makefile.toml
@@ -35,3 +35,14 @@ args = [ "fmt", "--", "--config-path=${REPOSITORY_ROOT}/.cargo-husky/hooks/rustf
 
 [tasks.pretty]
 dependencies = ["fix", "test", "lint", "format"]
+
+[tasks.udeps]
+install_crate = { crate_name = "cargo-udeps" }
+toolchain = "nightly"
+command = "cargo"
+args = [ "udeps", "--all-targets", "--all-features" ]
+
+[tasks.sort]
+install_crate = { crate_name = "cargo-sort" }
+command = "cargo"
+args = ["sort", "-wg"]

--- a/server/common/Cargo.toml
+++ b/server/common/Cargo.toml
@@ -2,12 +2,11 @@
 name = "common"
 version = "0.1.0"
 edition = "2021"
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-proptest = { workspace = true }
 chrono = { workspace = true }
-once_cell = { workspace = true }
-serde = { workspace = true }
 envy = { workspace = true }
+once_cell = { workspace = true }
+proptest = { workspace = true }
+serde = { workspace = true }

--- a/server/domain/Cargo.toml
+++ b/server/domain/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 common = { path = "../common" }
 errors = { path = "../errors" }
+types = { path = "../types" }
 async-trait = { workspace = true }
 anyhow = { workspace = true }
 serde = { workspace = true }
@@ -14,7 +15,7 @@ derive-getters = "0.3.0"
 typed-builder = "0.14.0"
 strum = { workspace = true }
 strum_macros = "0.25.0"
-deriving_via = "1.4.2"
+deriving_via = { workspace = true }
 chrono = { workspace = true }
 
 [dev-dependencies]
@@ -23,3 +24,4 @@ proptest = { workspace = true }
 proptest-derive = { workspace = true }
 serde_json = { workspace = true }
 chrono = { workspace = true, features = ["arbitrary"] }
+types = { path = "../types", features = ["arbitrary"] }

--- a/server/domain/Cargo.toml
+++ b/server/domain/Cargo.toml
@@ -4,24 +4,23 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-common = { path = "../common" }
-errors = { path = "../errors" }
-types = { path = "../types" }
 async-trait = { workspace = true }
-anyhow = { workspace = true }
-serde = { workspace = true }
-mockall = { workspace = true }
+chrono = { workspace = true }
+common = { path = "../common" }
 derive-getters = "0.3.0"
-typed-builder = "0.14.0"
+deriving_via = { workspace = true }
+errors = { path = "../errors" }
+mockall = { workspace = true }
+serde = { workspace = true }
 strum = { workspace = true }
 strum_macros = "0.25.0"
-deriving_via = { workspace = true }
-chrono = { workspace = true }
+typed-builder = "0.14.0"
+types = { path = "../types" }
 
 [dev-dependencies]
-test-case = { workspace = true }
+chrono = { workspace = true, features = ["arbitrary"] }
 proptest = { workspace = true }
 proptest-derive = { workspace = true }
 serde_json = { workspace = true }
-chrono = { workspace = true, features = ["arbitrary"] }
+test-case = { workspace = true }
 types = { path = "../types", features = ["arbitrary"] }

--- a/server/domain/src/form/models.rs
+++ b/server/domain/src/form/models.rs
@@ -31,7 +31,7 @@ pub struct FormUpdateTargets {
 
 #[cfg_attr(test, derive(Arbitrary))]
 #[derive(DerivingVia, TypedBuilder, Clone, Getters, Debug, PartialOrd, PartialEq)]
-#[deriving(From, Into, Serialize(via: String), Deserialize(via: String))]
+#[deriving(From, Into, IntoInner, Serialize(via: String), Deserialize(via: String))]
 pub struct FormTitle {
     #[builder(setter(into))]
     title: String,

--- a/server/domain/src/form/models.rs
+++ b/server/domain/src/form/models.rs
@@ -59,7 +59,7 @@ pub struct Form {
 
 #[cfg_attr(test, derive(Arbitrary))]
 #[derive(DerivingVia, TypedBuilder, Serialize, Getters, Debug, PartialEq)]
-#[deriving(From, Into, Deserialize(via: Option::<String>))]
+#[deriving(From, Into, IntoInner, Deserialize(via: Option::<String>))]
 pub struct FormDescription {
     description: Option<String>,
 }

--- a/server/domain/src/form/models.rs
+++ b/server/domain/src/form/models.rs
@@ -9,10 +9,7 @@ use serde::{Deserialize, Serialize};
 use strum_macros::EnumString;
 use typed_builder::TypedBuilder;
 
-#[cfg_attr(test, derive(Arbitrary))]
-#[derive(DerivingVia, Clone, Copy, Debug, PartialOrd, PartialEq)]
-#[deriving(From, Into, Default, Serialize(via: i32), Deserialize(via: i32))]
-pub struct FormId(pub i32);
+pub type FormId = types::Id<Form>;
 
 #[derive(Deserialize)]
 pub struct OffsetAndLimit {
@@ -44,8 +41,11 @@ pub struct FormTitle {
 #[derive(TypedBuilder, Serialize, Deserialize, Debug, PartialEq)]
 pub struct Form {
     #[serde(default)]
+    #[builder(setter(into))]
     pub id: FormId,
+    #[builder(setter(into))]
     pub title: FormTitle,
+    #[builder(setter(into))]
     pub description: FormDescription,
     #[cfg_attr(test, proptest(strategy = "arbitrary_with_size(1..100)"))]
     #[serde(default)]

--- a/server/domain/src/form/models.rs
+++ b/server/domain/src/form/models.rs
@@ -51,6 +51,7 @@ pub struct Form {
     #[serde(default)]
     pub questions: Vec<Question>,
     #[serde(default)]
+    #[builder(setter(into))]
     pub metadata: FormMeta,
     #[serde(default)]
     pub settings: FormSettings,
@@ -100,6 +101,15 @@ pub struct FormMeta {
     #[cfg_attr(test, proptest(strategy = "arbitrary_date_time()"))]
     #[serde(default = "chrono::Utc::now")]
     update_at: DateTime<Utc>,
+}
+
+impl From<(DateTime<Utc>, DateTime<Utc>)> for FormMeta {
+    fn from((created_at, update_at): (DateTime<Utc>, DateTime<Utc>)) -> Self {
+        Self {
+            created_at,
+            update_at,
+        }
+    }
 }
 
 #[cfg_attr(test, derive(Arbitrary))]

--- a/server/domain/src/repository/form_repository.rs
+++ b/server/domain/src/repository/form_repository.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use errors::Error;
 use mockall::automock;
 
 use crate::form::models::{Form, FormDescription, FormId, FormTitle, FormUpdateTargets};
@@ -6,17 +7,14 @@ use crate::form::models::{Form, FormDescription, FormId, FormTitle, FormUpdateTa
 #[automock]
 #[async_trait]
 pub trait FormRepository: Send + Sync + 'static {
-    async fn create(
-        &self,
-        title: FormTitle,
-        description: FormDescription,
-    ) -> anyhow::Result<FormId>;
-    async fn list(&self, offset: i32, limit: i32) -> anyhow::Result<Vec<Form>>;
-    async fn get(&self, id: FormId) -> anyhow::Result<Form>;
-    async fn delete(&self, id: FormId) -> anyhow::Result<FormId>;
+    async fn create(&self, title: FormTitle, description: FormDescription)
+        -> Result<FormId, Error>;
+    async fn list(&self, offset: i32, limit: i32) -> Result<Vec<Form>, Error>;
+    async fn get(&self, id: FormId) -> Result<Form, Error>;
+    async fn delete(&self, id: FormId) -> Result<FormId, Error>;
     async fn update(
         &self,
         form_id: FormId,
         form_update_targets: FormUpdateTargets,
-    ) -> anyhow::Result<Form>;
+    ) -> Result<(), Error>;
 }

--- a/server/entrypoint/Cargo.toml
+++ b/server/entrypoint/Cargo.toml
@@ -5,20 +5,23 @@ edition = "2021"
 default-run = "entrypoint"
 
 [dependencies]
-resource = { path = "../infra/resource" }
+anyhow = { workspace = true }
+axum = { workspace = true }
+common = { path = "../common" }
+hyper = { version = "0.14.27", features = ["full"] }
 migration = { path = "../migration" }
 presentation = { path = "../presentation" }
-common = { path = "../common" }
-axum = { workspace = true }
-tracing = { workspace = true }
-anyhow = { workspace = true }
-hyper = { version = "0.14.27", features = ["full"] }
-tower = "0.4.13"
-tower-http = { version = "0.4.1", features = ["cors"] }
-tracing-subscriber = { version = "0.3.17", features = ["std", "registry", "env-filter"] }
-tokio = { version = "1.29.1", features = ["full"] }
+resource = { path = "../infra/resource" }
 # default featureは推移的にnative-tls featureを有効しているため、native-tls (LinuxではOpenSSL) を連れてくる。これをオプトアウトするためにrustlsを使う。
 sentry = { version = "0.31.5", default-features = false, features = ["backtrace", "contexts", "panic", "anyhow", "reqwest", "profiling", "tracing", "debug-images", "rustls", "tower", "tower-http"] }
+tokio = { version = "1.29.0", features = ["full"] }
+tower = "0.4.13"
+tower-http = { version = "0.4.1", features = ["cors"] }
+tracing = { workspace = true }
+tracing-subscriber = { version = "0.3.17", features = ["std", "registry", "env-filter"] }
+
+[package.metadata.cargo-udeps.ignore]
+development = ["cargo-husky"]
 
 [dev-dependencies.cargo-husky]
 version = "1"

--- a/server/errors/Cargo.toml
+++ b/server/errors/Cargo.toml
@@ -6,5 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-thiserror = "1.0.40"
+sea-orm = { workspace = true }
 strum = { workspace = true }
+thiserror = "1.0.40"

--- a/server/errors/src/infra.rs
+++ b/server/errors/src/infra.rs
@@ -1,0 +1,14 @@
+use thiserror::Error;
+
+#[derive(Debug, Error, PartialEq)]
+pub enum InfraError {
+    #[error("Database Error: {}", .source)]
+    Database {
+        #[from]
+        source: sea_orm::error::DbErr,
+    },
+    #[error("Form Not Found: id = {}", .id)]
+    FormNotFound { id: i32 },
+    #[error("Outgoing Error: {}", .cause)]
+    Outgoing { cause: String },
+}

--- a/server/errors/src/lib.rs
+++ b/server/errors/src/lib.rs
@@ -1,2 +1,24 @@
 pub mod domain;
+pub mod infra;
 pub mod presentation;
+
+use thiserror::Error;
+
+#[derive(Debug, Error, PartialEq)]
+pub enum Error {
+    #[error(transparent)]
+    Domain {
+        #[from]
+        source: domain::DomainError,
+    },
+    #[error(transparent)]
+    Infra {
+        #[from]
+        source: infra::InfraError,
+    },
+    #[error(transparent)]
+    Presentation {
+        #[from]
+        source: presentation::PresentationError,
+    },
+}

--- a/server/infra/entities/Cargo.toml
+++ b/server/infra/entities/Cargo.toml
@@ -11,6 +11,9 @@ path = "src/mod.rs"
 sea-orm = { workspace = true }
 serde = { workspace = true }
 
+[package.metadata.cargo-udeps.ignore]
+development = ["cargo-husky"]
+
 [dev-dependencies.cargo-husky]
 version = "1"
 default-features = false # Disable features which are enabled by default

--- a/server/infra/outgoing/Cargo.toml
+++ b/server/infra/outgoing/Cargo.toml
@@ -2,13 +2,12 @@
 name = "outgoing"
 version = "0.1.0"
 edition = "2021"
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 domain = { path = "../../domain" }
-anyhow = { workspace = true }
+errors = { path = "../../errors" }
+reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }
-reqwest = { version = "0.11.18", default-features = false, features = ["rustls"] }

--- a/server/infra/outgoing/src/form_outgoing.rs
+++ b/server/infra/outgoing/src/form_outgoing.rs
@@ -1,9 +1,10 @@
 use domain::form::models::Form;
+use errors::infra::InfraError;
 
 use crate::webhook::Webhook;
 
 #[tracing::instrument]
-pub async fn create(form: Form) -> anyhow::Result<()> {
+pub async fn create(form: Form) -> Result<(), InfraError> {
     if let Some(url) = form.settings.webhook_url.into() {
         Webhook::new(url, "フォームが作成されました".to_string())
             .field(
@@ -27,7 +28,7 @@ pub async fn create(form: Form) -> anyhow::Result<()> {
 }
 
 #[tracing::instrument]
-pub async fn delete(form: Form) -> anyhow::Result<()> {
+pub async fn delete(form: Form) -> Result<(), InfraError> {
     if let Some(url) = form.settings.webhook_url.into() {
         Webhook::new(url, "フォームが削除されました".to_string())
             .field(

--- a/server/infra/outgoing/src/webhook.rs
+++ b/server/infra/outgoing/src/webhook.rs
@@ -1,3 +1,4 @@
+use errors::infra::InfraError;
 use serde::Serialize;
 use serde_json::json;
 
@@ -56,7 +57,7 @@ impl Webhook {
     }
 
     #[tracing::instrument]
-    pub async fn send(&self) -> anyhow::Result<()> {
+    pub async fn send(&self) -> Result<(), InfraError> {
         let contents = SendContents {
             username: "seichi-portal-backend".to_string(),
             embeds: vec![Embeds {
@@ -70,7 +71,10 @@ impl Webhook {
             .post(self.target_url.to_owned())
             .json(&json!(contents))
             .send()
-            .await?;
+            .await
+            .map_err(|cause| InfraError::Outgoing {
+                cause: cause.to_string(),
+            })?;
         Ok(())
     }
 }

--- a/server/infra/resource/Cargo.toml
+++ b/server/infra/resource/Cargo.toml
@@ -4,18 +4,19 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+chrono = { workspace = true }
 domain = { path = "../../domain" }
 entities =  { path = "../entities" }
-migration = { path = "../../migration" }
+envy = { workspace = true }
 errors = { path = "../../errors" }
+futures = { workspace = true }
+itertools = { workspace = true }
+migration = { path = "../../migration" }
+mockall = { workspace = true }
+once_cell = { workspace = true }
 outgoing = { path = "../outgoing" }
 sea-orm = { workspace = true }
-async-trait = { workspace = true }
-anyhow = { workspace = true }
 serde = { workspace = true }
-mockall = { workspace = true }
-envy = { workspace = true }
-once_cell = { workspace = true }
-itertools = { workspace = true }
-futures = { workspace = true }
 tracing = { workspace = true }

--- a/server/infra/resource/src/database/components.rs
+++ b/server/infra/resource/src/database/components.rs
@@ -1,6 +1,9 @@
 use async_trait::async_trait;
-use domain::form::models::{Form, FormDescription, FormId, FormTitle, FormUpdateTargets};
+use domain::form::models::{FormDescription, FormId, FormTitle, FormUpdateTargets};
+use errors::infra::InfraError;
 use mockall::automock;
+
+use crate::dto::FormDto;
 
 #[async_trait]
 pub trait DatabaseComponents: Send + Sync {
@@ -18,13 +21,13 @@ pub trait FormDatabase: Send + Sync {
         &self,
         title: FormTitle,
         description: FormDescription,
-    ) -> anyhow::Result<FormId>;
-    async fn list(&self, offset: i32, limit: i32) -> anyhow::Result<Vec<Form>>;
-    async fn get(&self, form_id: FormId) -> anyhow::Result<Form>;
-    async fn delete(&self, form_id: FormId) -> anyhow::Result<FormId>;
+    ) -> Result<FormId, InfraError>;
+    async fn list(&self, offset: i32, limit: i32) -> Result<Vec<FormDto>, InfraError>;
+    async fn get(&self, form_id: FormId) -> Result<FormDto, InfraError>;
+    async fn delete(&self, form_id: FormId) -> Result<FormId, InfraError>;
     async fn update(
         &self,
         form_id: FormId,
         form_update_targets: FormUpdateTargets,
-    ) -> anyhow::Result<Form>;
+    ) -> Result<(), InfraError>;
 }

--- a/server/infra/resource/src/database/form.rs
+++ b/server/infra/resource/src/database/form.rs
@@ -220,18 +220,9 @@ impl FormDatabase for ConnectionPool {
         Ok(Form::builder()
             .id(target_form.id)
             .title(target_form.title.to_owned())
-            .description(
-                FormDescription::builder()
-                    .description(target_form.description.to_owned())
-                    .build(),
-            )
+            .description(target_form.description.to_owned())
             .questions(form_questions)
-            .metadata(
-                FormMeta::builder()
-                    .created_at(target_form.created_at)
-                    .update_at(target_form.updated_at)
-                    .build(),
-            )
+            .metadata((target_form.created_at, target_form.updated_at))
             .settings(form_settings)
             .build())
     }

--- a/server/infra/resource/src/database/form.rs
+++ b/server/infra/resource/src/database/form.rs
@@ -1,14 +1,11 @@
 use async_trait::async_trait;
-use domain::form::models::{
-    Form, FormDescription, FormId, FormMeta, FormSettings, FormTitle, FormUpdateTargets, Question,
-    ResponsePeriod, WebhookUrl,
-};
+use domain::form::models::{FormDescription, FormId, FormTitle, FormUpdateTargets};
 use entities::{
     form_choices, form_meta_data, form_questions, form_webhooks,
     prelude::{FormChoices, FormMetaData, FormQuestions, FormWebhooks},
     response_period,
 };
-use errors::presentation::PresentationError::FormNotFound;
+use errors::infra::{InfraError, InfraError::FormNotFound};
 use futures::{stream, stream::StreamExt};
 use itertools::Itertools;
 use sea_orm::{
@@ -18,7 +15,10 @@ use sea_orm::{
     ColumnTrait, EntityTrait, ModelTrait, QueryFilter, QueryOrder, QuerySelect,
 };
 
-use crate::database::{components::FormDatabase, connection::ConnectionPool};
+use crate::{
+    database::{components::FormDatabase, connection::ConnectionPool},
+    dto::{FormDto, QuestionDto},
+};
 
 #[async_trait]
 impl FormDatabase for ConnectionPool {
@@ -27,7 +27,7 @@ impl FormDatabase for ConnectionPool {
         &self,
         title: FormTitle,
         description: FormDescription,
-    ) -> anyhow::Result<FormId> {
+    ) -> Result<FormId, InfraError> {
         let form_id = form_meta_data::ActiveModel {
             id: ActiveValue::NotSet,
             title: Set(title.title().to_owned()),
@@ -43,7 +43,7 @@ impl FormDatabase for ConnectionPool {
     }
 
     #[tracing::instrument]
-    async fn list(&self, offset: i32, limit: i32) -> anyhow::Result<Vec<Form>> {
+    async fn list(&self, offset: i32, limit: i32) -> Result<Vec<FormDto>, InfraError> {
         let forms = FormMetaData::find()
             .order_by_asc(form_meta_data::Column::Id)
             .offset(offset as u64)
@@ -78,7 +78,7 @@ impl FormDatabase for ConnectionPool {
             .all(&self.pool)
             .await?;
 
-        forms
+        Ok(forms
             .into_iter()
             .map(|form| {
                 let questions = all_questions
@@ -92,72 +92,57 @@ impl FormDatabase for ConnectionPool {
                             .map(|choice| choice.choice)
                             .collect_vec();
 
-                        anyhow::Ok(
-                            Question::builder()
-                                .title(question.title.to_owned())
-                                .description(question.description.to_owned())
-                                .question_type(question.question_type.to_string().try_into()?)
-                                .choices(choices)
-                                .build(),
-                        )
+                        QuestionDto {
+                            title: question.title.to_owned(),
+                            description: question.description.to_owned(),
+                            question_type: question.question_type.to_string(),
+                            choices,
+                        }
                     })
-                    .collect::<Result<Vec<_>, _>>()?;
+                    .collect::<Vec<_>>();
 
                 let response_period = all_periods
                     .iter()
                     .filter(|period| period.form_id == form.id)
                     .map(|period| {
-                        ResponsePeriod::new(Some((
+                        Some((
                             period.start_at.to_owned().and_utc(),
                             period.end_at.to_owned().and_utc(),
-                        )))
+                        ))
                     })
                     .next()
-                    .unwrap_or(ResponsePeriod::default());
+                    .unwrap_or_default();
 
                 let webhook_url = all_webhook_urls
                     .iter()
                     .filter(|webhook_url| webhook_url.form_id == form.id)
-                    .map(|webhook_url| WebhookUrl {
-                        webhook_url: Some(webhook_url.url.to_owned()),
-                    })
+                    .map(|webhook_url| Some(webhook_url.url.to_owned()))
                     .next()
-                    .unwrap_or(WebhookUrl::default());
+                    .unwrap_or_default();
 
-                anyhow::Ok(
-                    Form::builder()
-                        .id(form.id)
-                        .title(form.title)
-                        .description(
-                            FormDescription::builder()
-                                .description(form.description)
-                                .build(),
-                        )
-                        .questions(questions)
-                        .metadata(
-                            FormMeta::builder()
-                                .created_at(form.created_at)
-                                .update_at(form.updated_at)
-                                .build(),
-                        )
-                        .settings(FormSettings {
-                            response_period,
-                            webhook_url,
-                        })
-                        .build(),
-                )
+                FormDto {
+                    id: form.id,
+                    title: form.title,
+                    description: form.description,
+                    questions,
+                    metadata: (form.created_at, form.updated_at),
+                    response_period,
+                    webhook_url,
+                }
             })
-            .collect()
+            .collect())
     }
 
     #[tracing::instrument]
-    async fn get(&self, form_id: FormId) -> anyhow::Result<Form> {
+    async fn get(&self, form_id: FormId) -> Result<FormDto, InfraError> {
         let target_form = FormMetaData::find()
             .filter(Expr::col(form_meta_data::Column::Id).eq(form_id.to_owned()))
             .all(&self.pool)
             .await?
             .first()
-            .ok_or(FormNotFound)?
+            .ok_or(FormNotFound {
+                id: form_id.to_owned(),
+            })?
             .to_owned();
 
         let form_questions = stream::iter(
@@ -166,28 +151,26 @@ impl FormDatabase for ConnectionPool {
                 .all(&self.pool)
                 .await?,
         )
-        .then(|question| async {
+        .then(move |question| async move {
             let choices = FormChoices::find()
-                .filter(
-                    Expr::col(form_choices::Column::QuestionId).eq(question.to_owned().question_id),
-                )
+                .filter(Expr::col(form_choices::Column::QuestionId).eq(question.question_id))
                 .all(&self.pool)
                 .await?
                 .into_iter()
                 .map(|choice| choice.choice)
                 .collect_vec();
 
-            Ok(Question::builder()
-                .title(question.title)
-                .description(question.description)
-                .question_type(question.question_type.to_string().try_into()?)
-                .choices(choices)
-                .build())
+            Ok::<QuestionDto, InfraError>(QuestionDto {
+                title: question.title.to_owned(),
+                description: question.description.to_owned(),
+                question_type: question.question_type.to_string(),
+                choices,
+            })
         })
-        .collect::<Vec<anyhow::Result<Question>>>()
+        .collect::<Vec<Result<QuestionDto, _>>>()
         .await
         .into_iter()
-        .collect::<anyhow::Result<Vec<Question>>>()?;
+        .collect::<Result<Vec<QuestionDto>, _>>()?;
 
         let response_period = entities::response_period::Entity::find()
             .filter(Expr::col(response_period::Column::FormId).eq(target_form.id))
@@ -195,45 +178,41 @@ impl FormDatabase for ConnectionPool {
             .await?
             .first()
             .map(|period| {
-                ResponsePeriod::new(Some((
+                Some((
                     period.start_at.to_owned().and_utc(),
                     period.end_at.to_owned().and_utc(),
-                )))
+                ))
             })
-            .unwrap_or(ResponsePeriod::default());
+            .unwrap_or_default();
 
         let webhook_url = FormWebhooks::find()
             .filter(Expr::col(form_webhooks::Column::FormId).eq(target_form.id))
             .all(&self.pool)
             .await?
             .first()
-            .map(|webhook_url_model| WebhookUrl {
-                webhook_url: Some(webhook_url_model.url.to_owned()),
-            })
-            .unwrap_or(WebhookUrl::default());
+            .map(|webhook_url_model| Some(webhook_url_model.url.to_owned()))
+            .unwrap_or_default();
 
-        let form_settings = FormSettings {
+        Ok(FormDto {
+            id: target_form.id,
+            title: target_form.title,
+            description: target_form.description,
+            questions: form_questions,
+            metadata: (target_form.created_at, target_form.updated_at),
             response_period,
             webhook_url,
-        };
-
-        Ok(Form::builder()
-            .id(target_form.id)
-            .title(target_form.title.to_owned())
-            .description(target_form.description.to_owned())
-            .questions(form_questions)
-            .metadata((target_form.created_at, target_form.updated_at))
-            .settings(form_settings)
-            .build())
+        })
     }
 
     #[tracing::instrument]
-    async fn delete(&self, form_id: FormId) -> anyhow::Result<FormId> {
+    async fn delete(&self, form_id: FormId) -> Result<FormId, InfraError> {
         let target_form = FormMetaData::find_by_id(form_id.to_owned())
             .all(&self.pool)
             .await?
             .first()
-            .ok_or(FormNotFound)?
+            .ok_or(FormNotFound {
+                id: form_id.to_owned(),
+            })?
             .to_owned();
 
         let question_ids = FormQuestions::find()
@@ -273,22 +252,25 @@ impl FormDatabase for ConnectionPool {
             response_period,
             webhook,
         }: FormUpdateTargets,
-    ) -> anyhow::Result<Form> {
+    ) -> Result<(), InfraError> {
         let current_form = self.get(form_id.to_owned().into()).await?;
 
         FormMetaData::update_many()
             .filter(form_meta_data::Column::Id.eq(form_id.to_owned()))
             .col_expr(
                 form_meta_data::Column::Title,
-                Expr::value(title.unwrap_or(current_form.title).into_inner()),
+                Expr::value(
+                    title
+                        .map(|title| title.into_inner())
+                        .unwrap_or(current_form.title),
+                ),
             )
             .col_expr(
                 form_meta_data::Column::Description,
                 Expr::value(
                     description
-                        .unwrap_or(current_form.description)
-                        .description()
-                        .to_owned(),
+                        .map(|description| description.into_inner())
+                        .unwrap_or(current_form.description),
                 ),
             )
             .col_expr(
@@ -313,7 +295,7 @@ impl FormDatabase for ConnectionPool {
                 .await?;
         }
 
-        if current_form.settings.webhook_url.webhook_url.is_some() {
+        if current_form.webhook_url.is_some() {
             FormWebhooks::update_many()
                 .filter(form_webhooks::Column::FormId.eq(form_id.to_owned()))
                 .col_expr(
@@ -332,8 +314,6 @@ impl FormDatabase for ConnectionPool {
             .await?;
         }
 
-        let updated_form = self.get(form_id).await?;
-
-        Ok(updated_form)
+        Ok(())
     }
 }

--- a/server/infra/resource/src/dto.rs
+++ b/server/infra/resource/src/dto.rs
@@ -1,0 +1,72 @@
+use chrono::{DateTime, Utc};
+use domain::form::models::{FormSettings, ResponsePeriod};
+
+pub struct QuestionDto {
+    pub title: String,
+    pub description: Option<String>,
+    pub question_type: String,
+    pub choices: Vec<String>,
+}
+
+impl TryFrom<QuestionDto> for domain::form::models::Question {
+    type Error = errors::domain::DomainError;
+
+    fn try_from(
+        QuestionDto {
+            title,
+            description,
+            question_type,
+            choices,
+        }: QuestionDto,
+    ) -> Result<Self, Self::Error> {
+        Ok(domain::form::models::Question::builder()
+            .title(title)
+            .description(description)
+            .question_type(question_type.try_into()?)
+            .choices(choices)
+            .build())
+    }
+}
+
+pub struct FormDto {
+    pub id: i32,
+    pub title: String,
+    pub description: Option<String>,
+    pub questions: Vec<QuestionDto>,
+    pub metadata: (DateTime<Utc>, DateTime<Utc>),
+    pub response_period: Option<(DateTime<Utc>, DateTime<Utc>)>,
+    pub webhook_url: Option<String>,
+}
+
+impl TryFrom<FormDto> for domain::form::models::Form {
+    type Error = errors::domain::DomainError;
+
+    fn try_from(
+        FormDto {
+            id,
+            title,
+            description,
+            questions,
+            metadata,
+            response_period,
+            webhook_url,
+        }: FormDto,
+    ) -> Result<Self, Self::Error> {
+        Ok(domain::form::models::Form::builder()
+            .id(id)
+            .title(title)
+            .description(description)
+            .questions(
+                questions
+                    .into_iter()
+                    .map(TryInto::try_into)
+                    .collect::<Result<Vec<_>, _>>()?,
+            )
+            .metadata(metadata)
+            .settings(FormSettings {
+                response_period: ResponsePeriod::new(response_period),
+                webhook_url: webhook_url.into(),
+            })
+            .build())
+    }
+}

--- a/server/infra/resource/src/lib.rs
+++ b/server/infra/resource/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod database;
+pub mod dto;
 pub mod repository;

--- a/server/infra/resource/src/repository/form_repository_impl.rs
+++ b/server/infra/resource/src/repository/form_repository_impl.rs
@@ -3,6 +3,7 @@ use domain::{
     form::models::{Form, FormDescription, FormId, FormTitle, FormUpdateTargets},
     repository::form_repository::FormRepository,
 };
+use errors::Error;
 use outgoing::form_outgoing;
 
 use crate::{
@@ -17,42 +18,49 @@ impl<Client: DatabaseComponents + 'static> FormRepository for Repository<Client>
         &self,
         title: FormTitle,
         description: FormDescription,
-    ) -> anyhow::Result<FormId> {
+    ) -> Result<FormId, Error> {
         let form_id = self.client.form().create(title, description).await?;
         let form = self.client.form().get(form_id.to_owned().into()).await?;
 
-        form_outgoing::create(form).await?;
+        form_outgoing::create(form.try_into()?).await?;
 
         Ok(form_id)
     }
 
     #[tracing::instrument(skip(self))]
-    async fn list(&self, offset: i32, limit: i32) -> anyhow::Result<Vec<Form>> {
-        self.client.form().list(offset, limit).await
+    async fn list(&self, offset: i32, limit: i32) -> Result<Vec<Form>, Error> {
+        let forms = self.client.form().list(offset, limit).await?;
+        forms
+            .into_iter()
+            .map(|form| form.try_into())
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(Into::into)
     }
 
     #[tracing::instrument(skip(self))]
-    async fn get(&self, id: FormId) -> anyhow::Result<Form> {
-        self.client.form().get(id).await
+    async fn get(&self, id: FormId) -> Result<Form, Error> {
+        let form = self.client.form().get(id).await?;
+        form.try_into().map_err(Into::into)
     }
 
     #[tracing::instrument(skip(self))]
-    async fn delete(&self, id: FormId) -> anyhow::Result<FormId> {
+    async fn delete(&self, id: FormId) -> Result<FormId, Error> {
         let form = self.client.form().get(id.to_owned().into()).await?;
 
-        form_outgoing::delete(form).await?;
+        form_outgoing::delete(form.try_into()?).await?;
 
-        self.client.form().delete(id).await
+        self.client.form().delete(id).await.map_err(Into::into)
     }
 
     async fn update(
         &self,
         form_id: FormId,
         form_update_targets: FormUpdateTargets,
-    ) -> anyhow::Result<Form> {
+    ) -> Result<(), Error> {
         self.client
             .form()
             .update(form_id, form_update_targets)
             .await
+            .map_err(Into::into)
     }
 }

--- a/server/infra/resource/src/repository/form_repository_impl.rs
+++ b/server/infra/resource/src/repository/form_repository_impl.rs
@@ -19,7 +19,7 @@ impl<Client: DatabaseComponents + 'static> FormRepository for Repository<Client>
         description: FormDescription,
     ) -> anyhow::Result<FormId> {
         let form_id = self.client.form().create(title, description).await?;
-        let form = self.client.form().get(form_id).await?;
+        let form = self.client.form().get(form_id.to_owned().into()).await?;
 
         form_outgoing::create(form).await?;
 
@@ -38,7 +38,7 @@ impl<Client: DatabaseComponents + 'static> FormRepository for Repository<Client>
 
     #[tracing::instrument(skip(self))]
     async fn delete(&self, id: FormId) -> anyhow::Result<FormId> {
-        let form = self.client.form().get(id).await?;
+        let form = self.client.form().get(id.to_owned().into()).await?;
 
         form_outgoing::delete(form).await?;
 

--- a/server/migration/Cargo.toml
+++ b/server/migration/Cargo.toml
@@ -22,6 +22,10 @@ features = [
   # "sqlx-postgres",         # `DATABASE_DRIVER` feature
 ]
 
+[package.metadata.cargo-udeps.ignore]
+normal = ["entities"]
+development = ["cargo-husky"]
+
 [dev-dependencies.cargo-husky]
 version = "1"
 default-features = false # Disable features which are enabled by default

--- a/server/presentation/Cargo.toml
+++ b/server/presentation/Cargo.toml
@@ -4,12 +4,12 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-resource = { path = "../infra/resource" }
-domain = { path = "../domain" }
-usecase = { path = "../usecase" }
-errors = { path = "../errors" }
-common = { path = "../common" }
 axum = { workspace = true }
-tracing = { workspace = true }
+common = { path = "../common" }
+domain = { path = "../domain" }
+errors = { path = "../errors" }
+resource = { path = "../infra/resource" }
 serde_json = { workspace = true }
+tracing = { workspace = true }
+usecase = { path = "../usecase" }
 uuid = { workspace = true }

--- a/server/types/Cargo.toml
+++ b/server/types/Cargo.toml
@@ -9,6 +9,6 @@ arbitrary = ["proptest", "proptest-derive"]
 
 [dependencies]
 deriving_via = { workspace = true }
-serde = { workspace = true }
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
+serde = { workspace = true }

--- a/server/types/Cargo.toml
+++ b/server/types/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "types"
+version = "0.1.0"
+edition = "2021"
+
+[features]
+default = []
+arbitrary = ["proptest", "proptest-derive"]
+
+[dependencies]
+deriving_via = { workspace = true }
+serde = { workspace = true }
+proptest = { workspace = true, optional = true }
+proptest-derive = { workspace = true, optional = true }

--- a/server/types/src/lib.rs
+++ b/server/types/src/lib.rs
@@ -1,0 +1,8 @@
+use deriving_via::DerivingVia;
+#[cfg(feature = "arbitrary")]
+use proptest_derive::Arbitrary;
+
+#[derive(DerivingVia, Clone, Debug, PartialOrd, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+#[deriving(From, Into, Default, IntoInner(via: i32), Display(via: i32), Serialize(via: i32), Deserialize(via: i32))]
+pub struct Id<T>(#[underlying] i32, std::marker::PhantomData<T>);

--- a/server/usecase/Cargo.toml
+++ b/server/usecase/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2021"
 
 [dependencies]
 domain = { path = "../domain" }
-anyhow = { workspace = true }
+errors = { path = "../errors" }

--- a/server/usecase/src/form.rs
+++ b/server/usecase/src/form.rs
@@ -2,6 +2,7 @@ use domain::{
     form::models::{Form, FormDescription, FormId, FormTitle, FormUpdateTargets},
     repository::form_repository::FormRepository,
 };
+use errors::Error;
 
 pub struct FormUseCase<'a, FormRepo: FormRepository> {
     pub repository: &'a FormRepo,
@@ -12,19 +13,19 @@ impl<R: FormRepository> FormUseCase<'_, R> {
         &self,
         title: FormTitle,
         description: FormDescription,
-    ) -> anyhow::Result<FormId> {
+    ) -> Result<FormId, Error> {
         self.repository.create(title, description).await
     }
 
-    pub async fn form_list(&self, offset: i32, limit: i32) -> anyhow::Result<Vec<Form>> {
+    pub async fn form_list(&self, offset: i32, limit: i32) -> Result<Vec<Form>, Error> {
         self.repository.list(offset, limit).await
     }
 
-    pub async fn get_form(&self, form_id: FormId) -> anyhow::Result<Form> {
+    pub async fn get_form(&self, form_id: FormId) -> Result<Form, Error> {
         self.repository.get(form_id).await
     }
 
-    pub async fn delete_form(&self, form_id: FormId) -> anyhow::Result<FormId> {
+    pub async fn delete_form(&self, form_id: FormId) -> Result<FormId, Error> {
         self.repository.delete(form_id).await
     }
 
@@ -32,7 +33,7 @@ impl<R: FormRepository> FormUseCase<'_, R> {
         &self,
         form_id: FormId,
         form_update_targets: FormUpdateTargets,
-    ) -> anyhow::Result<Form> {
+    ) -> Result<(), Error> {
         self.repository.update(form_id, form_update_targets).await
     }
 }


### PR DESCRIPTION
- form 以外に id を使う前に先回りして `Id<T>` を作っておいた
- builder のアトリビュートを使ったらコードがきれいになった
- anyhow を 使わずに全部 thiserror を使うようにした（エラーハンドリングしたそうなコードがあったため）
- インフラ層は DTO を返すようにした