### PR TITLE
refactor: user/question/label ハンドラに IntoResponses パターンを適用し OpenAPI との乖離を解消する

### DIFF
--- a/server/entrypoint/src/main.rs
+++ b/server/entrypoint/src/main.rs
@@ -47,7 +47,15 @@ use utoipa_swagger_ui::SwaggerUi;
         presentation::handlers::form::message_handler::post_message_handler,
     ),
     info(title = "Seichi Portal API", version = "1.0.0"),
-    components(schemas(presentation::schemas::error_response::ErrorResponse)),
+    components(schemas(
+        presentation::schemas::error_response::ErrorResponse,
+        presentation::schemas::user::UserInfoResponse,
+        presentation::schemas::user::UserSchema,
+        presentation::schemas::form::form_response_schemas::AnswerLabelResponseSchema,
+        presentation::schemas::form::form_response_schemas::FormLabelResponseSchema,
+        presentation::schemas::form::form_response_schemas::QuestionResponseSchema,
+        presentation::schemas::form::form_response_schemas::PutQuestionsResponseSchema,
+    )),
     modifiers(&SecurityAddon),
     tags(
         (name = "Forms"),

--- a/server/presentation/src/handlers/form/answer_label_handler.rs
+++ b/server/presentation/src/handlers/form/answer_label_handler.rs
@@ -17,10 +17,64 @@ use usecase::forms::answer_label::AnswerLabelUseCase;
 
 use crate::schemas::error_responses::*;
 use crate::schemas::form::form_request_schemas::AnswerLabelSchema;
+use crate::schemas::form::form_response_schemas::AnswerLabelResponseSchema;
 use crate::{
     handlers::error_handler::handle_error,
     schemas::form::form_request_schemas::{AnswerLabelUpdateSchema, ReplaceAnswerLabelSchema},
 };
+
+#[derive(utoipa::IntoResponses)]
+pub enum CreateAnswerLabelResponse {
+    #[response(
+        status = 201,
+        description = "The request has succeeded and a new resource has been created as a result."
+    )]
+    Created(AnswerLabelResponseSchema),
+}
+
+impl IntoResponse for CreateAnswerLabelResponse {
+    fn into_response(self) -> Response {
+        match self {
+            Self::Created(body) => (
+                StatusCode::CREATED,
+                [(
+                    header::LOCATION,
+                    HeaderValue::from_str(body.id.as_str()).unwrap(),
+                )],
+                Json(body),
+            )
+                .into_response(),
+        }
+    }
+}
+
+#[derive(utoipa::IntoResponses)]
+pub enum GetAnswerLabelsResponse {
+    #[response(status = 200, description = "The request has succeeded.")]
+    Ok(Vec<AnswerLabelResponseSchema>),
+}
+
+impl IntoResponse for GetAnswerLabelsResponse {
+    fn into_response(self) -> Response {
+        match self {
+            Self::Ok(body) => (StatusCode::OK, Json(body)).into_response(),
+        }
+    }
+}
+
+#[derive(utoipa::IntoResponses)]
+pub enum EditAnswerLabelResponse {
+    #[response(status = 200, description = "The request has succeeded.")]
+    Ok(AnswerLabelResponseSchema),
+}
+
+impl IntoResponse for EditAnswerLabelResponse {
+    fn into_response(self) -> Response {
+        match self {
+            Self::Ok(body) => (StatusCode::OK, Json(body)).into_response(),
+        }
+    }
+}
 
 #[utoipa::path(
     post,
@@ -28,7 +82,7 @@ use crate::{
     summary = "回答用ラベルを作成する",
     request_body = AnswerLabelSchema,
     responses(
-        (status = 201, description = "The request has succeeded and a new resource has been created as a result."),
+        CreateAnswerLabelResponse,
         BadRequest,
         Unauthorized,
         Forbidden,
@@ -42,7 +96,7 @@ pub async fn create_label_for_answers(
     Extension(user): Extension<User>,
     State(repository): State<RealInfrastructureRepository>,
     json: Result<Json<AnswerLabelSchema>, JsonRejection>,
-) -> Result<impl IntoResponse, Response> {
+) -> Result<CreateAnswerLabelResponse, Response> {
     let answer_label_use_case = AnswerLabelUseCase {
         answer_label_repository: repository.answer_label_repository(),
     };
@@ -54,15 +108,7 @@ pub async fn create_label_for_answers(
         .await
         .map_err(handle_error)?;
 
-    Ok((
-        StatusCode::CREATED,
-        [(
-            header::LOCATION,
-            HeaderValue::from_str(label.id().to_owned().into_inner().to_string().as_str()).unwrap(),
-        )],
-        Json(label),
-    )
-        .into_response())
+    Ok(CreateAnswerLabelResponse::Created(label.into()))
 }
 
 #[utoipa::path(
@@ -70,7 +116,7 @@ pub async fn create_label_for_answers(
     path = "/labels/answers",
     summary = "回答用ラベルの一覧を取得する",
     responses(
-        (status = 200, description = "The request has succeeded."),
+        GetAnswerLabelsResponse,
         BadRequest,
         Unauthorized,
         Forbidden,
@@ -82,7 +128,7 @@ pub async fn create_label_for_answers(
 pub async fn get_labels_for_answers(
     Extension(user): Extension<User>,
     State(repository): State<RealInfrastructureRepository>,
-) -> Result<impl IntoResponse, Response> {
+) -> Result<GetAnswerLabelsResponse, Response> {
     let answer_label_use_case = AnswerLabelUseCase {
         answer_label_repository: repository.answer_label_repository(),
     };
@@ -91,7 +137,9 @@ pub async fn get_labels_for_answers(
         .get_labels_for_answers(&user)
         .await
         .map_err(handle_error)?;
-    Ok((StatusCode::OK, Json(labels)).into_response())
+    Ok(GetAnswerLabelsResponse::Ok(
+        labels.into_iter().map(Into::into).collect(),
+    ))
 }
 
 #[utoipa::path(
@@ -140,7 +188,7 @@ pub async fn delete_label_for_answers(
     ),
     request_body = AnswerLabelUpdateSchema,
     responses(
-        (status = 200, description = "The request has succeeded."),
+        EditAnswerLabelResponse,
         BadRequest,
         Unauthorized,
         Forbidden,
@@ -156,7 +204,7 @@ pub async fn edit_label_for_answers(
     State(repository): State<RealInfrastructureRepository>,
     path: Result<Path<AnswerLabelId>, PathRejection>,
     json: Result<Json<AnswerLabelUpdateSchema>, JsonRejection>,
-) -> Result<impl IntoResponse, Response> {
+) -> Result<EditAnswerLabelResponse, Response> {
     let answer_label_use_case = AnswerLabelUseCase {
         answer_label_repository: repository.answer_label_repository(),
     };
@@ -169,7 +217,7 @@ pub async fn edit_label_for_answers(
         .await
         .map_err(handle_error)?;
 
-    Ok((StatusCode::OK, Json(updated_label)).into_response())
+    Ok(EditAnswerLabelResponse::Ok(updated_label.into()))
 }
 
 #[utoipa::path(

--- a/server/presentation/src/handlers/form/form_label_handler.rs
+++ b/server/presentation/src/handlers/form/form_label_handler.rs
@@ -18,10 +18,50 @@ use usecase::forms::form_label::FormLabelUseCase;
 
 use crate::schemas::error_responses::*;
 use crate::schemas::form::form_request_schemas::FormLabelCreateSchema;
+use crate::schemas::form::form_response_schemas::FormLabelResponseSchema;
 use crate::{
     handlers::error_handler::handle_error,
     schemas::form::form_request_schemas::{FormLabelUpdateSchema, ReplaceFormLabelSchema},
 };
+
+#[derive(utoipa::IntoResponses)]
+pub enum CreateFormLabelResponse {
+    #[response(
+        status = 201,
+        description = "The request has succeeded and a new resource has been created as a result."
+    )]
+    Created(FormLabelResponseSchema),
+}
+
+impl IntoResponse for CreateFormLabelResponse {
+    fn into_response(self) -> Response {
+        match self {
+            Self::Created(body) => (
+                StatusCode::CREATED,
+                [(
+                    header::LOCATION,
+                    HeaderValue::from_str(body.id.as_str()).unwrap(),
+                )],
+                Json(body),
+            )
+                .into_response(),
+        }
+    }
+}
+
+#[derive(utoipa::IntoResponses)]
+pub enum GetFormLabelsResponse {
+    #[response(status = 200, description = "The request has succeeded.")]
+    Ok(Vec<FormLabelResponseSchema>),
+}
+
+impl IntoResponse for GetFormLabelsResponse {
+    fn into_response(self) -> Response {
+        match self {
+            Self::Ok(body) => (StatusCode::OK, Json(body)).into_response(),
+        }
+    }
+}
 
 #[utoipa::path(
     post,
@@ -29,7 +69,7 @@ use crate::{
     summary = "フォーム用ラベルを作成する",
     request_body = FormLabelCreateSchema,
     responses(
-        (status = 201, description = "The request has succeeded and a new resource has been created as a result."),
+        CreateFormLabelResponse,
         BadRequest,
         Unauthorized,
         Forbidden,
@@ -43,7 +83,7 @@ pub async fn create_label_for_forms(
     Extension(user): Extension<User>,
     State(repository): State<RealInfrastructureRepository>,
     json: Result<Json<FormLabelCreateSchema>, JsonRejection>,
-) -> Result<impl IntoResponse, Response> {
+) -> Result<CreateFormLabelResponse, Response> {
     let form_label_use_case = FormLabelUseCase {
         form_label_repository: repository.form_label_repository(),
     };
@@ -55,23 +95,7 @@ pub async fn create_label_for_forms(
         .await
         .map_err(handle_error)?;
 
-    Ok((
-        StatusCode::CREATED,
-        [(
-            header::LOCATION,
-            HeaderValue::from_str(
-                created_label
-                    .id()
-                    .to_owned()
-                    .into_inner()
-                    .to_string()
-                    .as_str(),
-            )
-            .unwrap(),
-        )],
-        Json(created_label),
-    )
-        .into_response())
+    Ok(CreateFormLabelResponse::Created(created_label.into()))
 }
 
 #[utoipa::path(
@@ -79,7 +103,7 @@ pub async fn create_label_for_forms(
     path = "/labels/forms",
     summary = "フォーム用ラベルの一覧を取得する",
     responses(
-        (status = 200, description = "The request has succeeded."),
+        GetFormLabelsResponse,
         BadRequest,
         Unauthorized,
         Forbidden,
@@ -91,7 +115,7 @@ pub async fn create_label_for_forms(
 pub async fn get_labels_for_forms(
     Extension(user): Extension<User>,
     State(repository): State<RealInfrastructureRepository>,
-) -> Result<impl IntoResponse, Response> {
+) -> Result<GetFormLabelsResponse, Response> {
     let form_label_use_case = FormLabelUseCase {
         form_label_repository: repository.form_label_repository(),
     };
@@ -100,7 +124,9 @@ pub async fn get_labels_for_forms(
         .get_labels_for_forms(&user)
         .await
         .map_err(handle_error)?;
-    Ok((StatusCode::OK, Json(labels)).into_response())
+    Ok(GetFormLabelsResponse::Ok(
+        labels.into_iter().map(Into::into).collect(),
+    ))
 }
 
 #[utoipa::path(

--- a/server/presentation/src/handlers/form/question_handler.rs
+++ b/server/presentation/src/handlers/form/question_handler.rs
@@ -10,14 +10,44 @@ use domain::{form::models::FormId, repository::Repositories, user::models::User}
 use errors::ErrorExtra;
 use itertools::Itertools;
 use resource::repository::RealInfrastructureRepository;
-use serde_json::json;
 use usecase::forms::question::QuestionUseCase;
 
 use crate::schemas::error_responses::*;
+use crate::schemas::form::form_response_schemas::{
+    PutQuestionsResponseSchema, QuestionResponseSchema,
+};
 use crate::{
     handlers::error_handler::handle_error,
     schemas::form::form_request_schemas::FormQuestionPutSchema,
 };
+
+#[derive(utoipa::IntoResponses)]
+pub enum GetQuestionsResponse {
+    #[response(status = 200, description = "The request has succeeded.")]
+    Ok(Vec<QuestionResponseSchema>),
+}
+
+impl IntoResponse for GetQuestionsResponse {
+    fn into_response(self) -> Response {
+        match self {
+            Self::Ok(body) => (StatusCode::OK, Json(body)).into_response(),
+        }
+    }
+}
+
+#[derive(utoipa::IntoResponses)]
+pub enum PutQuestionsResponse {
+    #[response(status = 200, description = "The request has succeeded.")]
+    Ok(PutQuestionsResponseSchema),
+}
+
+impl IntoResponse for PutQuestionsResponse {
+    fn into_response(self) -> Response {
+        match self {
+            Self::Ok(body) => (StatusCode::OK, Json(body)).into_response(),
+        }
+    }
+}
 
 #[utoipa::path(
     get,
@@ -27,7 +57,7 @@ use crate::{
         ("id" = String, Path, description = "Form ID"),
     ),
     responses(
-        (status = 200, description = "The request has succeeded.", body = Vec<super::super::super::schemas::form::form_response_schemas::QuestionResponseSchema>),
+        GetQuestionsResponse,
         BadRequest,
         Unauthorized,
         Forbidden,
@@ -41,7 +71,7 @@ pub async fn get_questions_handler(
     Extension(user): Extension<User>,
     State(repository): State<RealInfrastructureRepository>,
     path: Result<Path<FormId>, PathRejection>,
-) -> Result<impl IntoResponse, Response> {
+) -> Result<GetQuestionsResponse, Response> {
     let question_use_case = QuestionUseCase {
         question_repository: repository.form_question_repository(),
     };
@@ -52,7 +82,9 @@ pub async fn get_questions_handler(
         .get_questions(&user, form_id)
         .await
         .map_err(handle_error)?;
-    Ok((StatusCode::OK, Json(questions)).into_response())
+    Ok(GetQuestionsResponse::Ok(
+        questions.into_iter().map(Into::into).collect(),
+    ))
 }
 
 #[utoipa::path(
@@ -64,7 +96,7 @@ pub async fn get_questions_handler(
     ),
     request_body = FormQuestionPutSchema,
     responses(
-        (status = 200, description = "The request has succeeded."),
+        PutQuestionsResponse,
         BadRequest,
         Unauthorized,
         Forbidden,
@@ -80,7 +112,7 @@ pub async fn put_question_handler(
     State(repository): State<RealInfrastructureRepository>,
     path: Result<Path<FormId>, PathRejection>,
     json: Result<Json<FormQuestionPutSchema>, JsonRejection>,
-) -> Result<impl IntoResponse, Response> {
+) -> Result<PutQuestionsResponse, Response> {
     let question_use_case = QuestionUseCase {
         question_repository: repository.form_question_repository(),
     };
@@ -109,5 +141,7 @@ pub async fn put_question_handler(
         .await
         .map_err(handle_error)?;
 
-    Ok((StatusCode::OK, Json(json!({"questions": questions }))).into_response())
+    Ok(PutQuestionsResponse::Ok(PutQuestionsResponseSchema {
+        questions: questions.into_iter().map(Into::into).collect(),
+    }))
 }

--- a/server/presentation/src/handlers/user_handler.rs
+++ b/server/presentation/src/handlers/user_handler.rs
@@ -18,7 +18,7 @@ use usecase::user::UserUseCase;
 use uuid::Uuid;
 
 use crate::schemas::error_responses::*;
-use crate::schemas::user::UserUpdateSchema;
+use crate::schemas::user::{UserInfoResponse, UserSchema, UserUpdateSchema};
 use crate::{handlers::error_handler::handle_error, schemas::user::DiscordOAuthToken};
 use axum::extract::rejection::{JsonRejection, PathRejection};
 use axum::response::Response;
@@ -26,12 +26,54 @@ use axum_extra::typed_header::TypedHeaderRejection;
 use errors::presentation::PresentationError;
 use errors::{Error, ErrorExtra};
 
+#[derive(utoipa::IntoResponses)]
+pub enum GetUserInfoResponse {
+    #[response(status = 200, description = "The request has succeeded.")]
+    Ok(UserInfoResponse),
+}
+
+impl IntoResponse for GetUserInfoResponse {
+    fn into_response(self) -> Response {
+        match self {
+            Self::Ok(body) => (StatusCode::OK, Json(body)).into_response(),
+        }
+    }
+}
+
+#[derive(utoipa::IntoResponses)]
+pub enum PatchUserRoleResponse {
+    #[response(status = 200, description = "The request has succeeded.")]
+    Ok(UserSchema),
+}
+
+impl IntoResponse for PatchUserRoleResponse {
+    fn into_response(self) -> Response {
+        match self {
+            Self::Ok(body) => (StatusCode::OK, Json(body)).into_response(),
+        }
+    }
+}
+
+#[derive(utoipa::IntoResponses)]
+pub enum UserListResponse {
+    #[response(status = 200, description = "The request has succeeded.")]
+    Ok(Vec<UserSchema>),
+}
+
+impl IntoResponse for UserListResponse {
+    fn into_response(self) -> Response {
+        match self {
+            Self::Ok(body) => (StatusCode::OK, Json(body)).into_response(),
+        }
+    }
+}
+
 #[utoipa::path(
     get,
     path = "/users/me",
     summary = "自分のユーザー情報の取得",
     responses(
-        (status = 200, description = "The request has succeeded."),
+        GetUserInfoResponse,
         BadRequest,
         Unauthorized,
         Forbidden,
@@ -43,7 +85,7 @@ use errors::{Error, ErrorExtra};
 pub async fn get_my_user_info(
     Extension(user): Extension<User>,
     State(repository): State<RealInfrastructureRepository>,
-) -> Result<impl IntoResponse, Response> {
+) -> Result<GetUserInfoResponse, Response> {
     let user_use_case = UserUseCase {
         repository: repository.user_repository(),
     };
@@ -58,16 +100,13 @@ pub async fn get_my_user_info(
             user.name().to_owned().into_inner(),
         )
     });
-    Ok((
-        StatusCode::OK,
-        Json(json!({
-            "id": user_dto.user.id.to_string(),
-            "name": user_dto.user.name,
-            "role": user_dto.user.role.to_string(),
-            "discord_user_id": discord_user_id_with_name.to_owned().map(|(discord_user, _)| discord_user),
-            "discord_username": discord_user_id_with_name.map(|(_, username)| username),
-        })),
-    ).into_response())
+    Ok(GetUserInfoResponse::Ok(UserInfoResponse {
+        id: user_dto.user.id.to_string(),
+        name: user_dto.user.name,
+        role: user_dto.user.role.to_string(),
+        discord_user_id: discord_user_id_with_name.to_owned().map(|(id, _)| id),
+        discord_username: discord_user_id_with_name.map(|(_, name)| name),
+    }))
 }
 
 #[utoipa::path(
@@ -78,7 +117,7 @@ pub async fn get_my_user_info(
         ("uuid" = String, Path, description = "User UUID"),
     ),
     responses(
-        (status = 200, description = "The request has succeeded."),
+        GetUserInfoResponse,
         BadRequest,
         Unauthorized,
         Forbidden,
@@ -92,7 +131,7 @@ pub async fn get_user_info(
     Extension(actor): Extension<User>,
     State(repository): State<RealInfrastructureRepository>,
     path: Result<Path<Uuid>, PathRejection>,
-) -> Result<impl IntoResponse, Response> {
+) -> Result<GetUserInfoResponse, Response> {
     let user_use_case = UserUseCase {
         repository: repository.user_repository(),
     };
@@ -109,16 +148,13 @@ pub async fn get_user_info(
             user.name().to_owned().into_inner(),
         )
     });
-    Ok((
-        StatusCode::OK,
-        Json(json!({
-            "id": user_dto.user.id.to_string(),
-            "name": user_dto.user.name,
-            "role": user_dto.user.role.to_string(),
-            "discord_user_id": discord_user_id_with_name.to_owned().map(|(discord_user, _)| discord_user),
-            "discord_username": discord_user_id_with_name.map(|(_, username)| username),
-        })),
-    ).into_response())
+    Ok(GetUserInfoResponse::Ok(UserInfoResponse {
+        id: user_dto.user.id.to_string(),
+        name: user_dto.user.name,
+        role: user_dto.user.role.to_string(),
+        discord_user_id: discord_user_id_with_name.to_owned().map(|(id, _)| id),
+        discord_username: discord_user_id_with_name.map(|(_, name)| name),
+    }))
 }
 
 #[utoipa::path(
@@ -130,7 +166,7 @@ pub async fn get_user_info(
     ),
     request_body = UserUpdateSchema,
     responses(
-        (status = 200, description = "The request has succeeded."),
+        PatchUserRoleResponse,
         BadRequest,
         Unauthorized,
         Forbidden,
@@ -145,7 +181,7 @@ pub async fn patch_user_role(
     State(repository): State<RealInfrastructureRepository>,
     path: Result<Path<Uuid>, PathRejection>,
     json: Result<Json<UserUpdateSchema>, JsonRejection>,
-) -> Result<impl IntoResponse, Response> {
+) -> Result<PatchUserRoleResponse, Response> {
     let user_use_case = UserUseCase {
         repository: repository.user_repository(),
     };
@@ -160,7 +196,7 @@ pub async fn patch_user_role(
     }
     .map_err(handle_error)?;
 
-    Ok((StatusCode::OK, Json(user)).into_response())
+    Ok(PatchUserRoleResponse::Ok(user.into()))
 }
 
 #[utoipa::path(
@@ -168,7 +204,7 @@ pub async fn patch_user_role(
     path = "/users",
     summary = "ユーザーの一覧取得",
     responses(
-        (status = 200, description = "The request has succeeded."),
+        UserListResponse,
         BadRequest,
         Unauthorized,
         Forbidden,
@@ -180,7 +216,7 @@ pub async fn patch_user_role(
 pub async fn user_list(
     Extension(actor): Extension<User>,
     State(repository): State<RealInfrastructureRepository>,
-) -> Result<impl IntoResponse, Response> {
+) -> Result<UserListResponse, Response> {
     let user_use_case = UserUseCase {
         repository: repository.user_repository(),
     };
@@ -189,7 +225,9 @@ pub async fn user_list(
         .fetch_all_users(&actor)
         .await
         .map_err(handle_error)?;
-    Ok((StatusCode::OK, Json(json!(users))).into_response())
+    Ok(UserListResponse::Ok(
+        users.into_iter().map(Into::into).collect(),
+    ))
 }
 
 #[utoipa::path(

--- a/server/presentation/src/schemas/form/form_response_schemas.rs
+++ b/server/presentation/src/schemas/form/form_response_schemas.rs
@@ -113,7 +113,7 @@ pub struct FormSchema {
     pub labels: Vec<FormLabel>,
 }
 
-#[derive(utoipa::ToSchema)]
+#[derive(Serialize, Debug, utoipa::ToSchema)]
 pub struct QuestionResponseSchema {
     pub id: Option<i32>,
     pub form_id: String,
@@ -124,10 +124,53 @@ pub struct QuestionResponseSchema {
     pub is_required: bool,
 }
 
-#[derive(utoipa::ToSchema)]
+impl From<domain::form::question::models::Question> for QuestionResponseSchema {
+    fn from(val: domain::form::question::models::Question) -> Self {
+        QuestionResponseSchema {
+            id: val.id.map(|id| id.into_inner()),
+            form_id: val.form_id.into_inner().to_string(),
+            title: val.title,
+            description: val.description,
+            question_type: val.question_type.to_string(),
+            choices: val.choices,
+            is_required: val.is_required,
+        }
+    }
+}
+
+#[derive(Serialize, Debug, utoipa::ToSchema)]
 pub struct FormLabelResponseSchema {
     pub id: String,
     pub name: String,
+}
+
+impl From<domain::form::models::FormLabel> for FormLabelResponseSchema {
+    fn from(val: domain::form::models::FormLabel) -> Self {
+        FormLabelResponseSchema {
+            id: val.id().to_owned().into_inner().to_string(),
+            name: val.name().to_string(),
+        }
+    }
+}
+
+#[derive(Serialize, Debug, utoipa::ToSchema)]
+pub struct AnswerLabelResponseSchema {
+    pub id: String,
+    pub name: String,
+}
+
+impl From<domain::form::answer::models::AnswerLabel> for AnswerLabelResponseSchema {
+    fn from(val: domain::form::answer::models::AnswerLabel) -> Self {
+        AnswerLabelResponseSchema {
+            id: val.id().to_owned().into_inner().to_string(),
+            name: val.name().to_string(),
+        }
+    }
+}
+
+#[derive(Serialize, Debug, utoipa::ToSchema)]
+pub struct PutQuestionsResponseSchema {
+    pub questions: Vec<QuestionResponseSchema>,
 }
 
 #[derive(Serialize, Debug, utoipa::ToSchema)]

--- a/server/presentation/src/schemas/user.rs
+++ b/server/presentation/src/schemas/user.rs
@@ -1,6 +1,32 @@
 use domain::user::models::Role;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
+
+#[derive(Serialize, Debug, utoipa::ToSchema)]
+pub struct UserInfoResponse {
+    pub id: String,
+    pub name: String,
+    pub role: String,
+    pub discord_user_id: Option<String>,
+    pub discord_username: Option<String>,
+}
+
+#[derive(Serialize, Debug, utoipa::ToSchema)]
+pub struct UserSchema {
+    pub id: String,
+    pub name: String,
+    pub role: String,
+}
+
+impl From<domain::user::models::User> for UserSchema {
+    fn from(val: domain::user::models::User) -> Self {
+        UserSchema {
+            id: val.id.to_string(),
+            name: val.name,
+            role: val.role.to_string(),
+        }
+    }
+}
 
 #[derive(Deserialize, Debug, utoipa::ToSchema)]
 pub struct DiscordOAuthToken {


### PR DESCRIPTION
## Summary

- `UserInfoResponse` / `UserSchema` / `AnswerLabelResponseSchema` / `FormLabelResponseSchema` / `QuestionResponseSchema` / `PutQuestionsResponseSchema` を presentation 層のスキーマ型として追加し、対応する `From` 実装を定義
- `user_handler` / `question_handler` / `answer_label_handler` / `form_label_handler` の各ハンドラに既存の `IntoResponses` パターンを適用し、ハンドラの戻り値型を具体型に変更
- 新規スキーマ型を OpenAPI コンポーネントとして登録

## Background

実際には JSON ボディを返しているにもかかわらず、`#[utoipa::path]` の `responses` にスキーマが定義されておらず OpenAPI 定義と実装に乖離が生じていた。既存の修正済みハンドラ（form, notification 等）と同じ `IntoResponses` パターンに揃えることで、型レベルで OpenAPI 定義と実装の整合性を保つようにした。

## Test plan

- [x] `cargo build` が通ること
- [x] `makers pretty`（clippy + nextest + fmt）がエラーなく完了すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)