### PR TITLE
fix serialized string for User

### DIFF
--- a/server/domain/src/user/models.rs
+++ b/server/domain/src/user/models.rs
@@ -12,8 +12,11 @@ pub struct User {
 
 #[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq, Display)]
 pub enum Role {
+    #[serde(rename = "ADMINISTRATOR")]
+    #[strum(serialize = "ADMINISTRATOR")]
     Administrator,
     #[default]
+    #[serde(rename = "STANDARD_USER")]
     #[strum(serialize = "STANDARD_USER")]
     StandardUser,
 }


### PR DESCRIPTION
User::AdministratorやStandardUserがそのままシリアライズされるのを修正
ローカルで確認済み

close #348 