### PR TITLE
ユーザーがログインしたときにroleがStandardUserに上書きされるのを修正

### DIFF
--- a/server/infra/resource/src/database/user.rs
+++ b/server/infra/resource/src/database/user.rs
@@ -13,8 +13,7 @@ impl UserDatabase for ConnectionPool {
                 DatabaseBackend::MySql,
                 "INSERT INTO users (uuid, name, role) VALUES (?, ?, ?)
                         ON DUPLICATE KEY UPDATE
-                        name = VALUES(name),
-                        role = VALUES(role)",
+                        name = VALUES(name)",
                 [
                     user.id.to_string().into(),
                     user.name.to_owned().into(),


### PR DESCRIPTION
close #350

初めてログインしたユーザーの`role`は`insert`されてもいいですが、再ログインユーザーの`role`は`update`されると強制的に`role`のデフォルトである`StandardUser`に上書きれるので、`role`の`update`を行わないようにしました