### PR TITLE
fix: webhook url カラムから not null 制約を外す

### DIFF
--- a/server/migration/src/m20220101_000001_create_table.rs
+++ b/server/migration/src/m20220101_000001_create_table.rs
@@ -109,7 +109,7 @@ impl MigrationTrait for Migration {
                 r"CREATE TABLE IF NOT EXISTS form_webhooks(
                     id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
                     form_id CHAR(36) NOT NULL,
-                    url TEXT NOT NULL,
+                    url TEXT,
                     FOREIGN KEY fk_form_webhooks_form_id(form_id) REFERENCES form_meta_data(id) ON DELETE CASCADE
                 )",
             ))


### PR DESCRIPTION
不要だった