### PR TITLE
UseCaseエラーの追加とエラーレスポンスでエラーコード追加

### DIFF
--- a/server/errors/src/infra.rs
+++ b/server/errors/src/infra.rs
@@ -18,8 +18,6 @@ pub enum InfraError {
     FormNotFound { id: i32 },
     #[error("Answer Not Fount: id = {}", .id)]
     AnswerNotFount { id: i32 },
-    #[error("Forbidden")]
-    Forbidden,
     #[error("Outgoing Error: {}", .cause)]
     Outgoing { cause: String },
     #[error("Enum Parse Error: source = {}", .source)]

--- a/server/errors/src/lib.rs
+++ b/server/errors/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod domain;
 pub mod infra;
 pub mod presentation;
+pub mod usecase;
 
 use thiserror::Error;
 
@@ -20,5 +21,10 @@ pub enum Error {
     Presentation {
         #[from]
         source: presentation::PresentationError,
+    },
+    #[error(transparent)]
+    UseCase {
+        #[from]
+        source: usecase::UseCaseError,
     },
 }

--- a/server/errors/src/usecase.rs
+++ b/server/errors/src/usecase.rs
@@ -2,8 +2,8 @@ use thiserror::Error;
 
 #[derive(Debug, Error, PartialEq)]
 pub enum UseCaseError {
-    #[error("Form answer out of period.")]
-    FormAnswerOutOfPeriod,
+    #[error("Out of period.")]
+    OutOfPeriod,
     #[error("Do not have permission to post form comment.")]
     DoNotHavePermissionToPostFormComment,
 }

--- a/server/errors/src/usecase.rs
+++ b/server/errors/src/usecase.rs
@@ -1,0 +1,9 @@
+use thiserror::Error;
+
+#[derive(Debug, Error, PartialEq)]
+pub enum UseCaseError {
+    #[error("Form answer out of period.")]
+    FormAnswerOutOfPeriod,
+    #[error("Do not have permission to post form comment.")]
+    DoNotHavePermissionToPostFormComment,
+}

--- a/server/presentation/src/form_handler.rs
+++ b/server/presentation/src/form_handler.rs
@@ -230,7 +230,7 @@ pub fn handle_error(err: Error) -> impl IntoResponse {
         } => (
             StatusCode::FORBIDDEN,
             Json(json!({
-                "errorCode": "FORM_ANSWER_OUT_OF_PERIOD",
+                "errorCode": "OUT_OF_PERIOD",
                 "reason": "Posted form is out of period."
             })),
         )

--- a/server/presentation/src/form_handler.rs
+++ b/server/presentation/src/form_handler.rs
@@ -225,9 +225,6 @@ pub fn handle_error(err: Error) -> impl IntoResponse {
             })),
         )
             .into_response(),
-        Error::Infra {
-            source: InfraError::Forbidden,
-        } => StatusCode::FORBIDDEN.into_response(),
         Error::UseCase {
             source: UseCaseError::FormAnswerOutOfPeriod,
         } => (

--- a/server/presentation/src/form_handler.rs
+++ b/server/presentation/src/form_handler.rs
@@ -12,6 +12,7 @@ use domain::{
     repository::Repositories,
     user::models::User,
 };
+use errors::usecase::UseCaseError;
 use errors::{infra::InfraError, Error};
 use resource::repository::RealInfrastructureRepository;
 use serde_json::json;
@@ -219,17 +220,43 @@ pub fn handle_error(err: Error) -> impl IntoResponse {
             source: InfraError::FormNotFound { .. },
         } => (
             StatusCode::NOT_FOUND,
-            Json(json!({ "reason": "FORM NOT FOUND" })),
+            Json(json!({
+                "errorCode": "FORM_NOT_FOUND",
+                "reason": "FORM NOT FOUND"
+            })),
         )
             .into_response(),
         Error::Infra {
             source: InfraError::Forbidden,
         } => StatusCode::FORBIDDEN.into_response(),
+        Error::UseCase {
+            source: UseCaseError::FormAnswerOutOfPeriod,
+        } => (
+            StatusCode::FORBIDDEN,
+            Json(json!({
+                "errorCode": "FORM_ANSWER_OUT_OF_PERIOD",
+                "reason": "Posted form is out of period."
+            })),
+        )
+            .into_response(),
+        Error::UseCase {
+            source: UseCaseError::DoNotHavePermissionToPostFormComment,
+        } => (
+            StatusCode::FORBIDDEN,
+            Json(json!({
+                "errorCode": "DO_NOT_HAVE_PERMISSION_TO_POST_FORM_COMMENT",
+                "reason": "Do not have permission to post form comment."
+            })),
+        )
+            .into_response(),
         _ => {
             tracing::error!("{}", err);
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                Json(json!({ "reason": "unknown error" })),
+                Json(json!({
+                    "errorCode": "INTERNAL_SERVER_ERROR",
+                    "reason": "unknown error"
+                })),
             )
                 .into_response()
         }

--- a/server/presentation/src/form_handler.rs
+++ b/server/presentation/src/form_handler.rs
@@ -226,7 +226,7 @@ pub fn handle_error(err: Error) -> impl IntoResponse {
         )
             .into_response(),
         Error::UseCase {
-            source: UseCaseError::FormAnswerOutOfPeriod,
+            source: UseCaseError::OutOfPeriod,
         } => (
             StatusCode::FORBIDDEN,
             Json(json!({

--- a/server/presentation/src/form_handler.rs
+++ b/server/presentation/src/form_handler.rs
@@ -12,8 +12,7 @@ use domain::{
     repository::Repositories,
     user::models::User,
 };
-use errors::usecase::UseCaseError;
-use errors::{infra::InfraError, Error};
+use errors::{infra::InfraError, usecase::UseCaseError, Error};
 use resource::repository::RealInfrastructureRepository;
 use serde_json::json;
 use usecase::form::FormUseCase;

--- a/server/usecase/src/form.rs
+++ b/server/usecase/src/form.rs
@@ -8,8 +8,10 @@ use domain::{
     repository::form_repository::FormRepository,
     user::models::User,
 };
-use errors::usecase::UseCaseError::{DoNotHavePermissionToPostFormComment, FormAnswerOutOfPeriod};
-use errors::{infra::InfraError::Forbidden, Error};
+use errors::{
+    usecase::UseCaseError::{DoNotHavePermissionToPostFormComment, FormAnswerOutOfPeriod},
+    Error,
+};
 use types::Resolver;
 
 pub struct FormUseCase<'a, FormRepo: FormRepository> {

--- a/server/usecase/src/form.rs
+++ b/server/usecase/src/form.rs
@@ -8,6 +8,7 @@ use domain::{
     repository::form_repository::FormRepository,
     user::models::User,
 };
+use errors::usecase::UseCaseError::{DoNotHavePermissionToPostFormComment, FormAnswerOutOfPeriod};
 use errors::{infra::InfraError::Forbidden, Error};
 use types::Resolver;
 
@@ -78,7 +79,7 @@ impl<R: FormRepository> FormUseCase<'_, R> {
         if is_within_period {
             self.repository.post_answer(user, answers).await
         } else {
-            Err(Error::from(Forbidden))
+            Err(Error::from(FormAnswerOutOfPeriod))
         }
     }
 
@@ -106,7 +107,7 @@ impl<R: FormRepository> FormUseCase<'_, R> {
         if has_permission {
             self.repository.post_comment(&comment).await
         } else {
-            Err(Error::from(Forbidden))
+            Err(Error::from(DoNotHavePermissionToPostFormComment))
         }
     }
 }

--- a/server/usecase/src/form.rs
+++ b/server/usecase/src/form.rs
@@ -9,7 +9,7 @@ use domain::{
     user::models::User,
 };
 use errors::{
-    usecase::UseCaseError::{DoNotHavePermissionToPostFormComment, FormAnswerOutOfPeriod},
+    usecase::UseCaseError::{DoNotHavePermissionToPostFormComment, OutOfPeriod},
     Error,
 };
 use types::Resolver;
@@ -81,7 +81,7 @@ impl<R: FormRepository> FormUseCase<'_, R> {
         if is_within_period {
             self.repository.post_answer(user, answers).await
         } else {
-            Err(Error::from(FormAnswerOutOfPeriod))
+            Err(Error::from(OutOfPeriod))
         }
     }
 


### PR DESCRIPTION
UseCaseで`InfraError`が返されていたのでそれを直す目的と、フロントエンド側でなんのエラーが発生したかを区別できたほうが嬉しいので追加しました

lintが落ちてますが #468 がマージされたら通ると思います