### PR TITLE
ユーザーに権限を割り振れるようにする

### DIFF
--- a/server/domain/src/user/models.rs
+++ b/server/domain/src/user/models.rs
@@ -6,11 +6,13 @@ use uuid::Uuid;
 pub struct User {
     pub name: String,
     pub id: Uuid,
+    #[serde(default)]
     pub role: Role,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Display)]
+#[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq, Display)]
 pub enum Role {
     Administrator,
+    #[default]
     StandardUser,
 }

--- a/server/domain/src/user/models.rs
+++ b/server/domain/src/user/models.rs
@@ -1,8 +1,16 @@
 use serde::{Deserialize, Serialize};
+use strum_macros::Display;
 use uuid::Uuid;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct User {
     pub name: String,
     pub id: Uuid,
+    pub role: Role,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Display)]
+pub enum Role {
+    Administrator,
+    StandardUser,
 }

--- a/server/infra/resource/src/database/user.rs
+++ b/server/infra/resource/src/database/user.rs
@@ -11,10 +11,15 @@ impl UserDatabase for ConnectionPool {
         self.pool
             .execute(Statement::from_sql_and_values(
                 DatabaseBackend::MySql,
-                "INSERT INTO users (uuid, name) VALUES (?, ?)
+                "INSERT INTO users (uuid, name, role) VALUES (?, ?, ?)
                         ON DUPLICATE KEY UPDATE
-                        name = VALUES(name)",
-                [user.id.to_string().into(), user.name.to_owned().into()],
+                        name = VALUES(name),
+                        role = VALUES(role)",
+                [
+                    user.id.to_string().into(),
+                    user.name.to_owned().into(),
+                    user.role.to_string().into(),
+                ],
             ))
             .await?;
 

--- a/server/migration/src/m20220101_000001_create_table.rs
+++ b/server/migration/src/m20220101_000001_create_table.rs
@@ -16,7 +16,8 @@ impl MigrationTrait for Migration {
                 r"CREATE TABLE IF NOT EXISTS users(
                     id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
                     uuid CHAR(36) NOT NULL UNIQUE KEY,
-                    name VARCHAR(16) NOT NULL
+                    name VARCHAR(16) NOT NULL,
+                    role ENUM('ADMINISTRATOR', 'STANDARD_USER') NOT NULL
                 )",
             ))
             .await?;

--- a/server/presentation/src/auth.rs
+++ b/server/presentation/src/auth.rs
@@ -8,7 +8,7 @@ use axum::{
 use common::config::ENV;
 use domain::{
     repository::{user_repository::UserRepository, Repositories},
-    user::models::User,
+    user::models::{Role::Administrator, User},
 };
 use reqwest::header::{ACCEPT, CONTENT_TYPE};
 use resource::repository::RealInfrastructureRepository;
@@ -27,6 +27,7 @@ pub async fn auth<B>(
         User {
             name: "test_user".to_string(),
             id: uuid!("478911be-3356-46c1-936e-fb14b71bf282"),
+            role: Administrator,
         }
     } else {
         let client = reqwest::Client::new();

--- a/server/presentation/src/auth.rs
+++ b/server/presentation/src/auth.rs
@@ -1,14 +1,17 @@
 use axum::{
     extract::{State, TypedHeader},
     headers::authorization::{Authorization, Bearer},
-    http::{HeaderValue, Request, StatusCode},
+    http::{HeaderValue, Method, Request, StatusCode},
     middleware::Next,
     response::Response,
 };
 use common::config::ENV;
 use domain::{
     repository::{user_repository::UserRepository, Repositories},
-    user::models::{Role::Administrator, User},
+    user::models::{
+        Role::{Administrator, StandardUser},
+        User,
+    },
 };
 use reqwest::header::{ACCEPT, CONTENT_TYPE};
 use resource::repository::RealInfrastructureRepository;
@@ -50,6 +53,16 @@ pub async fn auth<B>(
         )
         .map_err(|_| StatusCode::UNAUTHORIZED)?
     };
+
+    let standard_user_endpoints = [(&Method::GET, "/forms"), (&Method::POST, "/forms/answers")];
+
+    if user.role == StandardUser
+        && !standard_user_endpoints.contains(&(request.method(), request.uri().path()))
+    {
+        // NOTE: standard_user_endpointsに存在しないMethodとエンドポイントに
+        //          一般ユーザーがアクセスした場合は、アクセス権限なしとしてすべてFORBIDDENを返す。
+        return Err(StatusCode::FORBIDDEN);
+    }
 
     let user_use_case = UserUseCase {
         repository: repository.user_repository(),


### PR DESCRIPTION
やったこと
- `Users` テーブルと `Users`struct にroleを追加する(管理者と一般ユーザーとで分ける)
- 一般ユーザがアクセスできるエンドポイントを列挙して、それ以外で`FORBIDDEN`を返すようにする