### PR TITLE
refactor: debug_user 認証を廃止し Redis シードによる認証に置き換える

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,3 +17,10 @@ cd server/ && cargo build
 ```bash
 cd server/ && makers pretty
 ```
+
+## ローカル開発時の認証
+
+`docker compose up` で Redis にデバッグ用セッションデータが自動投入される。API リクエスト時は以下のセッション ID を `Authorization` ヘッダーに指定する:
+
+- `Bearer debug_session` — ADMINISTRATOR ロール
+- `Bearer debug_session_standard` — STANDARD_USER ロール

--- a/compose.yaml
+++ b/compose.yaml
@@ -27,6 +27,17 @@ services:
     networks:
       - seichi_portal
     restart: always
+  redis-seed:
+    image: redis/redis-stack:7.4.0-v3
+    container_name: redis-seed
+    depends_on:
+      - redis
+    volumes:
+      - ./docker/redis/seed.sh:/seed.sh
+    entrypoint: ["sh", "/seed.sh"]
+    networks:
+      - seichi_portal
+    restart: "no"
   meilisearch:
     # NOTE: meilisearch の公式 Docker イメージをそのまま使用すると、全文検索時に日本語の漢字と中国語の漢字が衝突するために検索できない場合があるため、
     # 中国語のトークン化が無効化された日本語用の Docker イメージを使用する

--- a/docker/redis/seed.sh
+++ b/docker/redis/seed.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -eu
+
+echo "Seeding Redis with debug session data..."
+
+# ADMINISTRATOR ロールのデバッグ用セッション
+redis-cli -h redis -p 6379 JSON.SET "debug_session" "$" '{"name":"test_user","id":"478911be-3356-46c1-936e-fb14b71bf282","role":"ADMINISTRATOR"}'
+
+# STANDARD_USER ロールのデバッグ用セッション
+redis-cli -h redis -p 6379 JSON.SET "debug_session_standard" "$" '{"name":"test_standard_user","id":"5cb955fb-5a05-4729-93ea-edException001","role":"STANDARD_USER"}'
+
+echo "Redis seed data has been loaded."

--- a/schemathesis.toml
+++ b/schemathesis.toml
@@ -1,4 +1,4 @@
-headers = { Authorization = "Bearer debug_user" }
+headers = { Authorization = "Bearer debug_session" }
 continue-on-failure = true
 
 [[operations]]

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -5863,7 +5863,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "hashbrown 0.15.2",
  "indexmap",
  "semver",
@@ -6411,7 +6411,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.10.0",
+ "bitflags",
  "indexmap",
  "log",
  "serde",

--- a/server/infra/resource/src/repository/user_repository_impl.rs
+++ b/server/infra/resource/src/repository/user_repository_impl.rs
@@ -1,17 +1,16 @@
 use async_trait::async_trait;
-use common::config::ENV;
 use domain::{
     repository::user_repository::UserRepository,
     types::{
         authorization_guard::AuthorizationGuard,
         authorization_guard_with_context::{Create, Read, Update},
     },
-    user::models::{DiscordUser, DiscordUserId, DiscordUserName, Role::Administrator, User},
+    user::models::{DiscordUser, DiscordUserId, DiscordUserName, User},
 };
 use errors::{Error, infra::InfraError::Reqwest};
 use itertools::Itertools;
 use reqwest::header::{ACCEPT, CONTENT_TYPE, HeaderValue};
-use uuid::{Uuid, uuid};
+use uuid::Uuid;
 
 use crate::{
     database::components::{DatabaseComponents, UserDatabase},
@@ -50,37 +49,29 @@ impl<Client: DatabaseComponents + 'static> UserRepository for Repository<Client>
     }
 
     async fn fetch_user_by_xbox_token(&self, token: String) -> Result<Option<User>, Error> {
-        Ok(if ENV.name == "local" && token == "debug_user" {
-            Some(User {
-                name: "test_user".to_string(),
-                id: uuid!("478911be-3356-46c1-936e-fb14b71bf282"),
-                role: Administrator,
-            })
-        } else {
-            let client = reqwest::Client::new();
+        let client = reqwest::Client::new();
 
-            let response = client
-                .get("https://api.minecraftservices.com/minecraft/profile")
-                .bearer_auth(token.to_owned())
-                .header(CONTENT_TYPE, HeaderValue::from_static("application/json"))
-                .header(ACCEPT, HeaderValue::from_static("application/json"))
-                .send()
+        let response = client
+            .get("https://api.minecraftservices.com/minecraft/profile")
+            .bearer_auth(token.to_owned())
+            .header(CONTENT_TYPE, HeaderValue::from_static("application/json"))
+            .header(ACCEPT, HeaderValue::from_static("application/json"))
+            .send()
+            .await
+            .map_err(|err| Reqwest {
+                cause: err.to_string(),
+            })?;
+
+        Ok(serde_json::from_str::<User>(
+            response
+                .text()
                 .await
                 .map_err(|err| Reqwest {
                     cause: err.to_string(),
-                })?;
-
-            serde_json::from_str::<User>(
-                response
-                    .text()
-                    .await
-                    .map_err(|err| Reqwest {
-                        cause: err.to_string(),
-                    })?
-                    .as_str(),
-            )
-            .ok()
-        })
+                })?
+                .as_str(),
+        )
+        .ok())
     }
 
     async fn fetch_all_users(&self) -> Result<Vec<AuthorizationGuard<User, Read>>, Error> {

--- a/server/presentation/src/auth.rs
+++ b/server/presentation/src/auth.rs
@@ -11,15 +11,10 @@ use axum_extra::{
     extract::TypedHeader,
     headers::{Authorization, authorization::Bearer},
 };
-use common::config::ENV;
-use domain::{
-    repository::Repositories,
-    user::models::{Role::Administrator, User},
-};
+use domain::repository::Repositories;
 use resource::repository::RealInfrastructureRepository;
 use serde_json::json;
 use usecase::user::UserUseCase;
-use uuid::uuid;
 
 pub async fn auth(
     State(repository): State<RealInfrastructureRepository>,
@@ -60,45 +55,37 @@ pub async fn auth(
 
     let session_id = auth.token();
 
-    let user = if ENV.name == "local" && session_id == "debug_user" {
-        User {
-            name: "debug_user".to_string(),
-            id: uuid!("478911be-3356-46c1-936e-fb14b71bf282"),
-            role: Administrator,
-        }
-    } else {
-        match user_use_case
-            .fetch_user_by_session_id(session_id.to_string())
-            .await
-            .map_err(|_| {
-                (
-                    StatusCode::UNAUTHORIZED,
-                    [(header::CONTENT_TYPE, "application/problem+json")],
-                    Json(json!({
-                        "type": "about:blank",
-                        "title": "Unauthorized",
-                        "status": 401,
-                        "detail": "Failed to retrieve user by session id.",
-                        "errorCode": "UNAUTHORIZED"
-                    })),
-                )
-                    .into_response()
-            })? {
-            Some(user) => user,
-            None => {
-                return Err((
-                    StatusCode::UNAUTHORIZED,
-                    [(header::CONTENT_TYPE, "application/problem+json")],
-                    Json(json!({
-                        "type": "about:blank",
-                        "title": "Unauthorized",
-                        "status": 401,
-                        "detail": "Invalid session id.",
-                        "errorCode": "UNAUTHORIZED"
-                    })),
-                )
-                    .into_response());
-            }
+    let user = match user_use_case
+        .fetch_user_by_session_id(session_id.to_string())
+        .await
+        .map_err(|_| {
+            (
+                StatusCode::UNAUTHORIZED,
+                [(header::CONTENT_TYPE, "application/problem+json")],
+                Json(json!({
+                    "type": "about:blank",
+                    "title": "Unauthorized",
+                    "status": 401,
+                    "detail": "Failed to retrieve user by session id.",
+                    "errorCode": "UNAUTHORIZED"
+                })),
+            )
+                .into_response()
+        })? {
+        Some(user) => user,
+        None => {
+            return Err((
+                StatusCode::UNAUTHORIZED,
+                [(header::CONTENT_TYPE, "application/problem+json")],
+                Json(json!({
+                    "type": "about:blank",
+                    "title": "Unauthorized",
+                    "status": 401,
+                    "detail": "Invalid session id.",
+                    "errorCode": "UNAUTHORIZED"
+                })),
+            )
+                .into_response());
         }
     };
 


### PR DESCRIPTION
## Summary

- ローカル開発環境での認証バイパス用 `debug_user` ハードコードを削除し、Redis にセッションデータをシードする方式に変更
- `docker compose up` 時に `redis-seed` サービスが自動的に既知のセッション ID を Redis に投入するため、通常の認証パスをそのまま通るようになる

## 変更内容

- `docker/redis/seed.sh` を新規追加 — `debug_session` (ADMINISTRATOR) と `debug_session_standard` (STANDARD_USER) のセッションを投入
- `compose.yaml` — `redis-seed` サービスを追加（`redis` 起動後にシードスクリプトを実行）
- `server/presentation/src/auth.rs` — `debug_user` 分岐を削除し、常に `fetch_user_by_session_id` を通るように変更
- `server/infra/resource/src/repository/user_repository_impl.rs` — `fetch_user_by_xbox_token` 内の `debug_user` 分岐を削除
- `schemathesis.toml` — Authorization ヘッダーを `Bearer debug_session` に更新
- `CLAUDE.md` — ローカル開発時の認証方法を追記

## ローカル開発時の認証

| セッション ID | ロール |
|---|---|
| `Bearer debug_session` | ADMINISTRATOR |
| `Bearer debug_session_standard` | STANDARD_USER |

## Test plan

- [ ] `docker compose up` で Redis シードが投入されることを確認
- [ ] `redis-cli JSON.GET debug_session` でデータが存在することを確認
- [ ] `cd server/ && cargo build` でコンパイルが通ることを確認
- [ ] `cd server/ && makers pretty` で lint/format が通ることを確認
- [ ] `curl -H "Authorization: Bearer debug_session" http://localhost:8080/...` で認証が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)