### PR TITLE
fix: graceful shutdown 時のデバッグ用 panic を削除

### DIFF
--- a/server/entrypoint/src/main.rs
+++ b/server/entrypoint/src/main.rs
@@ -317,7 +317,6 @@ async fn graceful_handler(
             serenity_shared_manager.shutdown_all().await;
             messaging_connection.shutdown().await;
             search_engine_syncer_shutdown_notifier.notify_waiters();
-            panic!("bug tracking test")
         },
         _ = terminate => {},
     }


### PR DESCRIPTION
## Summary

- `graceful_handler` 内に残っていたデバッグ用の `panic!("bug tracking test")` を削除
- Ctrl+C や SIGTERM によるグレースフルシャットダウンが正常に完了するよう修正

## Test plan

- [ ] サーバーを起動し Ctrl+C でシャットダウンして panic しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)