### PR TITLE
feat: Redis を Valkey に乗り換える

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ cd server/ && makers pretty
 
 ## ローカル開発時の認証
 
-`docker compose up` で Redis にデバッグ用セッションデータが自動投入される。API リクエスト時は以下のセッション ID を `Authorization` ヘッダーに指定する:
+`docker compose up` で Valkey にデバッグ用セッションデータが自動投入される。API リクエスト時は以下のセッション ID を `Authorization` ヘッダーに指定する:
 
 - `Bearer debug_session` — ADMINISTRATOR ロール
 - `Bearer debug_session_standard` — STANDARD_USER ロール

--- a/compose.yaml
+++ b/compose.yaml
@@ -19,21 +19,21 @@ services:
       - ./docker/mariadb/my.cnf:/etc/mysql/conf.d/my.cnf
       - ./docker/create-debezium-user.sql:/docker-entrypoint-initdb.d/create-debezium-user.sql
     restart: always
-  redis:
-    image: redis/redis-stack:7.4.0-v3
-    container_name: redis
+  valkey:
+    image: valkey/valkey:8-alpine
+    container_name: valkey
     ports:
       - "6379:6379"
     networks:
       - seichi_portal
     restart: always
-  redis-seed:
-    image: redis/redis-stack:7.4.0-v3
-    container_name: redis-seed
+  valkey-seed:
+    image: valkey/valkey:8-alpine
+    container_name: valkey-seed
     depends_on:
-      - redis
+      - valkey
     volumes:
-      - ./docker/redis/seed.sh:/seed.sh
+      - ./docker/valkey/seed.sh:/seed.sh
     entrypoint: ["sh", "/seed.sh"]
     networks:
       - seichi_portal

--- a/docker/valkey/seed.sh
+++ b/docker/valkey/seed.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -eu
+
+echo "Seeding Valkey with debug session data..."
+
+# ADMINISTRATOR ロールのデバッグ用セッション
+valkey-cli -h valkey -p 6379 SET "debug_session" '{"name":"test_user","id":"478911be-3356-46c1-936e-fb14b71bf282","role":"ADMINISTRATOR"}'
+
+# STANDARD_USER ロールのデバッグ用セッション
+valkey-cli -h valkey -p 6379 SET "debug_session_standard" '{"name":"test_standard_user","id":"5cb955fb-5a05-4729-93ea-edException001","role":"STANDARD_USER"}'
+
+echo "Valkey seed data has been loaded."

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -3456,8 +3456,6 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "ryu",
- "serde",
- "serde_json",
  "sha1_smol",
  "socket2 0.6.1",
  "tokio",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -41,7 +41,7 @@ uuid = { version = "1.22.0", features = ["v4", "v7"] }
 deriving_via = "2.2.0"
 reqwest = { version = "0.13.2", default-features = false, features = ["rustls", "json"] }
 regex = "1.12.3"
-redis = { version = "1.0.4", features = ["tokio-comp", "json"] }
+redis = { version = "1.0.4", features = ["tokio-comp"] }
 meilisearch-sdk = "0.32.0"
 serenity = "0.12.5"
 lapin = "4.1.1"

--- a/server/infra/resource/src/database/connection.rs
+++ b/server/infra/resource/src/database/connection.rs
@@ -313,5 +313,5 @@ pub async fn redis_connection() -> Client {
 
     let client_result = Client::open(redis_url);
 
-    client_result.unwrap_or_else(|_| panic!("Cannot connect to Redis."))
+    client_result.unwrap_or_else(|_| panic!("Cannot connect to Valkey."))
 }

--- a/server/infra/resource/src/database/user.rs
+++ b/server/infra/resource/src/database/user.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use chrono::Utc;
 use domain::user::models::{DiscordUser, Role, User};
 use errors::infra::InfraError;
-use redis::{Commands, JsonCommands};
+use redis::Commands;
 use sha256::digest;
 use uuid::Uuid;
 
@@ -124,9 +124,9 @@ impl UserDatabase for ConnectionPool {
 
         let mut redis_connection = redis_connection().await;
 
-        redis_connection.json_set::<&str, &str, _, ()>(&session_id, "$", user)?;
+        let user_json = serde_json::to_string(user)?;
+        redis_connection.set_ex::<&str, String, ()>(&session_id, user_json, expires as u64)?;
 
-        redis_connection.expire::<&str, ()>(&session_id, expires as i64)?;
         Ok(session_id)
     }
 
@@ -136,12 +136,8 @@ impl UserDatabase for ConnectionPool {
     ) -> Result<Option<User>, InfraError> {
         let mut redis_connection = redis_connection().await;
 
-        let user = serde_json::from_str::<Vec<User>>(
-            &redis_connection.json_get::<&String, &str, String>(&session_id, "$")?,
-        )
-        .map(|users| users.into_iter().nth(0))
-        .ok()
-        .flatten();
+        let result: Option<String> = redis_connection.get(&session_id)?;
+        let user = result.and_then(|s| serde_json::from_str::<User>(&s).ok());
 
         Ok(user)
     }


### PR DESCRIPTION
## Summary

- `compose.yaml` の Redis イメージ (`redis/redis-stack:7.4.0-v3`) を Valkey (`valkey/valkey:8-alpine`) に変更
- `docker/valkey/seed.sh` を追加し、`valkey-cli` + `SET` コマンドでデバッグ用セッションデータを投入するように変更
- セッション保存に使用していた `JSON.SET`/`JSON.GET` (RedisJSON モジュール依存) を、`serde_json` + 通常の `SET`/`GET` に置き換え。これにより JSON モジュールなしの vanilla Valkey イメージが使用可能
- `redis` クレートの `json` feature を削除

## Test plan

- [ ] `docker compose up` が正常に起動する
- [ ] `Bearer debug_session` (ADMINISTRATOR) / `Bearer debug_session_standard` (STANDARD_USER) でのセッション認証が動作する
- [ ] ログイン → セッション作成 → セッション取得 → ログアウトの一連のフローが動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)