### PR TITLE
chore: Renovate が Cargo.toml のバージョンを直接更新するよう rangeStrategy を bump に変更

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,7 @@
       "matchManagers": [
         "cargo"
       ],
-      "rangeStrategy": "pin"
+      "rangeStrategy": "bump"
     }
   ]
 }


### PR DESCRIPTION
pin では Cargo.lock のみが更新されていたが、bump に変更することで
Cargo.toml のバージョン指定も最新バージョンに追従するようにする。