### PR TITLE
回答が送信されたときとコメントが送信されたときにWebhookを送ることができる機能を実装

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -2016,6 +2016,7 @@ version = "0.1.0"
 dependencies = [
  "domain",
  "errors",
+ "itertools 0.12.0",
  "reqwest",
  "serde",
  "serde_json",

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -2512,6 +2512,7 @@ dependencies = [
  "sea-orm",
  "serde",
  "tracing",
+ "types",
  "uuid",
 ]
 
@@ -3863,6 +3864,7 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 name = "types"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "deriving_via",
  "proptest",
  "proptest-derive",

--- a/server/domain/src/form/models.rs
+++ b/server/domain/src/form/models.rs
@@ -230,7 +230,7 @@ impl<Repo: FormRepository + Sized + Sync> Resolver<PostedAnswers, Repo> for Answ
             .unwrap()
             .into_iter()
             .find(|answer| &answer.id == self)
-            .unwrap()
+            .unwrap() // NOTE: AnswerIdからPostedAnswersが見つからないのであれば、データがぶっ壊れている
     }
 }
 

--- a/server/domain/src/form/models.rs
+++ b/server/domain/src/form/models.rs
@@ -1,4 +1,3 @@
-use crate::repository::form_repository::FormRepository;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 #[cfg(test)]
@@ -13,7 +12,7 @@ use typed_builder::TypedBuilder;
 use types::Resolver;
 use uuid::Uuid;
 
-use crate::user::models::User;
+use crate::{repository::form_repository::FormRepository, user::models::User};
 
 pub type FormId = types::Id<Form>;
 

--- a/server/domain/src/repository/form_repository.rs
+++ b/server/domain/src/repository/form_repository.rs
@@ -2,6 +2,7 @@ use async_trait::async_trait;
 use errors::Error;
 use mockall::automock;
 
+use crate::form::models::PostedAnswersSchema;
 use crate::{
     form::models::{
         AnswerId, Comment, Form, FormDescription, FormId, FormQuestionUpdateSchema, FormTitle,
@@ -27,7 +28,7 @@ pub trait FormRepository: Send + Sync + 'static {
         form_id: FormId,
         form_update_targets: FormUpdateTargets,
     ) -> Result<(), Error>;
-    async fn post_answer(&self, answers: PostedAnswers) -> Result<(), Error>;
+    async fn post_answer(&self, user: &User, answers: &PostedAnswersSchema) -> Result<(), Error>;
     async fn get_all_answers(&self) -> Result<Vec<PostedAnswers>, Error>;
     async fn create_questions(&self, questions: FormQuestionUpdateSchema) -> Result<(), Error>;
     async fn get_questions(&self, form_id: FormId) -> Result<Vec<Question>, Error>;

--- a/server/domain/src/repository/form_repository.rs
+++ b/server/domain/src/repository/form_repository.rs
@@ -2,11 +2,11 @@ use async_trait::async_trait;
 use errors::Error;
 use mockall::automock;
 
-use crate::form::models::PostedAnswersSchema;
 use crate::{
     form::models::{
         AnswerId, Comment, Form, FormDescription, FormId, FormQuestionUpdateSchema, FormTitle,
-        FormUpdateTargets, OffsetAndLimit, PostedAnswers, Question, SimpleForm,
+        FormUpdateTargets, OffsetAndLimit, PostedAnswers, PostedAnswersSchema, Question,
+        SimpleForm,
     },
     user::models::User,
 };

--- a/server/infra/outgoing/Cargo.toml
+++ b/server/infra/outgoing/Cargo.toml
@@ -11,3 +11,4 @@ reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }
+itertools = { workspace = true }

--- a/server/infra/outgoing/src/form_outgoing.rs
+++ b/server/infra/outgoing/src/form_outgoing.rs
@@ -2,7 +2,7 @@ use domain::form::models::{Form, PostedAnswers};
 use errors::infra::InfraError;
 use itertools::Itertools;
 
-use crate::webhook::Webhook;
+use crate::webhook::{Color, Webhook};
 
 #[tracing::instrument]
 pub async fn create(form: Form) -> Result<(), InfraError> {
@@ -21,7 +21,7 @@ pub async fn create(form: Form) -> Result<(), InfraError> {
                     .unwrap_or("フォームの説明は設定されていません。".to_string()),
                 false,
             )
-            .send()
+            .send(Color::Aqua)
             .await?;
     }
 
@@ -45,23 +45,25 @@ pub async fn post(form: &Form, answers: &PostedAnswers) -> Result<(), InfraError
                     .unwrap_or_default(),
                 false,
             )
-            .field(
-                "内容".to_string(),
+            .fields(
                 answers
                     .answers
                     .iter()
                     .map(|answer| {
-                        form.questions
-                            .iter()
-                            .find(|question| question.id == answer.question_id)
-                            .map(|question| question.title.to_owned())
-                            .unwrap_or_else(|| "不明な質問".to_string())
+                        (
+                            form.questions
+                                .iter()
+                                .find(|question| question.id == answer.question_id)
+                                .map(|question| question.title.to_owned())
+                                .unwrap_or("不明な質問".to_string()),
+                            answer.answer.to_owned(),
+                        )
                     })
-                    .join("\n"),
+                    .collect_vec(),
                 false,
             )
             .field("回答者".to_string(), answers.uuid.to_string(), false)
-            .send()
+            .send(Color::Lime)
             .await?;
     }
 
@@ -77,7 +79,7 @@ pub async fn delete(form: Form) -> Result<(), InfraError> {
                 form.title.title().to_owned(),
                 false,
             )
-            .send()
+            .send(Color::Red)
             .await?;
     }
 

--- a/server/infra/outgoing/src/form_outgoing.rs
+++ b/server/infra/outgoing/src/form_outgoing.rs
@@ -1,5 +1,6 @@
-use domain::form::models::Form;
+use domain::form::models::{Form, PostedAnswers};
 use errors::infra::InfraError;
+use itertools::Itertools;
 
 use crate::webhook::Webhook;
 
@@ -20,6 +21,46 @@ pub async fn create(form: Form) -> Result<(), InfraError> {
                     .unwrap_or("フォームの説明は設定されていません。".to_string()),
                 false,
             )
+            .send()
+            .await?;
+    }
+
+    Ok(())
+}
+
+pub async fn post(form: &Form, answers: &PostedAnswers) -> Result<(), InfraError> {
+    if let Some(url) = form.settings.webhook_url.to_owned() {
+        Webhook::new(url, "回答が送信されました".to_string())
+            .field(
+                "フォーム名".to_string(),
+                form.title.title().to_owned(),
+                false,
+            )
+            .field(
+                "タイトル".to_string(),
+                answers
+                    .title
+                    .default_answer_title
+                    .to_owned()
+                    .unwrap_or_default(),
+                false,
+            )
+            .field(
+                "内容".to_string(),
+                answers
+                    .answers
+                    .iter()
+                    .map(|answer| {
+                        form.questions
+                            .iter()
+                            .find(|question| question.id == answer.question_id)
+                            .map(|question| question.title.to_owned())
+                            .unwrap_or_else(|| "不明な質問".to_string())
+                    })
+                    .join("\n"),
+                false,
+            )
+            .field("回答者".to_string(), answers.uuid.to_string(), false)
             .send()
             .await?;
     }

--- a/server/infra/outgoing/src/form_outgoing.rs
+++ b/server/infra/outgoing/src/form_outgoing.rs
@@ -28,7 +28,7 @@ pub async fn create(form: Form) -> Result<(), InfraError> {
     Ok(())
 }
 
-pub async fn post(form: &Form, answers: &PostedAnswers) -> Result<(), InfraError> {
+pub async fn post_answer(form: &Form, answers: &PostedAnswers) -> Result<(), InfraError> {
     if let Some(url) = form.settings.webhook_url.to_owned() {
         Webhook::new(url, "回答が送信されました".to_string())
             .field(

--- a/server/infra/outgoing/src/form_outgoing.rs
+++ b/server/infra/outgoing/src/form_outgoing.rs
@@ -1,4 +1,5 @@
-use domain::form::models::{Form, PostedAnswers};
+use domain::form::models::{Answer, Comment, Form, PostedAnswersSchema};
+use domain::user::models::User;
 use errors::infra::InfraError;
 use itertools::Itertools;
 
@@ -28,7 +29,11 @@ pub async fn create(form: Form) -> Result<(), InfraError> {
     Ok(())
 }
 
-pub async fn post_answer(form: &Form, answers: &PostedAnswers) -> Result<(), InfraError> {
+pub async fn post_answer(
+    form: &Form,
+    user: &User,
+    answers: &PostedAnswersSchema,
+) -> Result<(), InfraError> {
     if let Some(url) = form.settings.webhook_url.to_owned() {
         Webhook::new(url, "回答が送信されました".to_string())
             .field(
@@ -62,12 +67,22 @@ pub async fn post_answer(form: &Form, answers: &PostedAnswers) -> Result<(), Inf
                     .collect_vec(),
                 false,
             )
-            .field("回答者".to_string(), answers.uuid.to_string(), false)
+            .field("回答者".to_string(), user.name.to_owned(), false)
             .send(Color::Lime)
             .await?;
     }
 
     Ok(())
+}
+
+#[tracing::instrument]
+pub async fn post_comment(
+    form: &Form,
+    comment: &Comment,
+    answer: Answer,
+) -> Result<(), InfraError> {
+    todo!()
+    // if let Some(url) = form.settings.webhook_url.into() {}
 }
 
 #[tracing::instrument]

--- a/server/infra/outgoing/src/form_outgoing.rs
+++ b/server/infra/outgoing/src/form_outgoing.rs
@@ -1,4 +1,4 @@
-use domain::form::models::{Answer, Comment, Form, PostedAnswersSchema};
+use domain::form::models::{Answer, Comment, Form, PostedAnswers, PostedAnswersSchema};
 use domain::user::models::User;
 use errors::infra::InfraError;
 use itertools::Itertools;
@@ -79,10 +79,22 @@ pub async fn post_answer(
 pub async fn post_comment(
     form: &Form,
     comment: &Comment,
-    answer: Answer,
+    answer: &PostedAnswers,
 ) -> Result<(), InfraError> {
-    todo!()
-    // if let Some(url) = form.settings.webhook_url.into() {}
+    if let Some(url) = form.settings.webhook_url.webhook_url.to_owned() {
+        Webhook::new(url, "回答に対してコメントが投稿されました".to_string())
+            .field("回答".to_string(), answer.title.unwrap_or_default(), false)
+            .field("内容".to_string(), comment.content.to_owned(), false)
+            .field(
+                "発言者".to_string(),
+                comment.commented_by.name.to_owned(),
+                false,
+            )
+            .send(Color::Lime)
+            .await?;
+    }
+
+    Ok(())
 }
 
 #[tracing::instrument]

--- a/server/infra/outgoing/src/form_outgoing.rs
+++ b/server/infra/outgoing/src/form_outgoing.rs
@@ -1,5 +1,7 @@
-use domain::form::models::{Answer, Comment, Form, PostedAnswers, PostedAnswersSchema};
-use domain::user::models::User;
+use domain::{
+    form::models::{Comment, Form, PostedAnswers, PostedAnswersSchema},
+    user::models::User,
+};
 use errors::infra::InfraError;
 use itertools::Itertools;
 

--- a/server/infra/outgoing/src/webhook.rs
+++ b/server/infra/outgoing/src/webhook.rs
@@ -1,4 +1,5 @@
 use errors::infra::InfraError;
+use itertools::Itertools;
 use serde::Serialize;
 use serde_json::json;
 
@@ -18,6 +19,7 @@ struct SendContents {
 #[derive(Debug, Serialize)]
 struct Embeds {
     title: String,
+    color: i32,
     fields: Vec<Field>,
 }
 
@@ -26,6 +28,23 @@ struct Field {
     name: String,
     value: String,
     inline: bool,
+}
+
+#[derive(Debug)]
+pub enum Color {
+    Red,
+    Lime,
+    Aqua,
+}
+
+impl Color {
+    pub fn to_color_code(&self) -> i32 {
+        match self {
+            Color::Red => 16711680,
+            Color::Lime => 65280,
+            Color::Aqua => 65535,
+        }
+    }
 }
 
 impl Webhook {
@@ -57,11 +76,33 @@ impl Webhook {
     }
 
     #[tracing::instrument]
-    pub async fn send(&self) -> Result<(), InfraError> {
+    pub fn fields(&self, name_and_values: Vec<(String, String)>, inline: bool) -> Self {
+        let fields = name_and_values
+            .into_iter()
+            .map(|(name, value)| Field {
+                name,
+                value,
+                inline,
+            })
+            .collect_vec();
+
+        Self {
+            target_url: self.target_url.to_owned(),
+            title: self.title.to_owned(),
+            fields: vec![self.fields.to_vec(), fields]
+                .into_iter()
+                .flatten()
+                .collect(),
+        }
+    }
+
+    #[tracing::instrument]
+    pub async fn send(&self, color: Color) -> Result<(), InfraError> {
         let contents = SendContents {
             username: "seichi-portal-backend".to_string(),
             embeds: vec![Embeds {
                 title: self.title.to_owned(),
+                color: color.to_color_code(),
                 fields: self.fields.to_vec(),
             }],
         };

--- a/server/infra/resource/Cargo.toml
+++ b/server/infra/resource/Cargo.toml
@@ -22,3 +22,4 @@ tracing = { workspace = true }
 num-traits = { workspace = true }
 regex = { workspace = true }
 uuid = { workspace = true }
+types = { path = "../../types"}

--- a/server/infra/resource/src/database/components.rs
+++ b/server/infra/resource/src/database/components.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use domain::form::models::PostedAnswersSchema;
 use domain::{
     form::models::{
         AnswerId, Comment, FormDescription, FormId, FormQuestionUpdateSchema, FormTitle,
@@ -43,7 +44,11 @@ pub trait FormDatabase: Send + Sync {
         form_id: FormId,
         form_update_targets: FormUpdateTargets,
     ) -> Result<(), InfraError>;
-    async fn post_answer(&self, answer: PostedAnswers) -> Result<(), InfraError>;
+    async fn post_answer(
+        &self,
+        user: &User,
+        answers_schema: &PostedAnswersSchema,
+    ) -> Result<(), InfraError>;
     async fn get_all_answers(&self) -> Result<Vec<PostedAnswersDto>, InfraError>;
     async fn create_questions(&self, questions: FormQuestionUpdateSchema)
         -> Result<(), InfraError>;

--- a/server/infra/resource/src/database/components.rs
+++ b/server/infra/resource/src/database/components.rs
@@ -1,9 +1,8 @@
 use async_trait::async_trait;
-use domain::form::models::PostedAnswersSchema;
 use domain::{
     form::models::{
         AnswerId, Comment, FormDescription, FormId, FormQuestionUpdateSchema, FormTitle,
-        FormUpdateTargets, OffsetAndLimit, PostedAnswers,
+        FormUpdateTargets, OffsetAndLimit, PostedAnswersSchema,
     },
     user::models::{Role, User},
 };

--- a/server/infra/resource/src/database/form.rs
+++ b/server/infra/resource/src/database/form.rs
@@ -2,11 +2,10 @@ use std::str::FromStr;
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use domain::form::models::PostedAnswersSchema;
 use domain::{
     form::models::{
         AnswerId, Comment, DefaultAnswerTitle, FormDescription, FormId, FormQuestionUpdateSchema,
-        FormTitle, FormUpdateTargets, OffsetAndLimit, PostedAnswers,
+        FormTitle, FormUpdateTargets, OffsetAndLimit, PostedAnswersSchema,
     },
     user::models::{Role::Administrator, User},
 };
@@ -366,6 +365,7 @@ impl FormDatabase for ConnectionPool {
                     .collect::<Result<Vec<_>, _>>()?;
 
                 Ok(PostedAnswersDto {
+                    id: answer_id,
                     uuid: uuid::Uuid::from_str(&rs.try_get::<String>("", "uuid")?)?,
                     timestamp: rs.try_get("", "time_stamp")?,
                     form_id: rs.try_get("", "form_id")?,

--- a/server/infra/resource/src/database/form.rs
+++ b/server/infra/resource/src/database/form.rs
@@ -501,7 +501,7 @@ impl FormDatabase for ConnectionPool {
     async fn post_comment(&self, comment: &Comment) -> Result<(), InfraError> {
         self.execute_and_values(
             r"INSERT INTO form_answer_comments (answer_id, commented_by, content)
-                SELECT ?, ?, users.id FROM users WHERE uuid = ?
+                SELECT ?, users.id, ? FROM users WHERE uuid = ?
             ",
             [
                 comment.answer_id.into_inner().into(),

--- a/server/infra/resource/src/dto.rs
+++ b/server/infra/resource/src/dto.rs
@@ -134,6 +134,7 @@ impl TryFrom<AnswerDto> for domain::form::models::Answer {
 }
 
 pub struct PostedAnswersDto {
+    pub id: i32,
     pub uuid: Uuid,
     pub timestamp: DateTime<Utc>,
     pub form_id: i32,
@@ -146,6 +147,7 @@ impl TryFrom<PostedAnswersDto> for domain::form::models::PostedAnswers {
 
     fn try_from(
         PostedAnswersDto {
+            id,
             uuid,
             timestamp,
             form_id,
@@ -154,7 +156,7 @@ impl TryFrom<PostedAnswersDto> for domain::form::models::PostedAnswers {
         }: PostedAnswersDto,
     ) -> Result<Self, Self::Error> {
         Ok(domain::form::models::PostedAnswers {
-            id: todo!(),
+            id: id.into(),
             uuid,
             timestamp,
             form_id: form_id.into(),

--- a/server/infra/resource/src/dto.rs
+++ b/server/infra/resource/src/dto.rs
@@ -154,6 +154,7 @@ impl TryFrom<PostedAnswersDto> for domain::form::models::PostedAnswers {
         }: PostedAnswersDto,
     ) -> Result<Self, Self::Error> {
         Ok(domain::form::models::PostedAnswers {
+            id: todo!(),
             uuid,
             timestamp,
             form_id: form_id.into(),

--- a/server/infra/resource/src/repository/form_repository_impl.rs
+++ b/server/infra/resource/src/repository/form_repository_impl.rs
@@ -73,6 +73,9 @@ impl<Client: DatabaseComponents + 'static> FormRepository for Repository<Client>
 
     #[tracing::instrument(skip(self))]
     async fn post_answer(&self, answers: PostedAnswers) -> Result<(), Error> {
+        let form = self.get(answers.form_id).await?;
+        form_outgoing::post(&form, &answers).await?;
+
         self.client
             .form()
             .post_answer(answers)

--- a/server/infra/resource/src/repository/form_repository_impl.rs
+++ b/server/infra/resource/src/repository/form_repository_impl.rs
@@ -1,9 +1,9 @@
 use async_trait::async_trait;
-use domain::form::models::PostedAnswersSchema;
 use domain::{
     form::models::{
         AnswerId, Comment, Form, FormDescription, FormId, FormQuestionUpdateSchema, FormTitle,
-        FormUpdateTargets, OffsetAndLimit, PostedAnswers, Question, SimpleForm,
+        FormUpdateTargets, OffsetAndLimit, PostedAnswers, PostedAnswersSchema, Question,
+        SimpleForm,
     },
     repository::form_repository::FormRepository,
     user::models::User,
@@ -80,7 +80,7 @@ impl<Client: DatabaseComponents + 'static> FormRepository for Repository<Client>
         answers_schema: &PostedAnswersSchema,
     ) -> Result<(), Error> {
         let form = self.get(answers_schema.form_id).await?;
-        form_outgoing::post_answer(&form, user, &answers_schema).await?;
+        form_outgoing::post_answer(&form, user, answers_schema).await?;
 
         self.client
             .form()

--- a/server/infra/resource/src/repository/form_repository_impl.rs
+++ b/server/infra/resource/src/repository/form_repository_impl.rs
@@ -74,7 +74,7 @@ impl<Client: DatabaseComponents + 'static> FormRepository for Repository<Client>
     #[tracing::instrument(skip(self))]
     async fn post_answer(&self, answers: PostedAnswers) -> Result<(), Error> {
         let form = self.get(answers.form_id).await?;
-        form_outgoing::post(&form, &answers).await?;
+        form_outgoing::post_answer(&form, &answers).await?;
 
         self.client
             .form()

--- a/server/infra/resource/src/repository/form_repository_impl.rs
+++ b/server/infra/resource/src/repository/form_repository_impl.rs
@@ -130,7 +130,11 @@ impl<Client: DatabaseComponents + 'static> FormRepository for Repository<Client>
     }
 
     async fn post_comment(&self, comment: &Comment) -> Result<(), Error> {
-        comment.answer_id.resolve(self).await;
+        let posted_answers = comment.answer_id.resolve(self).await;
+        let form = self.get(posted_answers.form_id).await?;
+
+        form_outgoing::post_comment(&form, comment, &posted_answers).await?;
+
         self.client
             .form()
             .post_comment(comment)

--- a/server/presentation/src/form_handler.rs
+++ b/server/presentation/src/form_handler.rs
@@ -4,7 +4,6 @@ use axum::{
     response::IntoResponse,
     Extension, Json,
 };
-
 use domain::{
     form::models::{
         Comment, CommentSchema, Form, FormId, FormQuestionUpdateSchema, FormUpdateTargets,

--- a/server/presentation/src/form_handler.rs
+++ b/server/presentation/src/form_handler.rs
@@ -4,11 +4,11 @@ use axum::{
     response::IntoResponse,
     Extension, Json,
 };
-use chrono::Utc;
+
 use domain::{
     form::models::{
         Comment, CommentSchema, Form, FormId, FormQuestionUpdateSchema, FormUpdateTargets,
-        OffsetAndLimit, PostedAnswers, PostedAnswersSchema,
+        OffsetAndLimit, PostedAnswersSchema,
     },
     repository::Repositories,
     user::models::User,
@@ -158,15 +158,7 @@ pub async fn post_answer_handler(
         repository: repository.form_repository(),
     };
 
-    let answers = PostedAnswers {
-        uuid: user.id,
-        timestamp: Utc::now(),
-        form_id: schema.form_id,
-        title: schema.title,
-        answers: schema.answers,
-    };
-
-    match form_use_case.post_answers(answers).await {
+    match form_use_case.post_answers(&user, &schema).await {
         Ok(_) => (StatusCode::OK).into_response(),
         Err(err) => handle_error(err).into_response(),
     }

--- a/server/types/Cargo.toml
+++ b/server/types/Cargo.toml
@@ -12,3 +12,4 @@ deriving_via = { workspace = true }
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
 serde = { workspace = true }
+async-trait = { workspace = true }

--- a/server/types/src/lib.rs
+++ b/server/types/src/lib.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use deriving_via::DerivingVia;
 #[cfg(feature = "arbitrary")]
 use proptest_derive::Arbitrary;
@@ -14,3 +15,8 @@ impl<T> Clone for Id<T> {
 }
 
 impl<T> Copy for Id<T> {}
+
+#[async_trait]
+pub trait Resolver<T, Repo> {
+    async fn resolve(&self, repo: &Repo) -> T;
+}

--- a/server/usecase/src/form.rs
+++ b/server/usecase/src/form.rs
@@ -1,8 +1,8 @@
-use domain::form::models::PostedAnswersSchema;
 use domain::{
     form::models::{
         Comment, Form, FormDescription, FormId, FormQuestionUpdateSchema, FormTitle,
-        FormUpdateTargets, OffsetAndLimit, PostedAnswers, Question, SimpleForm,
+        FormUpdateTargets, OffsetAndLimit, PostedAnswers, PostedAnswersSchema, Question,
+        SimpleForm,
     },
     repository::form_repository::FormRepository,
     user::models::User,

--- a/server/usecase/src/form.rs
+++ b/server/usecase/src/form.rs
@@ -1,3 +1,4 @@
+use domain::form::models::PostedAnswersSchema;
 use domain::{
     form::models::{
         Comment, Form, FormDescription, FormId, FormQuestionUpdateSchema, FormTitle,
@@ -49,8 +50,12 @@ impl<R: FormRepository> FormUseCase<'_, R> {
         self.repository.update(form_id, form_update_targets).await
     }
 
-    pub async fn post_answers(&self, answers: PostedAnswers) -> Result<(), Error> {
-        self.repository.post_answer(answers).await
+    pub async fn post_answers(
+        &self,
+        user: &User,
+        answers: &PostedAnswersSchema,
+    ) -> Result<(), Error> {
+        self.repository.post_answer(user, answers).await
     }
 
     pub async fn get_all_answers(&self) -> Result<Vec<PostedAnswers>, Error> {


### PR DESCRIPTION
回答が送信されたときと、コメントが送信されたときにWebhookを送信できる機能を実装しました。
また、コメントを送信するためのデータベースクエリが壊れていたので直しました。

Idについて、Idから元になっているもの(今回であれば`AnswerId`から`PostedAnswer`)を取得するための関数があると便利だと思い実装してみましたが、これで良いのかはわからないので特に見てほしいです。