### PR TITLE
refactor: Resolver 関数を廃止

### DIFF
--- a/server/domain/src/form/models.rs
+++ b/server/domain/src/form/models.rs
@@ -1,31 +1,21 @@
-use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 #[cfg(test)]
 use common::test_utils::{arbitrary_date_time, arbitrary_opt_date_time, arbitrary_with_size};
 use derive_getters::Getters;
 use deriving_via::DerivingVia;
-use errors::{domain::DomainError, Error};
+use errors::domain::DomainError;
 #[cfg(test)]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 use strum_macros::{Display, EnumString};
 use typed_builder::TypedBuilder;
-use types::Resolver;
 
 use crate::{
-    repository::form_repository::FormRepository,
     types::authorization_guard::AuthorizationGuardDefinitions,
     user::models::{Role::Administrator, User},
 };
 
 pub type FormId = types::IntegerId<Form>;
-
-#[async_trait]
-impl<Repo: FormRepository + Sized + Sync> Resolver<Form, Error, Repo> for FormId {
-    async fn resolve(&self, repo: &Repo) -> Result<Option<Form>, Error> {
-        repo.get(self.to_owned()).await
-    }
-}
 
 #[derive(Deserialize, Debug)]
 pub struct OffsetAndLimit {
@@ -217,13 +207,6 @@ impl DefaultAnswerTitle {
 }
 
 pub type AnswerId = types::IntegerId<FormAnswer>;
-
-#[async_trait]
-impl<Repo: FormRepository + Sized + Sync> Resolver<FormAnswer, Error, Repo> for AnswerId {
-    async fn resolve(&self, repo: &Repo) -> Result<Option<FormAnswer>, Error> {
-        repo.get_answers(self.to_owned()).await
-    }
-}
 
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
 pub struct FormAnswer {

--- a/server/infra/resource/src/repository/form_repository_impl.rs
+++ b/server/infra/resource/src/repository/form_repository_impl.rs
@@ -12,7 +12,6 @@ use domain::{
 use errors::{domain::DomainError, infra::InfraError::AnswerNotFount, Error};
 use futures::{stream, stream::StreamExt};
 use outgoing::form_outgoing;
-use types::Resolver;
 
 use crate::{
     database::components::{DatabaseComponents, FormDatabase},
@@ -303,7 +302,7 @@ impl<Client: DatabaseComponents + 'static> FormRepository for Repository<Client>
     }
 
     async fn post_comment(&self, answer_id: AnswerId, comment: &Comment) -> Result<(), Error> {
-        let posted_answers = answer_id.resolve(self).await?.ok_or(AnswerNotFount {
+        let posted_answers = self.get_answers(answer_id).await?.ok_or(AnswerNotFount {
             id: answer_id.into_inner(),
         })?;
 

--- a/server/types/src/lib.rs
+++ b/server/types/src/lib.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 #[cfg(feature = "arbitrary")]
 use common::test_utils::arbitrary_uuid_v7;
 use deriving_via::DerivingVia;
@@ -35,9 +34,4 @@ impl<T> Id<T> {
     pub fn new() -> Self {
         Self(Uuid::now_v7(), std::marker::PhantomData)
     }
-}
-
-#[async_trait]
-pub trait Resolver<T, Error, Repo> {
-    async fn resolve(&self, repo: &Repo) -> Result<Option<T>, Error>;
 }


### PR DESCRIPTION
普通に `repository` の関数を呼べば十分かつ、`presentation` 層などから `repository` にアクセスすることは不適切なので削除しました