### PR TITLE
フォームに回答ができない不具合を修正

### DIFF
--- a/server/infra/resource/src/database/form.rs
+++ b/server/infra/resource/src/database/form.rs
@@ -39,6 +39,12 @@ impl FormDatabase for ConnectionPool {
             .await?
             .last_insert_id() as i32;
 
+        self.execute_and_values(
+            "INSERT INTO default_answer_titles (form_id, title) VALUES (?, NULL)",
+            [form_id.to_owned().into()],
+        )
+        .await?;
+
         Ok(form_id.into())
     }
 

--- a/server/migration/src/m20220101_000001_create_table.rs
+++ b/server/migration/src/m20220101_000001_create_table.rs
@@ -127,7 +127,7 @@ impl MigrationTrait for Migration {
                 r"CREATE TABLE IF NOT EXISTS default_answer_titles(
                     id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
                     form_id INT NOT NULL,
-                    title TEXT NOT NULL,
+                    title TEXT,
                     FOREIGN KEY fk_default_answer_titles_form_id(form_id) REFERENCES form_meta_data(id) ON DELETE CASCADE
                 )",
             ))


### PR DESCRIPTION
フォームが作成されたときに`default_answer_titles`テーブルにinsertが行われていなかったため、フォームが見つからない判定になってしまうことが原因でした