### PR TITLE
fix: utoipa のエラーレスポンスの content-type を application/problem+json に修正する

### DIFF
--- a/server/presentation/src/schemas/error_responses.rs
+++ b/server/presentation/src/schemas/error_responses.rs
@@ -4,20 +4,29 @@ use super::error_response::ErrorResponse;
 pub enum BadRequest {
     #[response(
         status = 400,
-        description = "The server could not understand the request due to invalid syntax."
+        description = "The server could not understand the request due to invalid syntax.",
+        content_type = "application/problem+json"
     )]
     BadRequest(ErrorResponse),
 }
 
 #[derive(utoipa::IntoResponses)]
 pub enum Unauthorized {
-    #[response(status = 401, description = "Access is unauthorized.")]
+    #[response(
+        status = 401,
+        description = "Access is unauthorized.",
+        content_type = "application/problem+json"
+    )]
     Unauthorized(ErrorResponse),
 }
 
 #[derive(utoipa::IntoResponses)]
 pub enum Forbidden {
-    #[response(status = 403, description = "Access is forbidden.")]
+    #[response(
+        status = 403,
+        description = "Access is forbidden.",
+        content_type = "application/problem+json"
+    )]
     Forbidden(ErrorResponse),
 }
 
@@ -25,19 +34,28 @@ pub enum Forbidden {
 pub enum NotFound {
     #[response(
         status = 404,
-        description = "The server cannot find the requested resource."
+        description = "The server cannot find the requested resource.",
+        content_type = "application/problem+json"
     )]
     NotFound(ErrorResponse),
 }
 
 #[derive(utoipa::IntoResponses)]
 pub enum UnprocessableEntity {
-    #[response(status = 422, description = "Client error")]
+    #[response(
+        status = 422,
+        description = "Client error",
+        content_type = "application/problem+json"
+    )]
     UnprocessableEntity(ErrorResponse),
 }
 
 #[derive(utoipa::IntoResponses)]
 pub enum InternalServerError {
-    #[response(status = 500, description = "Server error")]
+    #[response(
+        status = 500,
+        description = "Server error",
+        content_type = "application/problem+json"
+    )]
     InternalServerError(ErrorResponse),
 }


### PR DESCRIPTION
## Summary

- utoipa が生成する OpenAPI スペックのエラーレスポンス（400/401/403/404/422/500）の content-type が、デフォルトの `application/json` になっていた
- 実際のレスポンス実装（`error_handler.rs`）では `application/problem+json` を正しく設定しているため、スペックと実装が乖離していた
- `error_responses.rs` の各 `#[response]` アトリビュートに `content_type = "application/problem+json"` を追加して修正した

## Test plan

- [ ] `cargo build` が通ることを確認
- [ ] 生成される OpenAPI スペックのエラーレスポンスの content-type が `application/problem+json` になっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)