### PR TITLE
refactor: UUID を DB から取得するときに String を経由しない

### DIFF
--- a/server/infra/resource/src/database/forms/answer_label.rs
+++ b/server/infra/resource/src/database/forms/answer_label.rs
@@ -1,10 +1,7 @@
-use std::str::FromStr;
-
 use async_trait::async_trait;
 use domain::form::answer::models::{AnswerId, AnswerLabel, AnswerLabelId};
 use errors::infra::InfraError;
 use itertools::Itertools;
-use uuid::Uuid;
 
 use crate::{
     database::{
@@ -50,7 +47,7 @@ impl FormAnswerLabelDatabase for ConnectionPool {
                     .into_iter()
                     .map(|rs| {
                         Ok::<_, InfraError>(AnswerLabelDto {
-                            id: Uuid::from_str(&rs.try_get::<String>("", "id")?)?,
+                            id: rs.try_get("", "id")?,
                             name: rs.try_get("", "name")?,
                         })
                     })
@@ -81,7 +78,7 @@ impl FormAnswerLabelDatabase for ConnectionPool {
                     .into_iter()
                     .map(|rs| {
                         Ok::<_, InfraError>(AnswerLabelDto {
-                            id: Uuid::from_str(&rs.try_get::<String>("", "id")?)?,
+                            id: rs.try_get("", "id")?,
                             name: rs.try_get("", "name")?,
                         })
                     })
@@ -121,7 +118,7 @@ impl FormAnswerLabelDatabase for ConnectionPool {
                     .into_iter()
                     .map(|rs| {
                         Ok::<_, InfraError>(AnswerLabelDto {
-                            id: Uuid::from_str(&rs.try_get::<String>("", "id")?)?,
+                            id: rs.try_get("", "id")?,
                             name: rs.try_get("", "name")?,
                         })
                     })
@@ -154,7 +151,7 @@ impl FormAnswerLabelDatabase for ConnectionPool {
                     .into_iter()
                     .map(|rs| {
                         Ok::<_, InfraError>(AnswerLabelDto {
-                            id: Uuid::from_str(&rs.try_get::<String>("", "label_id")?)?,
+                            id: rs.try_get("", "label_id")?,
                             name: rs.try_get("", "name")?,
                         })
                     })

--- a/server/infra/resource/src/database/forms/answers.rs
+++ b/server/infra/resource/src/database/forms/answers.rs
@@ -108,11 +108,11 @@ impl FormAnswerDatabase for ConnectionPool {
                     .map(|rs| {
                         Ok::<_, InfraError>(FormAnswerDto {
                             id: answer_id.into_inner(),
-                            uuid: uuid::Uuid::from_str(&rs.try_get::<String>("", "user")?)?,
+                            uuid: rs.try_get("", "user")?,
                             user_name: rs.try_get("", "name")?,
                             user_role: Role::from_str(&rs.try_get::<String>("", "role")?)?,
                             timestamp: rs.try_get("", "time_stamp")?,
-                            form_id: Uuid::from_str(rs.try_get::<String>("", "form_id")?.as_str())?,
+                            form_id: rs.try_get("", "form_id")?,
                             title: rs.try_get("", "title")?,
                             contents
                         })
@@ -143,15 +143,15 @@ impl FormAnswerDatabase for ConnectionPool {
                 let form_answer_dtos = answers
                     .iter()
                     .map(|rs| {
-                        let answer_id = uuid::Uuid::from_str(&rs.try_get::<String>("", "answer_id")?)?;
+                        let answer_id = rs.try_get::<Uuid>("", "answer_id")?;
 
                         Ok::<_, InfraError>(FormAnswerDto {
                             id: answer_id,
-                            uuid: uuid::Uuid::from_str(&rs.try_get::<String>("", "user")?)?,
+                            uuid: rs.try_get("", "user")?,
                             user_name: rs.try_get("", "name")?,
                             user_role: Role::from_str(&rs.try_get::<String>("", "role")?)?,
                             timestamp: rs.try_get("", "time_stamp")?,
-                            form_id: Uuid::from_str(rs.try_get::<String>("", "form_id")?.as_str())?,
+                            form_id: rs.try_get("", "form_id")?,
                             title: rs.try_get("", "title")?,
                             contents: Vec::new()
                         })
@@ -173,7 +173,7 @@ impl FormAnswerDatabase for ConnectionPool {
                 let answer_id_with_content_dto = contents
                     .iter()
                     .map(|rs| {
-                        Ok::<_, InfraError>((Uuid::from_str(rs.try_get::<String>("", "answer_id")?.as_str())?, FormAnswerContentDto {
+                        Ok::<_, InfraError>((rs.try_get::<Uuid>("", "answer_id")?, FormAnswerContentDto {
                             question_id: rs.try_get("", "question_id")?,
                             answer: rs.try_get("", "answer")?,
                         }))
@@ -215,15 +215,15 @@ impl FormAnswerDatabase for ConnectionPool {
                 let form_answer_dtos = answers
                     .iter()
                     .map(|rs| {
-                        let answer_id = uuid::Uuid::from_str(&rs.try_get::<String>("", "answer_id")?)?;
+                        let answer_id = rs.try_get::<Uuid>("", "answer_id")?;
 
                         Ok::<_, InfraError>(FormAnswerDto {
                             id: answer_id,
-                            uuid: uuid::Uuid::from_str(&rs.try_get::<String>("", "user")?)?,
+                            uuid: rs.try_get("", "user")?,
                             user_name: rs.try_get("", "name")?,
                             user_role: Role::from_str(&rs.try_get::<String>("", "role")?)?,
                             timestamp: rs.try_get("", "time_stamp")?,
-                            form_id: Uuid::from_str(rs.try_get::<String>("", "form_id")?.as_str())?,
+                            form_id: rs.try_get("", "form_id")?,
                             title: rs.try_get("", "title")?,
                             contents: Vec::new()
                         })
@@ -244,7 +244,7 @@ impl FormAnswerDatabase for ConnectionPool {
                 let answer_id_with_content_dto = contents
                     .iter()
                     .map(|rs| {
-                        Ok::<_, InfraError>((Uuid::from_str(rs.try_get::<String>("", "answer_id")?.as_str())?, FormAnswerContentDto {
+                        Ok::<_, InfraError>((rs.try_get::<Uuid>("", "answer_id")?, FormAnswerContentDto {
                             question_id: rs.try_get("", "question_id")?,
                             answer: rs.try_get("", "answer")?,
                         }))

--- a/server/infra/resource/src/database/forms/form.rs
+++ b/server/infra/resource/src/database/forms/form.rs
@@ -1,5 +1,3 @@
-use std::str::FromStr;
-
 use async_trait::async_trait;
 use domain::{
     form::models::{Form, FormId},
@@ -8,7 +6,6 @@ use domain::{
 use errors::infra::InfraError;
 use futures::future::try_join;
 use types::non_empty_string::NonEmptyString;
-use uuid::Uuid;
 
 use crate::{
     database::{
@@ -97,7 +94,7 @@ impl FormDatabase for ConnectionPool {
                     .into_iter()
                     .map(|query_rs| {
                         Ok::<_, InfraError>(FormDto {
-                            id: Uuid::from_str(query_rs.try_get::<String>("", "form_id")?.as_str())?,
+                            id: query_rs.try_get("", "form_id")?,
                             title: query_rs.try_get("", "form_title")?,
                             description: query_rs.try_get("", "description")?,
                             metadata: (

--- a/server/infra/resource/src/database/forms/form_label.rs
+++ b/server/infra/resource/src/database/forms/form_label.rs
@@ -1,10 +1,7 @@
-use std::str::FromStr;
-
 use async_trait::async_trait;
 use domain::form::models::{FormId, FormLabel, FormLabelId, FormLabelName};
 use errors::infra::InfraError;
 use itertools::Itertools;
-use uuid::Uuid;
 
 use crate::{
     database::{
@@ -52,7 +49,7 @@ impl FormLabelDatabase for ConnectionPool {
                     .into_iter()
                     .map(|rs| {
                         Ok::<_, InfraError>(FormLabelDto {
-                            id: Uuid::from_str(rs.try_get::<String>("", "id")?.as_str())?,
+                            id: rs.try_get("", "id")?,
                             name: rs.try_get("", "name")?,
                         })
                     })
@@ -91,7 +88,7 @@ impl FormLabelDatabase for ConnectionPool {
                     .into_iter()
                     .map(|rs| {
                         Ok::<_, InfraError>(FormLabelDto {
-                            id: Uuid::from_str(rs.try_get::<String>("", "id")?.as_str())?,
+                            id: rs.try_get("", "id")?,
                             name: rs.try_get("", "name")?,
                         })
                     })
@@ -134,7 +131,7 @@ impl FormLabelDatabase for ConnectionPool {
                 label_rs
                     .map(|rs| {
                         Ok::<_, InfraError>(FormLabelDto {
-                            id: Uuid::from_str(&rs.try_get::<String>("", "id")?)?,
+                            id: rs.try_get("", "id")?,
                             name: rs.try_get("", "name")?,
                         })
                     })
@@ -186,7 +183,7 @@ impl FormLabelDatabase for ConnectionPool {
                     .into_iter()
                     .map(|rs| {
                         Ok::<_, InfraError>(FormLabelDto {
-                            id: Uuid::from_str(&rs.try_get::<String>("", "id")?)?,
+                            id: rs.try_get("", "id")?,
                             name: rs.try_get("", "name")?,
                         })
                     })

--- a/server/infra/resource/src/database/forms/message.rs
+++ b/server/infra/resource/src/database/forms/message.rs
@@ -11,6 +11,7 @@ use domain::{
 };
 use errors::infra::InfraError;
 use itertools::Itertools;
+use uuid::Uuid;
 
 use crate::{
     database::{
@@ -94,13 +95,13 @@ impl FormMessageDatabase for ConnectionPool {
                             .map(|rs| {
                                 let user = Ok::<_, InfraError>(UserDto {
                                     name: rs.try_get("", "name")?,
-                                    id: uuid::Uuid::from_str(&rs.try_get::<String>("", "sender")?)?,
+                                    id: rs.try_get("", "sender")?,
                                     role: Role::from_str(&rs.try_get::<String>("", "role")?)?,
                                 });
 
                                 Ok::<_, InfraError>((
                                     user?,
-                                    uuid::Uuid::from_str(&rs.try_get::<String>("", "message_id")?)?,
+                                    rs.try_get::<Uuid>("", "message_id")?,
                                     rs.try_get::<String>("", "body")?,
                                     rs.try_get::<DateTime<Utc>>("", "timestamp")?,
                                 ))
@@ -144,7 +145,7 @@ impl FormMessageDatabase for ConnectionPool {
                 rs.map(|rs| {
                     let user = Ok::<_, InfraError>(UserDto {
                         name: rs.try_get("", "name")?,
-                        id: uuid::Uuid::from_str(&rs.try_get::<String>("", "sender")?)?,
+                        id: rs.try_get("", "sender")?,
                         role: Role::from_str(&rs.try_get::<String>("", "role")?)?,
                     })?;
 

--- a/server/infra/resource/src/database/forms/question.rs
+++ b/server/infra/resource/src/database/forms/question.rs
@@ -1,11 +1,8 @@
-use std::str::FromStr;
-
 use async_trait::async_trait;
 use domain::form::{models::FormId, question::models::Question};
 use errors::infra::InfraError;
 use itertools::Itertools;
 use sea_orm::DbErr;
-use uuid::Uuid;
 
 use crate::{
     database::{
@@ -216,7 +213,7 @@ impl FormQuestionDatabase for ConnectionPool {
 
                         Ok::<_, InfraError>(QuestionDto {
                             id: Some(question_id),
-                            form_id: Uuid::from_str(question_rs.try_get::<String>("", "form_id")?.as_str())?,
+                            form_id: question_rs.try_get("", "form_id")?,
                             title: question_rs.try_get("", "title")?,
                             description: question_rs.try_get("", "description")?,
                             question_type: question_rs.try_get("", "question_type")?,


### PR DESCRIPTION
今までは String から変換しないとランタイムエラーが発生していたが、sea-orm 側に修正 PR を投げてマージされたので修正された