### PR TITLE
ユーザー情報を取得するエンドポイントの改善

### DIFF
--- a/server/domain/src/repository/user_repository.rs
+++ b/server/domain/src/repository/user_repository.rs
@@ -49,7 +49,7 @@ pub trait UserRepository: Send + Sync + 'static {
     async fn fetch_discord_user_id(
         &self,
         actor: &User,
-        user: AuthorizationGuard<User, Read>,
+        user: &AuthorizationGuard<User, Read>,
     ) -> Result<Option<DiscordUserId>, Error>;
     async fn fetch_discord_user_id_by_token(
         &self,

--- a/server/entrypoint/src/main.rs
+++ b/server/entrypoint/src/main.rs
@@ -46,8 +46,8 @@ use presentation::{
         notification_handler::{get_notification_settings, update_notification_settings},
         search_handler::cross_search,
         user_handler::{
-            end_session, get_discord_link_state, get_my_user_info, link_discord, patch_user_role,
-            start_session, unlink_discord, user_list,
+            end_session, get_my_user_info, link_discord, patch_user_role, start_session,
+            unlink_discord, user_list,
         },
     },
 };
@@ -161,10 +161,12 @@ async fn main() -> anyhow::Result<()> {
             post(create_question_handler).put(put_question_handler),
         )
         .with_state(shared_repository.to_owned())
-        .route("/users", get(get_my_user_info))
-        .route("/users/list", get(user_list))
+        .route(
+            "/users/{uuid}",
+            get(get_my_user_info).patch(patch_user_role),
+        )
         .with_state(shared_repository.to_owned())
-        .route("/users/{uuid}", patch(patch_user_role))
+        .route("/users/list", get(user_list))
         .with_state(shared_repository.to_owned())
         .route("/search", get(cross_search))
         .with_state(shared_repository.to_owned())
@@ -192,8 +194,6 @@ async fn main() -> anyhow::Result<()> {
         .route("/session", post(start_session).delete(end_session))
         .with_state(shared_repository.to_owned())
         .route("/link-discord", post(link_discord).delete(unlink_discord))
-        .with_state(shared_repository.to_owned())
-        .route("/discord/accounts/{uuid}", get(get_discord_link_state))
         .with_state(shared_repository.to_owned())
         .fallback(not_found_handler)
         .layer(layer)

--- a/server/infra/resource/src/repository/user_repository_impl.rs
+++ b/server/infra/resource/src/repository/user_repository_impl.rs
@@ -150,7 +150,7 @@ impl<Client: DatabaseComponents + 'static> UserRepository for Repository<Client>
     async fn fetch_discord_user_id(
         &self,
         actor: &User,
-        user: AuthorizationGuard<User, Read>,
+        user: &AuthorizationGuard<User, Read>,
     ) -> Result<Option<DiscordUserId>, Error> {
         let user = user.try_read(actor)?;
 

--- a/server/usecase/src/dto.rs
+++ b/server/usecase/src/dto.rs
@@ -4,6 +4,7 @@ use domain::form::{
     models::{Form, FormLabel},
     question::models::Question,
 };
+use domain::user::models::DiscordUserId;
 
 pub struct AnswerDto {
     pub form_answer: AnswerEntry,
@@ -16,4 +17,9 @@ pub struct FormDto {
     pub form: Form,
     pub questions: Vec<Question>,
     pub labels: Vec<FormLabel>,
+}
+
+pub struct UserDto {
+    pub user: domain::user::models::User,
+    pub discord_user_id: Option<DiscordUserId>,
 }

--- a/server/usecase/src/dto.rs
+++ b/server/usecase/src/dto.rs
@@ -1,10 +1,12 @@
-use domain::form::{
-    answer::models::{AnswerEntry, AnswerLabel, FormAnswerContent},
-    comment::models::Comment,
-    models::{Form, FormLabel},
-    question::models::Question,
+use domain::{
+    form::{
+        answer::models::{AnswerEntry, AnswerLabel, FormAnswerContent},
+        comment::models::Comment,
+        models::{Form, FormLabel},
+        question::models::Question,
+    },
+    user::models::DiscordUserId,
 };
-use domain::user::models::DiscordUserId;
 
 pub struct AnswerDto {
     pub form_answer: AnswerEntry,

--- a/server/usecase/src/forms/message.rs
+++ b/server/usecase/src/forms/message.rs
@@ -103,7 +103,7 @@ impl<
                     Ok(_) if message_sender.id != notification_recipient.id => {
                         if let Some(discord_id) = self
                             .user_repository
-                            .fetch_discord_user_id(actor, notification_recipient.to_owned().into())
+                            .fetch_discord_user_id(actor, &notification_recipient.to_owned().into())
                             .await?
                         {
                             let settings = self

--- a/server/usecase/src/user.rs
+++ b/server/usecase/src/user.rs
@@ -1,10 +1,11 @@
-use crate::dto::UserDto;
 use domain::{
     repository::user_repository::UserRepository,
     user::models::{DiscordUserId, Role, User},
 };
 use errors::{usecase::UseCaseError, Error};
 use uuid::Uuid;
+
+use crate::dto::UserDto;
 
 pub struct UserUseCase<'a, UserRepo: UserRepository> {
     pub repository: &'a UserRepo,

--- a/server/usecase/src/user.rs
+++ b/server/usecase/src/user.rs
@@ -1,3 +1,4 @@
+use crate::dto::UserDto;
 use domain::{
     repository::user_repository::UserRepository,
     user::models::{DiscordUserId, Role, User},
@@ -117,6 +118,27 @@ impl<R: UserRepository> UserUseCase<'_, R> {
             .await
     }
 
+    pub async fn fetch_user_information(
+        &self,
+        actor: &User,
+        target_user_id: Uuid,
+    ) -> Result<UserDto, Error> {
+        let guard = self
+            .repository
+            .find_by(target_user_id)
+            .await?
+            .ok_or(Error::from(UseCaseError::UserNotFound))?;
+
+        let discord_user_id = self.repository.fetch_discord_user_id(actor, &guard).await?;
+
+        let user = guard.try_into_read(actor)?;
+
+        Ok(UserDto {
+            user,
+            discord_user_id,
+        })
+    }
+
     pub async fn fetch_discord_user(
         &self,
         actor: &User,
@@ -128,6 +150,6 @@ impl<R: UserRepository> UserUseCase<'_, R> {
             .await?
             .ok_or(Error::from(UseCaseError::UserNotFound))?;
 
-        self.repository.fetch_discord_user_id(actor, guard).await
+        self.repository.fetch_discord_user_id(actor, &guard).await
     }
 }


### PR DESCRIPTION
- Discord ID と、ユーザー情報を取得するエンドポイントが分離していたのを一つにまとめる
- 自身のユーザー情報しか確認できなかったのを、他の人の情報も取れるように