### PR TITLE
fix: form補助テーブルの1対1制約を明示する

### DIFF
--- a/server/infra/resource/src/database/forms/form.rs
+++ b/server/infra/resource/src/database/forms/form.rs
@@ -5,7 +5,7 @@ use domain::{
     user::models::User,
 };
 use errors::infra::InfraError;
-use futures::future::try_join;
+use futures::future::try_join3;
 use types::non_empty_string::NonEmptyString;
 
 use crate::database::connection::query_one;
@@ -54,9 +54,16 @@ impl FormDatabase for ConnectionPool {
                     txn,
                 );
 
-                try_join(
+                let insert_form_webhooks_table = execute_and_values(
+                    r"INSERT INTO form_webhooks (form_id, url) VALUES (?, NULL)",
+                    [form_id.to_owned().into_inner().to_string().into()],
+                    txn,
+                );
+
+                try_join3(
                     insert_default_answer_title_table,
                     insert_response_period_table,
+                    insert_form_webhooks_table,
                 )
                 .await?;
 
@@ -76,7 +83,7 @@ impl FormDatabase for ConnectionPool {
         self.read_only_transaction(|txn| {
             Box::pin(async move {
                 let form_query = query_all_and_values(
-                    r"SELECT form_meta_data.id AS form_id, form_meta_data.title AS form_title, description, visibility, answer_visibility, created_at, updated_at, url, start_at, end_at, default_answer_titles.title
+                    r"SELECT form_meta_data.id AS form_id, form_meta_data.title AS form_title, description, visibility, answer_visibility, created_at, updated_at, form_webhooks.url AS webhook_url, start_at, end_at, default_answer_titles.title AS default_answer_title
                             FROM form_meta_data
                             LEFT JOIN form_webhooks ON form_meta_data.id = form_webhooks.form_id
                             LEFT JOIN response_period ON form_meta_data.id = response_period.form_id
@@ -101,8 +108,8 @@ impl FormDatabase for ConnectionPool {
                             ),
                             start_at: query_rs.try_get("", "start_at")?,
                             end_at: query_rs.try_get("", "end_at")?,
-                            webhook_url: query_rs.try_get("", "url")?,
-                            default_answer_title: query_rs.try_get("", "default_answer_titles.title")?,
+                            webhook_url: query_rs.try_get("", "webhook_url")?,
+                            default_answer_title: query_rs.try_get("", "default_answer_title")?,
                             visibility: query_rs.try_get("", "visibility")?,
                             answer_visibility: query_rs.try_get("", "answer_visibility")?,
                         })
@@ -117,7 +124,7 @@ impl FormDatabase for ConnectionPool {
         self.read_only_transaction(|txn| {
             Box::pin(async move {
                 let form_query = query_all_and_values(
-                    r"SELECT form_meta_data.id AS form_id, form_meta_data.title AS form_title, description, visibility, answer_visibility, created_at, updated_at, url, start_at, end_at, default_answer_titles.title
+                    r"SELECT form_meta_data.id AS form_id, form_meta_data.title AS form_title, description, visibility, answer_visibility, created_at, updated_at, form_webhooks.url AS webhook_url, start_at, end_at, default_answer_titles.title AS default_answer_title
                             FROM form_meta_data
                             LEFT JOIN form_webhooks ON form_meta_data.id = form_webhooks.form_id
                             LEFT JOIN response_period ON form_meta_data.id = response_period.form_id
@@ -143,8 +150,8 @@ impl FormDatabase for ConnectionPool {
                     ),
                     start_at: form.try_get("", "start_at")?,
                     end_at: form.try_get("", "end_at")?,
-                    webhook_url: form.try_get("", "url")?,
-                    default_answer_title: form.try_get("", "title")?,
+                    webhook_url: form.try_get("", "webhook_url")?,
+                    default_answer_title: form.try_get("", "default_answer_title")?,
                     visibility: form.try_get("", "visibility")?,
                     answer_visibility: form.try_get("", "answer_visibility")?,
                 }))

--- a/server/migration/src/m20220101_000001_create_table.rs
+++ b/server/migration/src/m20220101_000001_create_table.rs
@@ -98,6 +98,7 @@ impl MigrationTrait for Migration {
                     form_id CHAR(36) NOT NULL,
                     start_at DATETIME,
                     end_at DATETIME,
+                    UNIQUE KEY uk_response_period_form_id(form_id),
                     FOREIGN KEY fk_response_period_form_id(form_id) REFERENCES form_meta_data(id) ON DELETE CASCADE
                 )",
             ))
@@ -110,6 +111,7 @@ impl MigrationTrait for Migration {
                     id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
                     form_id CHAR(36) NOT NULL,
                     url TEXT,
+                    UNIQUE KEY uk_form_webhooks_form_id(form_id),
                     FOREIGN KEY fk_form_webhooks_form_id(form_id) REFERENCES form_meta_data(id) ON DELETE CASCADE
                 )",
             ))
@@ -151,6 +153,7 @@ impl MigrationTrait for Migration {
                     id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
                     form_id CHAR(36) NOT NULL,
                     title TEXT,
+                    UNIQUE KEY uk_default_answer_titles_form_id(form_id),
                     FOREIGN KEY fk_default_answer_titles_form_id(form_id) REFERENCES form_meta_data(id) ON DELETE CASCADE
                 )",
             ))


### PR DESCRIPTION
## 概要
- `response_period`、`form_webhooks`、`default_answer_titles` の `form_id` に unique 制約を追加し、form ごとに 1 行だけを持つ前提を schema で明示しました。
- form 作成時に `form_webhooks` の初期行も同時に作るようにして、補助テーブル 3 つの初期化を一貫させました。
- form 一覧・単体取得の join 列に alias を付け、1:1 前提の読み出し結果が曖昧にならないようにしました。

## 確認事項
- `cd server && cargo build` を実行し、今回の migration と `form.rs` の変更を含めてビルドが通ることを確認しました。
- 初回ビルドは `utoipa-swagger-ui` のアセット取得で sandbox の DNS 制限に当たりましたが、依存取得を許可した再実行では成功しました。今回の差分起因のビルドエラーはありませんでした。

## 補足
- システム未稼働前提のため、既存 migration ファイルを直接更新しています。

🤖 Generated with Codex