### PR TITLE
fix: Ubuntu 24.04 の既存 ubuntu ユーザーを利用するよう Dockerfile を修正

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,11 +18,6 @@ LABEL org.opencontainers.image.source=https://github.com/GiganticMinecraft/seich
 
 COPY --from=init /seichi-portal-backend /seichi-portal-backend
 
-ARG USERNAME=ubuntu
-ARG GROUPNAME=ubuntu
-ARG UID=1000
-ARG GID=1000
-RUN groupadd -g $GID $GROUPNAME && \
-    useradd -m -s /bin/bash -u $UID -g $GID $USERNAME
+USER ubuntu
 
 ENTRYPOINT ["/seichi-portal-backend"]


### PR DESCRIPTION
## Summary

- Ubuntu 24.04 のベースイメージには `ubuntu` ユーザー/グループ (UID/GID=1000) がデフォルトで存在する
- そのため `groupadd -g 1000 ubuntu` が exit code 9 で失敗し、CI の Docker イメージビルドが壊れていた
- 不要な `ARG`/`RUN` ブロックを削除し、`USER ubuntu` に置き換えることで修正

## Test plan

- [ ] CI の "push docker image for all platforms" が成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)