### PR TITLE
フォームに紐づいた質問を取得するエンドポイントの実装

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -2093,6 +2093,7 @@ dependencies = [
  "common",
  "domain",
  "errors",
+ "regex",
  "reqwest",
  "resource",
  "serde",

--- a/server/domain/src/repository/form_repository.rs
+++ b/server/domain/src/repository/form_repository.rs
@@ -5,7 +5,7 @@ use mockall::automock;
 use crate::{
     form::models::{
         Form, FormDescription, FormId, FormQuestionUpdateSchema, FormTitle, FormUpdateTargets,
-        OffsetAndLimit, PostedAnswers, SimpleForm,
+        OffsetAndLimit, PostedAnswers, Question, SimpleForm,
     },
     user::models::User,
 };
@@ -30,4 +30,5 @@ pub trait FormRepository: Send + Sync + 'static {
     async fn post_answer(&self, answers: PostedAnswers) -> Result<(), Error>;
     async fn get_all_answers(&self) -> Result<Vec<PostedAnswers>, Error>;
     async fn create_questions(&self, questions: FormQuestionUpdateSchema) -> Result<(), Error>;
+    async fn get_questions(&self, form_id: FormId) -> Result<Vec<Question>, Error>;
 }

--- a/server/domain/src/user/models.rs
+++ b/server/domain/src/user/models.rs
@@ -14,5 +14,6 @@ pub struct User {
 pub enum Role {
     Administrator,
     #[default]
+    #[strum(serialize = "STANDARD_USER")]
     StandardUser,
 }

--- a/server/entrypoint/src/main.rs
+++ b/server/entrypoint/src/main.rs
@@ -12,7 +12,8 @@ use presentation::{
     auth::auth,
     form_handler::{
         create_form_handler, create_question_handler, delete_form_handler, form_list_handler,
-        get_all_answers, get_form_handler, post_answer_handler, update_form_handler,
+        get_all_answers, get_form_handler, get_questions_handler, post_answer_handler,
+        update_form_handler,
     },
     health_check_handler::health_check,
 };
@@ -68,6 +69,8 @@ async fn main() -> anyhow::Result<()> {
                 .delete(delete_form_handler)
                 .patch(update_form_handler),
         )
+        .with_state(shared_repository.to_owned())
+        .route("/forms/:id/questions", get(get_questions_handler))
         .with_state(shared_repository.to_owned())
         .route(
             "/forms/answers",

--- a/server/infra/resource/src/database/components.rs
+++ b/server/infra/resource/src/database/components.rs
@@ -9,7 +9,7 @@ use domain::{
 use errors::infra::InfraError;
 use mockall::automock;
 
-use crate::dto::{FormDto, PostedAnswersDto, SimpleFormDto};
+use crate::dto::{FormDto, PostedAnswersDto, QuestionDto, SimpleFormDto};
 
 #[async_trait]
 pub trait DatabaseComponents: Send + Sync {
@@ -46,6 +46,7 @@ pub trait FormDatabase: Send + Sync {
     async fn get_all_answers(&self) -> Result<Vec<PostedAnswersDto>, InfraError>;
     async fn create_questions(&self, questions: FormQuestionUpdateSchema)
         -> Result<(), InfraError>;
+    async fn get_questions(&self, form_id: FormId) -> Result<Vec<QuestionDto>, InfraError>;
 }
 
 #[automock]

--- a/server/infra/resource/src/database/form.rs
+++ b/server/infra/resource/src/database/form.rs
@@ -417,7 +417,7 @@ impl FormDatabase for ConnectionPool {
 
         let choices_rs = self
             .query_all_and_values(
-                r"SELECT form_choices.question_id AS choice_question_id, choice FROM form_choices 
+                r"SELECT form_choices.question_id, choice FROM form_choices 
             INNER JOIN form_questions ON form_choices.question_id = form_questions.question_id
             WHERE form_id = ?",
                 [form_id.to_owned().into()],
@@ -427,7 +427,7 @@ impl FormDatabase for ConnectionPool {
         questions_rs
             .into_iter()
             .map(|question_rs| {
-                let question_id: i32 = question_rs.try_get("", "choice_question_id")?;
+                let question_id: i32 = question_rs.try_get("", "question_id")?;
 
                 let choices = choices_rs
                     .iter()

--- a/server/infra/resource/src/database/form.rs
+++ b/server/infra/resource/src/database/form.rs
@@ -417,7 +417,7 @@ impl FormDatabase for ConnectionPool {
 
         let choices_rs = self
             .query_all_and_values(
-                r"SELECT question_id, choice FROM form_choices 
+                r"SELECT form_choices.question_id AS choice_question_id, choice FROM form_choices 
             INNER JOIN form_questions ON form_choices.question_id = form_questions.question_id
             WHERE form_id = ?",
                 [form_id.to_owned().into()],
@@ -427,7 +427,7 @@ impl FormDatabase for ConnectionPool {
         questions_rs
             .into_iter()
             .map(|question_rs| {
-                let question_id: i32 = question_rs.try_get("", "question_id")?;
+                let question_id: i32 = question_rs.try_get("", "choice_question_id")?;
 
                 let choices = choices_rs
                     .iter()

--- a/server/infra/resource/src/repository/form_repository_impl.rs
+++ b/server/infra/resource/src/repository/form_repository_impl.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use domain::{
     form::models::{
         Form, FormDescription, FormId, FormQuestionUpdateSchema, FormTitle, FormUpdateTargets,
-        OffsetAndLimit, PostedAnswers, SimpleForm,
+        OffsetAndLimit, PostedAnswers, Question, SimpleForm,
     },
     repository::form_repository::FormRepository,
     user::models::User,
@@ -95,6 +95,20 @@ impl<Client: DatabaseComponents + 'static> FormRepository for Repository<Client>
             .form()
             .create_questions(questions)
             .await
+            .map_err(Into::into)
+    }
+
+    async fn get_questions(&self, form_id: FormId) -> Result<Vec<Question>, Error> {
+        self.client
+            .form()
+            .get_questions(form_id)
+            .await
+            .map(|questions_dto| {
+                questions_dto
+                    .into_iter()
+                    .map(|question_dto| question_dto.try_into())
+                    .collect::<Result<Vec<Question>, _>>()
+            })?
             .map_err(Into::into)
     }
 }

--- a/server/presentation/Cargo.toml
+++ b/server/presentation/Cargo.toml
@@ -15,3 +15,4 @@ tracing = { workspace = true }
 usecase = { path = "../usecase" }
 uuid = { workspace = true }
 reqwest = { workspace = true }
+regex = { workspace = true }

--- a/server/presentation/src/form_handler.rs
+++ b/server/presentation/src/form_handler.rs
@@ -120,6 +120,20 @@ pub async fn update_form_handler(
     }
 }
 
+pub async fn get_questions_handler(
+    State(repository): State<RealInfrastructureRepository>,
+    Path(form_id): Path<FormId>,
+) -> impl IntoResponse {
+    let form_use_case = FormUseCase {
+        repository: repository.form_repository(),
+    };
+
+    match form_use_case.get_questions(form_id).await {
+        Ok(questions) => (StatusCode::OK, Json(questions)).into_response(),
+        Err(err) => handle_error(err).into_response(),
+    }
+}
+
 pub async fn get_all_answers(
     State(repository): State<RealInfrastructureRepository>,
 ) -> impl IntoResponse {

--- a/server/usecase/src/form.rs
+++ b/server/usecase/src/form.rs
@@ -1,7 +1,7 @@
 use domain::{
     form::models::{
         Form, FormDescription, FormId, FormQuestionUpdateSchema, FormTitle, FormUpdateTargets,
-        OffsetAndLimit, PostedAnswers, SimpleForm,
+        OffsetAndLimit, PostedAnswers, Question, SimpleForm,
     },
     repository::form_repository::FormRepository,
     user::models::User,
@@ -35,6 +35,10 @@ impl<R: FormRepository> FormUseCase<'_, R> {
 
     pub async fn delete_form(&self, form_id: FormId) -> Result<FormId, Error> {
         self.repository.delete(form_id).await
+    }
+
+    pub async fn get_questions(&self, form_id: FormId) -> Result<Vec<Question>, Error> {
+        self.repository.get_questions(form_id).await
     }
 
     pub async fn update_form(


### PR DESCRIPTION
通常ユーザーがフォームに紐づいた質問を取得する方法がなくなり、新しく取得用のAPIが定義されたので実装しました