### PR TITLE
fix: post_answersでUUIDとtimestampを受け取らないようにする

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -2090,6 +2090,7 @@ name = "presentation"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "chrono",
  "common",
  "domain",
  "errors",

--- a/server/domain/src/form/models.rs
+++ b/server/domain/src/form/models.rs
@@ -210,6 +210,13 @@ impl DefaultAnswerTitle {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
+pub struct PostedAnswersSchema {
+    pub form_id: FormId,
+    pub title: DefaultAnswerTitle,
+    pub answers: Vec<Answer>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
 pub struct PostedAnswers {
     pub uuid: Uuid, //todo: あとでUser型に直す
     pub timestamp: DateTime<Utc>,

--- a/server/infra/resource/src/database/form.rs
+++ b/server/infra/resource/src/database/form.rs
@@ -321,7 +321,7 @@ impl FormDatabase for ConnectionPool {
     async fn get_all_answers(&self) -> Result<Vec<PostedAnswersDto>, InfraError> {
         let answers = self
             .query_all(
-                "SELECT form_id, answers.id AS answer_id, title, uuid, time_stamp FROM answers
+                r"SELECT form_id, answers.id AS answer_id, title, uuid, time_stamp FROM answers
                         INNER JOIN users ON answers.user = users.id
                         ORDER BY answers.time_stamp",
             )

--- a/server/presentation/Cargo.toml
+++ b/server/presentation/Cargo.toml
@@ -16,3 +16,4 @@ usecase = { path = "../usecase" }
 uuid = { workspace = true }
 reqwest = { workspace = true }
 regex = { workspace = true }
+chrono = { workspace = true }

--- a/server/presentation/src/form_handler.rs
+++ b/server/presentation/src/form_handler.rs
@@ -4,9 +4,11 @@ use axum::{
     response::IntoResponse,
     Extension, Json,
 };
+use chrono::Utc;
 use domain::{
     form::models::{
         Form, FormId, FormQuestionUpdateSchema, FormUpdateTargets, OffsetAndLimit, PostedAnswers,
+        PostedAnswersSchema,
     },
     repository::Repositories,
     user::models::User,
@@ -148,11 +150,20 @@ pub async fn get_all_answers(
 }
 
 pub async fn post_answer_handler(
+    Extension(user): Extension<User>,
     State(repository): State<RealInfrastructureRepository>,
-    Json(answers): Json<PostedAnswers>,
+    Json(schema): Json<PostedAnswersSchema>,
 ) -> impl IntoResponse {
     let form_use_case = FormUseCase {
         repository: repository.form_repository(),
+    };
+
+    let answers = PostedAnswers {
+        uuid: user.id,
+        timestamp: Utc::now(),
+        form_id: schema.form_id,
+        title: schema.title,
+        answers: schema.answers,
     };
 
     match form_use_case.post_answers(answers).await {


### PR DESCRIPTION
UUIDは認証情報から、timestampはバックエンド側で生成するようにAPIスキーマが変わったので修正しました。