### PR TITLE
フォームの情報を更新するときのエンドポイントの実装を修正

### DIFF
--- a/server/domain/src/form/models.rs
+++ b/server/domain/src/form/models.rs
@@ -38,9 +38,9 @@ pub struct FormUpdateTargets {
     #[serde(default)]
     pub description: Option<FormDescription>,
     #[serde(default)]
-    pub start_at: Option<DateTime<Utc>>,
+    pub has_response_period: Option<bool>,
     #[serde(default)]
-    pub end_at: Option<DateTime<Utc>>,
+    pub response_period: Option<ResponsePeriod>,
     #[serde(default)]
     pub webhook: Option<WebhookUrl>,
     #[serde(default)]
@@ -178,8 +178,10 @@ pub struct WebhookUrl {
 #[derive(TypedBuilder, Serialize, Deserialize, Default, Debug, PartialEq)]
 pub struct ResponsePeriod {
     #[cfg_attr(test, proptest(strategy = "arbitrary_opt_date_time()"))]
+    #[serde(default)]
     pub start_at: Option<DateTime<Utc>>,
     #[cfg_attr(test, proptest(strategy = "arbitrary_opt_date_time()"))]
+    #[serde(default)]
     pub end_at: Option<DateTime<Utc>>,
 }
 

--- a/server/migration/src/m20220101_000001_create_table.rs
+++ b/server/migration/src/m20220101_000001_create_table.rs
@@ -73,8 +73,8 @@ impl MigrationTrait for Migration {
                 r"CREATE TABLE IF NOT EXISTS response_period(
                     id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
                     form_id INT NOT NULL,
-                    start_at DATETIME NOT NULL,
-                    end_at DATETIME NOT NULL,
+                    start_at DATETIME,
+                    end_at DATETIME,
                     FOREIGN KEY fk_response_period_form_id(form_id) REFERENCES form_meta_data(id) ON DELETE CASCADE
                 )",
             ))

--- a/server/presentation/src/form_handler.rs
+++ b/server/presentation/src/form_handler.rs
@@ -109,7 +109,7 @@ pub async fn delete_form_handler(
 pub async fn update_form_handler(
     State(repository): State<RealInfrastructureRepository>,
     Path(form_id): Path<FormId>,
-    Query(targets): Query<FormUpdateTargets>,
+    Json(targets): Json<FormUpdateTargets>,
 ) -> impl IntoResponse {
     let form_use_case = FormUseCase {
         repository: repository.form_repository(),


### PR DESCRIPTION
・API スキーマ側でフォームを更新するときのエンドポイントで、更新する情報は json で受け取るようになったのでそのように更新しました。
・API スキーマ側で `has_response_period` というパラメータも受け取るようになったのでパラメータを更新しました。
・それに合わせて `response_period` を更新する処理の修正を行いました。

#496 を先にマージして、リベースをかけてからマージしてほしいです
