### PR TITLE
refactor: DB接続境界をsqlxへ移す

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1470,6 +1470,7 @@ dependencies = [
  "sea-orm",
  "serde_json",
  "serenity",
+ "sqlx",
  "strum 0.28.0",
  "thiserror 2.0.18",
  "tokio",

--- a/server/errors/Cargo.toml
+++ b/server/errors/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 
 [dependencies]
 sea-orm = { workspace = true }
+sqlx = { workspace = true }
 strum = { workspace = true }
 thiserror = "2.0.18"
 uuid = { workspace = true }

--- a/server/errors/src/infra.rs
+++ b/server/errors/src/infra.rs
@@ -2,12 +2,12 @@ use serde_json::Error;
 use thiserror::Error;
 use uuid::Uuid;
 
-#[derive(Debug, Error, PartialEq)]
+#[derive(Debug, Error)]
 pub enum InfraError {
     #[error("Database Error: {}", .source)]
     Database {
         #[from]
-        source: sea_orm::error::DbErr,
+        source: sqlx::Error,
     },
     #[error("Transaction Error: {}", .cause)]
     DatabaseTransaction { cause: String },
@@ -49,13 +49,39 @@ pub enum InfraError {
     Send { cause: String },
 }
 
-impl<E> From<sea_orm::TransactionError<E>> for InfraError
-where
-    E: std::error::Error,
-{
-    fn from(value: sea_orm::TransactionError<E>) -> Self {
-        InfraError::DatabaseTransaction {
-            cause: value.to_string(),
+impl PartialEq for InfraError {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Database { source: left }, Self::Database { source: right }) => {
+                left.to_string() == right.to_string()
+            }
+            (
+                Self::DatabaseTransaction { cause: left },
+                Self::DatabaseTransaction { cause: right },
+            ) => left == right,
+            (Self::UuidParse { source: left }, Self::UuidParse { source: right }) => left == right,
+            (Self::FormNotFound { id: left }, Self::FormNotFound { id: right }) => left == right,
+            (Self::AnswerNotFount { id: left }, Self::AnswerNotFount { id: right }) => {
+                left == right
+            }
+            (Self::Outgoing { cause: left }, Self::Outgoing { cause: right }) => left == right,
+            (Self::EnumParse { source: left }, Self::EnumParse { source: right }) => left == right,
+            (Self::Redis { source: left }, Self::Redis { source: right }) => {
+                left.to_string() == right.to_string()
+            }
+            (Self::Reqwest { cause: left }, Self::Reqwest { cause: right }) => left == right,
+            (Self::MeiliSearch { cause: left }, Self::MeiliSearch { cause: right }) => {
+                left == right
+            }
+            (Self::SerdeJson { cause: left }, Self::SerdeJson { cause: right }) => left == right,
+            (Self::SerenityError { cause: left }, Self::SerenityError { cause: right }) => {
+                left == right
+            }
+            (Self::AMQP { source: left }, Self::AMQP { source: right }) => {
+                left.to_string() == right.to_string()
+            }
+            (Self::Send { cause: left }, Self::Send { cause: right }) => left == right,
+            _ => false,
         }
     }
 }

--- a/server/errors/src/infra.rs
+++ b/server/errors/src/infra.rs
@@ -51,37 +51,49 @@ pub enum InfraError {
 
 impl PartialEq for InfraError {
     fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (Self::Database { source: left }, Self::Database { source: right }) => {
-                left.to_string() == right.to_string()
+        match self {
+            Self::Database { source: left } => {
+                matches!(other, Self::Database { source: right } if left.to_string() == right.to_string())
             }
-            (
-                Self::DatabaseTransaction { cause: left },
-                Self::DatabaseTransaction { cause: right },
-            ) => left == right,
-            (Self::UuidParse { source: left }, Self::UuidParse { source: right }) => left == right,
-            (Self::FormNotFound { id: left }, Self::FormNotFound { id: right }) => left == right,
-            (Self::AnswerNotFount { id: left }, Self::AnswerNotFount { id: right }) => {
-                left == right
+            Self::DatabaseTransaction { cause: left } => {
+                matches!(other, Self::DatabaseTransaction { cause: right } if left == right)
             }
-            (Self::Outgoing { cause: left }, Self::Outgoing { cause: right }) => left == right,
-            (Self::EnumParse { source: left }, Self::EnumParse { source: right }) => left == right,
-            (Self::Redis { source: left }, Self::Redis { source: right }) => {
-                left.to_string() == right.to_string()
+            Self::UuidParse { source: left } => {
+                matches!(other, Self::UuidParse { source: right } if left == right)
             }
-            (Self::Reqwest { cause: left }, Self::Reqwest { cause: right }) => left == right,
-            (Self::MeiliSearch { cause: left }, Self::MeiliSearch { cause: right }) => {
-                left == right
+            Self::FormNotFound { id: left } => {
+                matches!(other, Self::FormNotFound { id: right } if left == right)
             }
-            (Self::SerdeJson { cause: left }, Self::SerdeJson { cause: right }) => left == right,
-            (Self::SerenityError { cause: left }, Self::SerenityError { cause: right }) => {
-                left == right
+            Self::AnswerNotFount { id: left } => {
+                matches!(other, Self::AnswerNotFount { id: right } if left == right)
             }
-            (Self::AMQP { source: left }, Self::AMQP { source: right }) => {
-                left.to_string() == right.to_string()
+            Self::Outgoing { cause: left } => {
+                matches!(other, Self::Outgoing { cause: right } if left == right)
             }
-            (Self::Send { cause: left }, Self::Send { cause: right }) => left == right,
-            _ => false,
+            Self::EnumParse { source: left } => {
+                matches!(other, Self::EnumParse { source: right } if left == right)
+            }
+            Self::Redis { source: left } => {
+                matches!(other, Self::Redis { source: right } if left.to_string() == right.to_string())
+            }
+            Self::Reqwest { cause: left } => {
+                matches!(other, Self::Reqwest { cause: right } if left == right)
+            }
+            Self::MeiliSearch { cause: left } => {
+                matches!(other, Self::MeiliSearch { cause: right } if left == right)
+            }
+            Self::SerdeJson { cause: left } => {
+                matches!(other, Self::SerdeJson { cause: right } if left == right)
+            }
+            Self::SerenityError { cause: left } => {
+                matches!(other, Self::SerenityError { cause: right } if left == right)
+            }
+            Self::AMQP { source: left } => {
+                matches!(other, Self::AMQP { source: right } if left.to_string() == right.to_string())
+            }
+            Self::Send { cause: left } => {
+                matches!(other, Self::Send { cause: right } if left == right)
+            }
         }
     }
 }

--- a/server/infra/resource/src/database.rs
+++ b/server/infra/resource/src/database.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::useless_conversion)]
+
 pub mod components;
 pub mod config;
 pub mod connection;

--- a/server/infra/resource/src/database.rs
+++ b/server/infra/resource/src/database.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::useless_conversion)]
-
 pub mod components;
 pub mod config;
 pub mod connection;

--- a/server/infra/resource/src/database/connection.rs
+++ b/server/infra/resource/src/database/connection.rs
@@ -337,9 +337,11 @@ where
             bind_values(
                 &sql.replace(
                     insert_part,
-                    &vec![insert_part; params_vec.len() / insert_part.matches('?').count()]
-                        .iter()
-                        .join(", "),
+                    &std::iter::repeat_n(
+                        insert_part,
+                        params_vec.len() / insert_part.matches('?').count(),
+                    )
+                    .join(", "),
                 ),
                 params_vec,
             )?
@@ -366,7 +368,11 @@ where
             bind_values(
                 &sql.replace(
                     "(?)",
-                    format!("({})", &vec!["?"; params_vec.len()].iter().join(", ")).as_str(),
+                    format!(
+                        "({})",
+                        std::iter::repeat_n("?", params_vec.len()).join(", ")
+                    )
+                    .as_str(),
                 ),
                 params_vec,
             )?

--- a/server/infra/resource/src/database/connection.rs
+++ b/server/infra/resource/src/database/connection.rs
@@ -7,7 +7,7 @@ use redis::Client;
 use regex::Regex;
 use sea_orm::{Database, Value};
 use sqlx::{
-    MySql, Row,
+    MySql,
     mysql::{MySqlArguments, MySqlPool, MySqlPoolOptions, MySqlQueryResult, MySqlRow},
     query::Query,
 };
@@ -20,18 +20,6 @@ use crate::database::{
 pub type DatabaseTransaction = sqlx::Transaction<'static, MySql>;
 pub type DbErr = sqlx::Error;
 pub type ExecResult = MySqlQueryResult;
-
-#[derive(Debug)]
-pub struct QueryResult(MySqlRow);
-
-impl QueryResult {
-    pub fn try_get<T>(&self, _prefix: &str, column: &str) -> Result<T, sqlx::Error>
-    where
-        T: sqlx::Type<MySql> + for<'r> sqlx::Decode<'r, MySql>,
-    {
-        self.0.try_get(column)
-    }
-}
 
 #[derive(Clone, Debug)]
 pub struct ConnectionPool {
@@ -267,49 +255,41 @@ where
 pub async fn query_all(
     sql: &str,
     transaction: &mut DatabaseTransaction,
-) -> Result<Vec<QueryResult>, DbErr> {
-    sqlx::query(sql)
-        .fetch_all(&mut **transaction)
-        .await
-        .map(|rows| rows.into_iter().map(QueryResult).collect())
+) -> Result<Vec<MySqlRow>, DbErr> {
+    sqlx::query(sql).fetch_all(&mut **transaction).await
 }
 
 pub async fn query_all_and_values<I>(
     sql: &str,
     values: I,
     transaction: &mut DatabaseTransaction,
-) -> Result<Vec<QueryResult>, DbErr>
+) -> Result<Vec<MySqlRow>, DbErr>
 where
     I: IntoIterator<Item = Value>,
 {
     bind_values(sql, values)?
         .fetch_all(&mut **transaction)
         .await
-        .map(|rows| rows.into_iter().map(QueryResult).collect())
 }
 
 pub async fn query_one(
     sql: &str,
     transaction: &mut DatabaseTransaction,
-) -> Result<Option<QueryResult>, DbErr> {
-    sqlx::query(sql)
-        .fetch_optional(&mut **transaction)
-        .await
-        .map(|row| row.map(QueryResult))
+) -> Result<Option<MySqlRow>, DbErr> {
+    sqlx::query(sql).fetch_optional(&mut **transaction).await
 }
 
 pub async fn query_one_and_values<I>(
     sql: &str,
     values: I,
     transaction: &mut DatabaseTransaction,
-) -> Result<Option<QueryResult>, DbErr>
+) -> Result<Option<MySqlRow>, DbErr>
 where
     I: IntoIterator<Item = Value>,
 {
     bind_values(sql, values)?
         .fetch_optional(&mut **transaction)
         .await
-        .map(|row| row.map(QueryResult))
 }
 
 pub async fn execute(

--- a/server/infra/resource/src/database/connection.rs
+++ b/server/infra/resource/src/database/connection.rs
@@ -5,10 +5,11 @@ use itertools::Itertools;
 use migration::MigratorTrait;
 use redis::Client;
 use regex::Regex;
-use sea_orm::{
-    AccessMode, ConnectionTrait, Database, DatabaseBackend, DatabaseConnection,
-    DatabaseTransaction, DbErr, ExecResult, QueryResult, Statement, TransactionError,
-    TransactionTrait, Value,
+use sea_orm::{Database, Value};
+use sqlx::{
+    MySql, Row,
+    mysql::{MySqlArguments, MySqlPool, MySqlPoolOptions, MySqlQueryResult, MySqlRow},
+    query::Query,
 };
 
 use crate::database::{
@@ -16,14 +17,30 @@ use crate::database::{
     config::{MEILISEARCH, MYSQL, MeiliSearch, MySQL, REDIS, Redis},
 };
 
+pub type DatabaseTransaction = sqlx::Transaction<'static, MySql>;
+pub type DbErr = sqlx::Error;
+pub type ExecResult = MySqlQueryResult;
+
+#[derive(Debug)]
+pub struct QueryResult(MySqlRow);
+
+impl QueryResult {
+    pub fn try_get<T>(&self, _prefix: &str, column: &str) -> Result<T, sqlx::Error>
+    where
+        T: sqlx::Type<MySql> + for<'r> sqlx::Decode<'r, MySql>,
+    {
+        self.0.try_get(column)
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct ConnectionPool {
-    pub(crate) rdb_pool: DatabaseConnection,
+    pub(crate) rdb_pool: MySqlPool,
     pub(crate) meilisearch_client: meilisearch_sdk::client::Client,
 }
 
 impl ConnectionPool {
-    pub async fn new() -> Self {
+    fn database_url() -> String {
         let MySQL {
             user,
             password,
@@ -33,12 +50,16 @@ impl ConnectionPool {
             ..
         } = &*MYSQL;
 
-        let database_url = format!("mysql://{user}:{password}@{host}:{port}/{database}");
+        format!("mysql://{user}:{password}@{host}:{port}/{database}")
+    }
 
+    pub async fn new() -> Self {
+        let database_url = Self::database_url();
         let MeiliSearch { host, api_key } = &*MEILISEARCH;
 
         Self {
-            rdb_pool: Database::connect(&database_url)
+            rdb_pool: MySqlPoolOptions::new()
+                .connect(&database_url)
                 .await
                 .unwrap_or_else(|_| panic!("Cannot establish connect to {database_url}.")),
             meilisearch_client: meilisearch_sdk::client::Client::new(host, api_key.to_owned())
@@ -47,7 +68,10 @@ impl ConnectionPool {
     }
 
     pub async fn ping_db(&self) -> bool {
-        self.rdb_pool.ping().await.is_ok()
+        sqlx::query("SELECT 1")
+            .execute(&self.rdb_pool)
+            .await
+            .is_ok()
     }
 
     pub async fn ping_meilisearch(&self) -> bool {
@@ -59,43 +83,71 @@ impl ConnectionPool {
     }
 
     pub async fn migrate(&self) -> anyhow::Result<()> {
-        migration::Migrator::up(&self.rdb_pool, None).await?;
-
+        let migration_conn = Database::connect(Self::database_url()).await?;
+        migration::Migrator::up(&migration_conn, None).await?;
         Ok(())
     }
 
-    pub async fn read_only_transaction<F, T, E>(
-        &self,
-        callback: F,
-    ) -> Result<T, TransactionError<E>>
+    pub async fn read_only_transaction<F, T, E>(&self, callback: F) -> Result<T, InfraError>
     where
         F: for<'c> FnOnce(
-                &'c DatabaseTransaction,
+                &'c mut DatabaseTransaction,
             ) -> Pin<Box<dyn Future<Output = Result<T, E>> + Send + 'c>>
             + Send,
         T: Send,
-        E: std::error::Error + Send,
+        E: Into<InfraError> + Send,
     {
-        self.rdb_pool
-            .transaction_with_config(callback, None, Some(AccessMode::ReadOnly))
+        let mut transaction = self
+            .rdb_pool
+            .begin_with("START TRANSACTION READ ONLY")
             .await
+            .map_err(|error| InfraError::DatabaseTransaction {
+                cause: error.to_string(),
+            })?;
+
+        let result = callback(&mut transaction).await;
+        match result {
+            Ok(value) => {
+                transaction.commit().await?;
+                Ok(value)
+            }
+            Err(error) => {
+                let infra_error = error.into();
+                let _ = transaction.rollback().await;
+                Err(infra_error)
+            }
+        }
     }
 
-    pub async fn read_write_transaction<F, T, E>(
-        &self,
-        callback: F,
-    ) -> Result<T, TransactionError<E>>
+    pub async fn read_write_transaction<F, T, E>(&self, callback: F) -> Result<T, InfraError>
     where
         F: for<'c> FnOnce(
-                &'c DatabaseTransaction,
+                &'c mut DatabaseTransaction,
             ) -> Pin<Box<dyn Future<Output = Result<T, E>> + Send + 'c>>
             + Send,
         T: Send,
-        E: std::error::Error + Send,
+        E: Into<InfraError> + Send,
     {
-        self.rdb_pool
-            .transaction_with_config(callback, None, Some(AccessMode::ReadWrite))
+        let mut transaction = self
+            .rdb_pool
+            .begin_with("START TRANSACTION READ WRITE")
             .await
+            .map_err(|error| InfraError::DatabaseTransaction {
+                cause: error.to_string(),
+            })?;
+
+        let result = callback(&mut transaction).await;
+        match result {
+            Ok(value) => {
+                transaction.commit().await?;
+                Ok(value)
+            }
+            Err(error) => {
+                let infra_error = error.into();
+                let _ = transaction.rollback().await;
+                Err(infra_error)
+            }
+        }
     }
 }
 
@@ -115,7 +167,10 @@ impl DatabaseComponents for ConnectionPool {
     type TransactionAcrossComponents = DatabaseTransaction;
 
     async fn begin_transaction(&self) -> anyhow::Result<Self::TransactionAcrossComponents> {
-        Ok(self.rdb_pool.begin().await?)
+        Ok(self
+            .rdb_pool
+            .begin_with("START TRANSACTION READ WRITE")
+            .await?)
     }
 
     fn form(&self) -> &Self::ConcreteFormDatabase {
@@ -163,85 +218,122 @@ impl DatabaseComponents for ConnectionPool {
     }
 }
 
+fn bind_value<'q>(
+    query: Query<'q, MySql, MySqlArguments>,
+    value: Value,
+) -> Result<Query<'q, MySql, MySqlArguments>, sqlx::Error> {
+    match value {
+        Value::Bool(value) => Ok(query.bind(value)),
+        Value::TinyInt(value) => Ok(query.bind(value)),
+        Value::SmallInt(value) => Ok(query.bind(value)),
+        Value::Int(value) => Ok(query.bind(value)),
+        Value::BigInt(value) => Ok(query.bind(value)),
+        Value::TinyUnsigned(value) => Ok(query.bind(value)),
+        Value::SmallUnsigned(value) => Ok(query.bind(value)),
+        Value::Unsigned(value) => Ok(query.bind(value)),
+        Value::BigUnsigned(value) => Ok(query.bind(value)),
+        Value::Float(value) => Ok(query.bind(value)),
+        Value::Double(value) => Ok(query.bind(value)),
+        Value::String(value) => Ok(query.bind(value.map(|value| *value))),
+        Value::Char(value) => Ok(query.bind(value.map(|value| value.to_string()))),
+        Value::Bytes(value) => Ok(query.bind(value.map(|value| *value))),
+        Value::ChronoDate(value) => Ok(query.bind(value.map(|value| *value))),
+        Value::ChronoTime(value) => Ok(query.bind(value.map(|value| *value))),
+        Value::ChronoDateTime(value) => Ok(query.bind(value.map(|value| *value))),
+        Value::ChronoDateTimeUtc(value) => Ok(query.bind(value.map(|value| *value))),
+        Value::ChronoDateTimeLocal(value) => {
+            Ok(query.bind(value.map(|value| value.fixed_offset().naive_local())))
+        }
+        Value::ChronoDateTimeWithTimeZone(value) => {
+            Ok(query.bind(value.map(|value| value.with_timezone(&chrono::Utc))))
+        }
+        Value::Uuid(value) => Ok(query.bind(value.map(|value| *value))),
+        other => Err(sqlx::Error::Protocol(format!(
+            "unsupported bind value for sqlx migration: {other:?}"
+        ))),
+    }
+}
+
+fn bind_values<'q, I>(
+    sql: &'q str,
+    values: I,
+) -> Result<Query<'q, MySql, MySqlArguments>, sqlx::Error>
+where
+    I: IntoIterator<Item = Value>,
+{
+    values.into_iter().try_fold(sqlx::query(sql), bind_value)
+}
+
 pub async fn query_all(
     sql: &str,
-    transaction: &DatabaseTransaction,
+    transaction: &mut DatabaseTransaction,
 ) -> Result<Vec<QueryResult>, DbErr> {
-    transaction
-        .query_all(Statement::from_string(DatabaseBackend::MySql, sql))
+    sqlx::query(sql)
+        .fetch_all(&mut **transaction)
         .await
+        .map(|rows| rows.into_iter().map(QueryResult).collect())
 }
 
 pub async fn query_all_and_values<I>(
     sql: &str,
     values: I,
-    transaction: &DatabaseTransaction,
+    transaction: &mut DatabaseTransaction,
 ) -> Result<Vec<QueryResult>, DbErr>
 where
     I: IntoIterator<Item = Value>,
 {
-    transaction
-        .query_all(Statement::from_sql_and_values(
-            DatabaseBackend::MySql,
-            sql,
-            values,
-        ))
+    bind_values(sql, values)?
+        .fetch_all(&mut **transaction)
         .await
+        .map(|rows| rows.into_iter().map(QueryResult).collect())
 }
 
 pub async fn query_one(
     sql: &str,
-    transaction: &DatabaseTransaction,
+    transaction: &mut DatabaseTransaction,
 ) -> Result<Option<QueryResult>, DbErr> {
-    transaction
-        .query_one(Statement::from_string(DatabaseBackend::MySql, sql))
+    sqlx::query(sql)
+        .fetch_optional(&mut **transaction)
         .await
+        .map(|row| row.map(QueryResult))
 }
 
 pub async fn query_one_and_values<I>(
     sql: &str,
     values: I,
-    transaction: &DatabaseTransaction,
+    transaction: &mut DatabaseTransaction,
 ) -> Result<Option<QueryResult>, DbErr>
 where
     I: IntoIterator<Item = Value>,
 {
-    transaction
-        .query_one(Statement::from_sql_and_values(
-            DatabaseBackend::MySql,
-            sql,
-            values,
-        ))
+    bind_values(sql, values)?
+        .fetch_optional(&mut **transaction)
         .await
+        .map(|row| row.map(QueryResult))
 }
 
-pub async fn execute(sql: &str, transaction: &DatabaseTransaction) -> Result<ExecResult, DbErr> {
-    transaction
-        .execute(Statement::from_string(DatabaseBackend::MySql, sql))
-        .await
+pub async fn execute(
+    sql: &str,
+    transaction: &mut DatabaseTransaction,
+) -> Result<ExecResult, DbErr> {
+    sqlx::query(sql).execute(&mut **transaction).await
 }
 
 pub async fn execute_and_values<I>(
     sql: &str,
     values: I,
-    transaction: &DatabaseTransaction,
+    transaction: &mut DatabaseTransaction,
 ) -> Result<ExecResult, DbErr>
 where
     I: IntoIterator<Item = Value>,
 {
-    transaction
-        .execute(Statement::from_sql_and_values(
-            DatabaseBackend::MySql,
-            sql,
-            values,
-        ))
-        .await
+    bind_values(sql, values)?.execute(&mut **transaction).await
 }
 
 pub async fn batch_insert<I>(
     sql: &str,
     params: I,
-    transaction: &DatabaseTransaction,
+    transaction: &mut DatabaseTransaction,
 ) -> Result<Option<ExecResult>, DbErr>
 where
     I: IntoIterator<Item = Value>,
@@ -262,18 +354,17 @@ where
         let insert_part = insert_part_opt.unwrap().as_str();
 
         Ok(Some(
-            transaction
-                .execute(Statement::from_sql_and_values(
-                    DatabaseBackend::MySql,
-                    sql.replace(
-                        insert_part,
-                        &vec![insert_part; params_vec.len() / insert_part.matches('?').count()]
-                            .iter()
-                            .join(", "),
-                    ),
-                    params_vec,
-                ))
-                .await?,
+            bind_values(
+                &sql.replace(
+                    insert_part,
+                    &vec![insert_part; params_vec.len() / insert_part.matches('?').count()]
+                        .iter()
+                        .join(", "),
+                ),
+                params_vec,
+            )?
+            .execute(&mut **transaction)
+            .await?,
         ))
     }
 }
@@ -281,7 +372,7 @@ where
 pub async fn multiple_delete<I>(
     sql: &str,
     params: I,
-    transaction: &DatabaseTransaction,
+    transaction: &mut DatabaseTransaction,
 ) -> Result<Option<ExecResult>, DbErr>
 where
     I: IntoIterator<Item = Value>,
@@ -292,16 +383,15 @@ where
         Ok(None)
     } else {
         Ok(Some(
-            transaction
-                .execute(Statement::from_sql_and_values(
-                    DatabaseBackend::MySql,
-                    sql.replace(
-                        "(?)",
-                        format!("({})", &vec!["?"; params_vec.len()].iter().join(", ")).as_str(),
-                    ),
-                    params_vec,
-                ))
-                .await?,
+            bind_values(
+                &sql.replace(
+                    "(?)",
+                    format!("({})", &vec!["?"; params_vec.len()].iter().join(", ")).as_str(),
+                ),
+                params_vec,
+            )?
+            .execute(&mut **transaction)
+            .await?,
         ))
     }
 }
@@ -315,3 +405,5 @@ pub async fn redis_connection() -> Client {
 
     client_result.unwrap_or_else(|_| panic!("Cannot connect to Valkey."))
 }
+
+use errors::infra::InfraError;

--- a/server/infra/resource/src/database/forms/answer_label.rs
+++ b/server/infra/resource/src/database/forms/answer_label.rs
@@ -37,7 +37,6 @@ impl FormAnswerLabelDatabase for ConnectionPool {
             })
         })
         .await
-        .map_err(Into::into)
     }
 
     #[tracing::instrument]
@@ -59,7 +58,6 @@ impl FormAnswerLabelDatabase for ConnectionPool {
             })
         })
         .await
-        .map_err(Into::into)
     }
 
     #[tracing::instrument]
@@ -91,7 +89,6 @@ impl FormAnswerLabelDatabase for ConnectionPool {
             })
         })
         .await
-        .map_err(Into::into)
     }
 
     #[tracing::instrument]
@@ -130,7 +127,6 @@ impl FormAnswerLabelDatabase for ConnectionPool {
             })
         })
         .await
-        .map_err(Into::into)
     }
 
     #[tracing::instrument]
@@ -163,7 +159,6 @@ impl FormAnswerLabelDatabase for ConnectionPool {
             })
         })
             .await
-            .map_err(Into::into)
     }
 
     #[tracing::instrument]
@@ -181,7 +176,6 @@ impl FormAnswerLabelDatabase for ConnectionPool {
             })
         })
         .await
-        .map_err(Into::into)
     }
 
     #[tracing::instrument]
@@ -204,7 +198,6 @@ impl FormAnswerLabelDatabase for ConnectionPool {
             })
         })
         .await
-        .map_err(Into::into)
     }
 
     #[tracing::instrument]
@@ -244,7 +237,6 @@ impl FormAnswerLabelDatabase for ConnectionPool {
             })
         })
         .await
-        .map_err(Into::into)
     }
 
     #[tracing::instrument]
@@ -263,6 +255,5 @@ impl FormAnswerLabelDatabase for ConnectionPool {
             })
         })
         .await
-        .map_err(Into::into)
     }
 }

--- a/server/infra/resource/src/database/forms/answer_label.rs
+++ b/server/infra/resource/src/database/forms/answer_label.rs
@@ -2,6 +2,7 @@ use async_trait::async_trait;
 use domain::form::answer::models::{AnswerId, AnswerLabel, AnswerLabelId};
 use errors::infra::InfraError;
 use itertools::Itertools;
+use sqlx::Row;
 
 use crate::database::connection::query_one;
 use crate::{
@@ -50,8 +51,8 @@ impl FormAnswerLabelDatabase for ConnectionPool {
                     .into_iter()
                     .map(|rs| {
                         Ok::<_, InfraError>(AnswerLabelDto {
-                            id: rs.try_get("", "id")?,
-                            name: rs.try_get("", "name")?,
+                            id: rs.try_get("id")?,
+                            name: rs.try_get("name")?,
                         })
                     })
                     .collect::<Result<Vec<_>, _>>()
@@ -80,8 +81,8 @@ impl FormAnswerLabelDatabase for ConnectionPool {
                     .into_iter()
                     .map(|rs| {
                         Ok::<_, InfraError>(AnswerLabelDto {
-                            id: rs.try_get("", "id")?,
-                            name: rs.try_get("", "name")?,
+                            id: rs.try_get("id")?,
+                            name: rs.try_get("name")?,
                         })
                     })
                     .next()
@@ -119,8 +120,8 @@ impl FormAnswerLabelDatabase for ConnectionPool {
                     .into_iter()
                     .map(|rs| {
                         Ok::<_, InfraError>(AnswerLabelDto {
-                            id: rs.try_get("", "id")?,
-                            name: rs.try_get("", "name")?,
+                            id: rs.try_get("id")?,
+                            name: rs.try_get("name")?,
                         })
                     })
                     .collect::<Result<Vec<AnswerLabelDto>, _>>()
@@ -151,8 +152,8 @@ impl FormAnswerLabelDatabase for ConnectionPool {
                     .into_iter()
                     .map(|rs| {
                         Ok::<_, InfraError>(AnswerLabelDto {
-                            id: rs.try_get("", "label_id")?,
-                            name: rs.try_get("", "name")?,
+                            id: rs.try_get("label_id")?,
+                            name: rs.try_get("name")?,
                         })
                     })
                     .collect::<Result<Vec<AnswerLabelDto>, _>>()
@@ -247,7 +248,7 @@ impl FormAnswerLabelDatabase for ConnectionPool {
                     query_one("SELECT COUNT(*) AS count FROM label_for_form_answers", txn).await?;
 
                 let size = query
-                    .map(|rs| rs.try_get::<i32>("", "count"))
+                    .map(|rs| rs.try_get::<i32, _>("count"))
                     .transpose()?
                     .unwrap_or(0);
 

--- a/server/infra/resource/src/database/forms/answers.rs
+++ b/server/infra/resource/src/database/forms/answers.rs
@@ -10,6 +10,7 @@ use domain::{
 };
 use errors::infra::InfraError;
 use itertools::Itertools;
+use sqlx::Row;
 use types::non_empty_string::NonEmptyString;
 use uuid::Uuid;
 
@@ -103,9 +104,9 @@ impl FormAnswerDatabase for ConnectionPool {
                     .iter()
                     .map(|rs| {
                         Ok::<_, InfraError>(FormAnswerContentDto {
-                            id: rs.try_get("", "id")?,
-                            question_id: rs.try_get("", "question_id")?,
-                            answer: rs.try_get("", "answer")?,
+                            id: rs.try_get("id")?,
+                            question_id: rs.try_get("question_id")?,
+                            answer: rs.try_get("answer")?,
                         })
                     })
                     .collect::<Result<Vec<_>, _>>()?;
@@ -114,12 +115,12 @@ impl FormAnswerDatabase for ConnectionPool {
                     .map(|rs| {
                         Ok::<_, InfraError>(FormAnswerDto {
                             id: answer_id.into_inner().to_string(),
-                            uuid: rs.try_get("", "user")?,
-                            user_name: rs.try_get("", "name")?,
-                            user_role: Role::from_str(&rs.try_get::<String>("", "role")?)?,
-                            timestamp: rs.try_get("", "timestamp")?,
-                            form_id: rs.try_get("", "form_id")?,
-                            title: rs.try_get("", "title")?,
+                            uuid: rs.try_get("user")?,
+                            user_name: rs.try_get("name")?,
+                            user_role: Role::from_str(&rs.try_get::<String, _>("role")?)?,
+                            timestamp: rs.try_get("timestamp")?,
+                            form_id: rs.try_get("form_id")?,
+                            title: rs.try_get("title")?,
                             contents
                         })
                     })
@@ -148,16 +149,16 @@ impl FormAnswerDatabase for ConnectionPool {
                 let form_answer_dtos = answers
                     .iter()
                     .map(|rs| {
-                        let answer_id = Uuid::from_str(&rs.try_get::<String>("", "answer_id")?)?;
+                        let answer_id = Uuid::from_str(&rs.try_get::<String, _>("answer_id")?)?;
 
                         Ok::<_, InfraError>(FormAnswerDto {
                             id: answer_id.to_string(),
-                            uuid: rs.try_get("", "user")?,
-                            user_name: rs.try_get("", "name")?,
-                            user_role: Role::from_str(&rs.try_get::<String>("", "role")?)?,
-                            timestamp: rs.try_get("", "timestamp")?,
-                            form_id: rs.try_get("", "form_id")?,
-                            title: rs.try_get("", "title")?,
+                            uuid: rs.try_get("user")?,
+                            user_name: rs.try_get("name")?,
+                            user_role: Role::from_str(&rs.try_get::<String, _>("role")?)?,
+                            timestamp: rs.try_get("timestamp")?,
+                            form_id: rs.try_get("form_id")?,
+                            title: rs.try_get("title")?,
                             contents: Vec::new()
                         })
                     }).collect::<Result<Vec<_>, _>>()?;
@@ -178,10 +179,10 @@ impl FormAnswerDatabase for ConnectionPool {
                 let answer_id_with_content_dto = contents
                     .iter()
                     .map(|rs| {
-                        Ok::<_, InfraError>((Uuid::from_str(&rs.try_get::<String>("", "answer_id")?)?, FormAnswerContentDto {
-                            id: rs.try_get("", "id")?,
-                            question_id: rs.try_get("", "question_id")?,
-                            answer: rs.try_get("", "answer")?,
+                        Ok::<_, InfraError>((Uuid::from_str(&rs.try_get::<String, _>("answer_id")?)?, FormAnswerContentDto {
+                            id: rs.try_get("id")?,
+                            question_id: rs.try_get("question_id")?,
+                            answer: rs.try_get("answer")?,
                         }))
                     })
                     .collect::<Result<Vec<_>, _>>()?;
@@ -220,16 +221,16 @@ impl FormAnswerDatabase for ConnectionPool {
                 let form_answer_dtos = answers
                     .iter()
                     .map(|rs| {
-                        let answer_id = Uuid::from_str(&rs.try_get::<String>("", "answer_id")?)?;
+                        let answer_id = Uuid::from_str(&rs.try_get::<String, _>("answer_id")?)?;
 
                         Ok::<_, InfraError>(FormAnswerDto {
                             id: answer_id.to_string(),
-                            uuid: rs.try_get("", "user")?,
-                            user_name: rs.try_get("", "name")?,
-                            user_role: Role::from_str(&rs.try_get::<String>("", "role")?)?,
-                            timestamp: rs.try_get("", "timestamp")?,
-                            form_id: rs.try_get("", "form_id")?,
-                            title: rs.try_get("", "title")?,
+                            uuid: rs.try_get("user")?,
+                            user_name: rs.try_get("name")?,
+                            user_role: Role::from_str(&rs.try_get::<String, _>("role")?)?,
+                            timestamp: rs.try_get("timestamp")?,
+                            form_id: rs.try_get("form_id")?,
+                            title: rs.try_get("title")?,
                             contents: Vec::new()
                         })
                     }).collect::<Result<Vec<_>, _>>()?;
@@ -249,10 +250,10 @@ impl FormAnswerDatabase for ConnectionPool {
                 let answer_id_with_content_dto = contents
                     .iter()
                     .map(|rs| {
-                        Ok::<_, InfraError>((Uuid::from_str(&rs.try_get::<String>("", "answer_id")?)?, FormAnswerContentDto {
-                            id: rs.try_get("", "id")?,
-                            question_id: rs.try_get("", "question_id")?,
-                            answer: rs.try_get("", "answer")?,
+                        Ok::<_, InfraError>((Uuid::from_str(&rs.try_get::<String, _>("answer_id")?)?, FormAnswerContentDto {
+                            id: rs.try_get("id")?,
+                            question_id: rs.try_get("question_id")?,
+                            answer: rs.try_get("answer")?,
                         }))
                     })
                     .collect::<Result<Vec<_>, _>>()?;
@@ -304,16 +305,16 @@ impl FormAnswerDatabase for ConnectionPool {
                 let form_answer_dtos = answers
                     .iter()
                     .map(|rs| {
-                        let answer_id = Uuid::from_str(&rs.try_get::<String>("", "answer_id")?)?;
+                        let answer_id = Uuid::from_str(&rs.try_get::<String, _>("answer_id")?)?;
 
                         Ok::<_, InfraError>(FormAnswerDto {
                             id: answer_id.to_string(),
-                            uuid: rs.try_get("", "user")?,
-                            user_name: rs.try_get("", "name")?,
-                            user_role: Role::from_str(&rs.try_get::<String>("", "role")?)?,
-                            timestamp: rs.try_get("", "timestamp")?,
-                            form_id: rs.try_get("", "form_id")?,
-                            title: rs.try_get("", "title")?,
+                            uuid: rs.try_get("user")?,
+                            user_name: rs.try_get("name")?,
+                            user_role: Role::from_str(&rs.try_get::<String, _>("role")?)?,
+                            timestamp: rs.try_get("timestamp")?,
+                            form_id: rs.try_get("form_id")?,
+                            title: rs.try_get("title")?,
                             contents: Vec::new()
                         })
                     }).collect::<Result<Vec<_>, _>>()?;
@@ -334,10 +335,10 @@ impl FormAnswerDatabase for ConnectionPool {
                 let answer_id_with_content_dto = contents
                     .iter()
                     .map(|rs| {
-                        Ok::<_, InfraError>((Uuid::from_str(&rs.try_get::<String>("", "answer_id")?)?, FormAnswerContentDto {
-                            id: rs.try_get("", "id")?,
-                            question_id: rs.try_get("", "question_id")?,
-                            answer: rs.try_get("", "answer")?,
+                        Ok::<_, InfraError>((Uuid::from_str(&rs.try_get::<String, _>("answer_id")?)?, FormAnswerContentDto {
+                            id: rs.try_get("id")?,
+                            question_id: rs.try_get("question_id")?,
+                            answer: rs.try_get("answer")?,
                         }))
                     })
                     .collect::<Result<Vec<_>, _>>()?;
@@ -394,7 +395,7 @@ impl FormAnswerDatabase for ConnectionPool {
                 let query = query_one("SELECT COUNT(*) AS count FROM real_answers", txn).await?;
 
                 let size = query
-                    .map(|rs| rs.try_get::<i32>("", "count"))
+                    .map(|rs| rs.try_get::<i32, _>("count"))
                     .transpose()?
                     .unwrap_or(0);
 

--- a/server/infra/resource/src/database/forms/answers.rs
+++ b/server/infra/resource/src/database/forms/answers.rs
@@ -78,7 +78,6 @@ impl FormAnswerDatabase for ConnectionPool {
                 Ok::<_, InfraError>(())
             })
         }).await
-            .map_err(Into::into)
     }
 
     #[tracing::instrument]
@@ -128,7 +127,6 @@ impl FormAnswerDatabase for ConnectionPool {
             })
         })
             .await
-            .map_err(Into::into)
     }
 
     #[tracing::instrument]
@@ -206,7 +204,6 @@ impl FormAnswerDatabase for ConnectionPool {
 
             })
         }).await
-            .map_err(Into::into)
     }
 
     #[tracing::instrument]
@@ -277,7 +274,6 @@ impl FormAnswerDatabase for ConnectionPool {
             })
         })
             .await
-            .map_err(Into::into)
     }
 
     #[tracing::instrument]
@@ -364,7 +360,6 @@ impl FormAnswerDatabase for ConnectionPool {
 
             })
         }).await
-            .map_err(Into::into)
     }
 
     #[tracing::instrument]
@@ -390,7 +385,6 @@ impl FormAnswerDatabase for ConnectionPool {
             })
         })
         .await
-        .map_err(Into::into)
     }
 
     #[tracing::instrument]
@@ -408,6 +402,5 @@ impl FormAnswerDatabase for ConnectionPool {
             })
         })
         .await
-        .map_err(Into::into)
     }
 }

--- a/server/infra/resource/src/database/forms/comment.rs
+++ b/server/infra/resource/src/database/forms/comment.rs
@@ -49,7 +49,6 @@ impl FormCommentDatabase for ConnectionPool {
             })
         })
             .await
-            .map_err(Into::into)
     }
 
     #[tracing::instrument]
@@ -80,7 +79,6 @@ impl FormCommentDatabase for ConnectionPool {
             })
         })
             .await
-            .map_err(Into::into)
     }
 
     #[tracing::instrument]
@@ -109,7 +107,6 @@ impl FormCommentDatabase for ConnectionPool {
             })
         })
             .await
-            .map_err(Into::into)
     }
 
     #[tracing::instrument]
@@ -146,7 +143,6 @@ impl FormCommentDatabase for ConnectionPool {
             })
         })
         .await
-        .map_err(Into::into)
     }
 
     #[tracing::instrument]
@@ -164,7 +160,6 @@ impl FormCommentDatabase for ConnectionPool {
             })
         })
         .await
-        .map_err(Into::into)
     }
 
     #[tracing::instrument]
@@ -183,6 +178,5 @@ impl FormCommentDatabase for ConnectionPool {
             })
         })
         .await
-        .map_err(Into::into)
     }
 }

--- a/server/infra/resource/src/database/forms/comment.rs
+++ b/server/infra/resource/src/database/forms/comment.rs
@@ -9,6 +9,7 @@ use domain::{
     user::models::Role,
 };
 use errors::infra::InfraError;
+use sqlx::Row;
 
 use crate::database::connection::{query_all, query_one};
 use crate::{
@@ -35,14 +36,14 @@ impl FormCommentDatabase for ConnectionPool {
 
                 comment.into_iter().next().map(|rs| {
                     Ok::<_, InfraError>(CommentDto {
-                        answer_id: rs.try_get("", "answer_id")?,
-                        comment_id: rs.try_get("", "id")?,
-                        content: rs.try_get("", "content")?,
-                        timestamp: rs.try_get("", "timestamp")?,
+                        answer_id: rs.try_get("answer_id")?,
+                        comment_id: rs.try_get("id")?,
+                        content: rs.try_get("content")?,
+                        timestamp: rs.try_get("timestamp")?,
                         commented_by: UserDto {
-                            name: rs.try_get("", "name")?,
-                            id: rs.try_get("", "commented_by")?,
-                            role: Role::from_str(rs.try_get::<String>("", "role")?.as_str())?,
+                            name: rs.try_get("name")?,
+                            id: rs.try_get("commented_by")?,
+                            role: Role::from_str(rs.try_get::<String, _>("role")?.as_str())?,
                         },
                     })
                 }).transpose()
@@ -65,14 +66,14 @@ impl FormCommentDatabase for ConnectionPool {
 
                 comments.into_iter().map(|rs| {
                     Ok::<_, InfraError>(CommentDto {
-                        answer_id: rs.try_get("", "answer_id")?,
-                        comment_id: rs.try_get("", "id")?,
-                        content: rs.try_get("", "content")?,
-                        timestamp: rs.try_get("", "timestamp")?,
+                        answer_id: rs.try_get("answer_id")?,
+                        comment_id: rs.try_get("id")?,
+                        content: rs.try_get("content")?,
+                        timestamp: rs.try_get("timestamp")?,
                         commented_by: UserDto {
-                            name: rs.try_get("", "name")?,
-                            id: rs.try_get("", "commented_by")?,
-                            role: Role::from_str(rs.try_get::<String>("", "role")?.as_str())?,
+                            name: rs.try_get("name")?,
+                            id: rs.try_get("commented_by")?,
+                            role: Role::from_str(rs.try_get::<String, _>("role")?.as_str())?,
                         },
                     })
                 }).collect::<Result<Vec<_>, _>>()
@@ -93,14 +94,14 @@ impl FormCommentDatabase for ConnectionPool {
 
                 comments.into_iter().map(|rs| {
                     Ok::<_, InfraError>(CommentDto {
-                        answer_id: rs.try_get("", "answer_id")?,
-                        comment_id: rs.try_get("", "id")?,
-                        content: rs.try_get("", "content")?,
-                        timestamp: rs.try_get("", "timestamp")?,
+                        answer_id: rs.try_get("answer_id")?,
+                        comment_id: rs.try_get("id")?,
+                        content: rs.try_get("content")?,
+                        timestamp: rs.try_get("timestamp")?,
                         commented_by: UserDto {
-                            name: rs.try_get("", "name")?,
-                            id: rs.try_get("", "commented_by")?,
-                            role: Role::from_str(rs.try_get::<String>("", "role")?.as_str())?,
+                            name: rs.try_get("name")?,
+                            id: rs.try_get("commented_by")?,
+                            role: Role::from_str(rs.try_get::<String, _>("role")?.as_str())?,
                         },
                     })
                 }).collect::<Result<Vec<_>, _>>()
@@ -170,7 +171,7 @@ impl FormCommentDatabase for ConnectionPool {
                     query_one("SELECT COUNT(*) AS count FROM form_answer_comments", txn).await?;
 
                 let size = query
-                    .map(|rs| rs.try_get::<i32>("", "count"))
+                    .map(|rs| rs.try_get::<i32, _>("count"))
                     .transpose()?
                     .unwrap_or(0);
 

--- a/server/infra/resource/src/database/forms/form.rs
+++ b/server/infra/resource/src/database/forms/form.rs
@@ -66,7 +66,6 @@ impl FormDatabase for ConnectionPool {
             })
         })
         .await
-        .map_err(Into::into)
     }
 
     #[tracing::instrument]
@@ -111,7 +110,6 @@ impl FormDatabase for ConnectionPool {
                     }).collect::<Result<Vec<_>, _>>()
             })
         }).await
-            .map_err(Into::into)
     }
 
     #[tracing::instrument]
@@ -152,7 +150,6 @@ impl FormDatabase for ConnectionPool {
                 }))
             })
         }).await
-            .map_err(Into::into)
     }
 
     #[tracing::instrument]
@@ -170,7 +167,6 @@ impl FormDatabase for ConnectionPool {
             })
         })
         .await
-        .map_err(Into::into)
     }
 
     #[tracing::instrument]
@@ -231,7 +227,6 @@ impl FormDatabase for ConnectionPool {
             })
         })
         .await
-        .map_err(Into::into)
     }
 
     #[tracing::instrument]
@@ -249,6 +244,5 @@ impl FormDatabase for ConnectionPool {
             })
         })
         .await
-        .map_err(Into::into)
     }
 }

--- a/server/infra/resource/src/database/forms/form.rs
+++ b/server/infra/resource/src/database/forms/form.rs
@@ -5,7 +5,6 @@ use domain::{
     user::models::User,
 };
 use errors::infra::InfraError;
-use futures::future::try_join3;
 use types::non_empty_string::NonEmptyString;
 
 use crate::database::connection::query_one;
@@ -42,28 +41,24 @@ impl FormDatabase for ConnectionPool {
                 )
                 .await?;
 
-                let insert_default_answer_title_table = execute_and_values(
+                execute_and_values(
                     r"INSERT INTO default_answer_titles (form_id, title) VALUES (?, NULL)",
                     [form_id.to_owned().into_inner().to_string().into()],
                     txn,
-                );
+                )
+                .await?;
 
-                let insert_response_period_table = execute_and_values(
+                execute_and_values(
                     r"INSERT INTO response_period (form_id, start_at, end_at) VALUES (?, NULL, NULL)",
                     [form_id.to_owned().into_inner().to_string().into()],
                     txn,
-                );
+                )
+                .await?;
 
-                let insert_form_webhooks_table = execute_and_values(
+                execute_and_values(
                     r"INSERT INTO form_webhooks (form_id, url) VALUES (?, NULL)",
                     [form_id.to_owned().into_inner().to_string().into()],
                     txn,
-                );
-
-                try_join3(
-                    insert_default_answer_title_table,
-                    insert_response_period_table,
-                    insert_form_webhooks_table,
                 )
                 .await?;
 

--- a/server/infra/resource/src/database/forms/form.rs
+++ b/server/infra/resource/src/database/forms/form.rs
@@ -5,6 +5,7 @@ use domain::{
     user::models::User,
 };
 use errors::infra::InfraError;
+use sqlx::Row;
 use types::non_empty_string::NonEmptyString;
 
 use crate::database::connection::query_one;
@@ -93,19 +94,19 @@ impl FormDatabase for ConnectionPool {
                     .into_iter()
                     .map(|query_rs| {
                         Ok::<_, InfraError>(FormDto {
-                            id: query_rs.try_get("", "form_id")?,
-                            title: query_rs.try_get("", "form_title")?,
-                            description: query_rs.try_get("", "description")?,
+                            id: query_rs.try_get("form_id")?,
+                            title: query_rs.try_get("form_title")?,
+                            description: query_rs.try_get("description")?,
                             metadata: (
-                                query_rs.try_get("", "created_at")?,
-                                query_rs.try_get("", "updated_at")?,
+                                query_rs.try_get("created_at")?,
+                                query_rs.try_get("updated_at")?,
                             ),
-                            start_at: query_rs.try_get("", "start_at")?,
-                            end_at: query_rs.try_get("", "end_at")?,
-                            webhook_url: query_rs.try_get("", "webhook_url")?,
-                            default_answer_title: query_rs.try_get("", "default_answer_title")?,
-                            visibility: query_rs.try_get("", "visibility")?,
-                            answer_visibility: query_rs.try_get("", "answer_visibility")?,
+                            start_at: query_rs.try_get("start_at")?,
+                            end_at: query_rs.try_get("end_at")?,
+                            webhook_url: query_rs.try_get("webhook_url")?,
+                            default_answer_title: query_rs.try_get("default_answer_title")?,
+                            visibility: query_rs.try_get("visibility")?,
+                            answer_visibility: query_rs.try_get("answer_visibility")?,
                         })
                     }).collect::<Result<Vec<_>, _>>()
             })
@@ -135,18 +136,18 @@ impl FormDatabase for ConnectionPool {
 
                 Ok::<_, InfraError>(Some(FormDto {
                     id: form_id.into_inner().to_string(),
-                    title: form.try_get("", "form_title")?,
-                    description: form.try_get("", "description")?,
+                    title: form.try_get("form_title")?,
+                    description: form.try_get("description")?,
                     metadata: (
-                        form.try_get("", "created_at")?,
-                        form.try_get("", "updated_at")?,
+                        form.try_get("created_at")?,
+                        form.try_get("updated_at")?,
                     ),
-                    start_at: form.try_get("", "start_at")?,
-                    end_at: form.try_get("", "end_at")?,
-                    webhook_url: form.try_get("", "webhook_url")?,
-                    default_answer_title: form.try_get("", "default_answer_title")?,
-                    visibility: form.try_get("", "visibility")?,
-                    answer_visibility: form.try_get("", "answer_visibility")?,
+                    start_at: form.try_get("start_at")?,
+                    end_at: form.try_get("end_at")?,
+                    webhook_url: form.try_get("webhook_url")?,
+                    default_answer_title: form.try_get("default_answer_title")?,
+                    visibility: form.try_get("visibility")?,
+                    answer_visibility: form.try_get("answer_visibility")?,
                 }))
             })
         }).await
@@ -236,7 +237,7 @@ impl FormDatabase for ConnectionPool {
                 let query = query_one("SELECT COUNT(*) AS count FROM form_meta_data", txn).await?;
 
                 let size = query
-                    .map(|rs| rs.try_get::<i32>("", "count"))
+                    .map(|rs| rs.try_get::<i32, _>("count"))
                     .transpose()?
                     .unwrap_or(0);
 

--- a/server/infra/resource/src/database/forms/form_label.rs
+++ b/server/infra/resource/src/database/forms/form_label.rs
@@ -37,7 +37,6 @@ impl FormLabelDatabase for ConnectionPool {
             })
         })
         .await
-        .map_err(Into::into)
     }
 
     #[tracing::instrument]
@@ -58,7 +57,6 @@ impl FormLabelDatabase for ConnectionPool {
             })
         })
         .await
-        .map_err(Into::into)
     }
 
     #[tracing::instrument]
@@ -97,7 +95,6 @@ impl FormLabelDatabase for ConnectionPool {
             })
         })
         .await
-        .map_err(Into::into)
     }
 
     #[tracing::instrument]
@@ -115,7 +112,6 @@ impl FormLabelDatabase for ConnectionPool {
             })
         })
         .await
-        .map_err(Into::into)
     }
 
     #[tracing::instrument]
@@ -140,7 +136,6 @@ impl FormLabelDatabase for ConnectionPool {
             })
         })
         .await
-        .map_err(Into::into)
     }
 
     #[tracing::instrument]
@@ -162,7 +157,6 @@ impl FormLabelDatabase for ConnectionPool {
             })
         })
         .await
-        .map_err(Into::into)
     }
 
     #[tracing::instrument]
@@ -192,7 +186,6 @@ impl FormLabelDatabase for ConnectionPool {
             })
         })
         .await
-        .map_err(Into::into)
     }
 
     #[tracing::instrument]
@@ -231,7 +224,6 @@ impl FormLabelDatabase for ConnectionPool {
             })
         })
         .await
-        .map_err(Into::into)
     }
 
     #[tracing::instrument]
@@ -249,6 +241,5 @@ impl FormLabelDatabase for ConnectionPool {
             })
         })
         .await
-        .map_err(Into::into)
     }
 }

--- a/server/infra/resource/src/database/forms/form_label.rs
+++ b/server/infra/resource/src/database/forms/form_label.rs
@@ -2,6 +2,7 @@ use async_trait::async_trait;
 use domain::form::models::{FormId, FormLabel, FormLabelId, FormLabelName};
 use errors::infra::InfraError;
 use itertools::Itertools;
+use sqlx::Row;
 
 use crate::database::connection::query_one;
 use crate::{
@@ -49,8 +50,8 @@ impl FormLabelDatabase for ConnectionPool {
                     .into_iter()
                     .map(|rs| {
                         Ok::<_, InfraError>(FormLabelDto {
-                            id: rs.try_get("", "id")?,
-                            name: rs.try_get("", "name")?,
+                            id: rs.try_get("id")?,
+                            name: rs.try_get("name")?,
                         })
                     })
                     .collect::<Result<Vec<FormLabelDto>, _>>()
@@ -87,8 +88,8 @@ impl FormLabelDatabase for ConnectionPool {
                     .into_iter()
                     .map(|rs| {
                         Ok::<_, InfraError>(FormLabelDto {
-                            id: rs.try_get("", "id")?,
-                            name: rs.try_get("", "name")?,
+                            id: rs.try_get("id")?,
+                            name: rs.try_get("name")?,
                         })
                     })
                     .collect::<Result<Vec<FormLabelDto>, _>>()
@@ -128,8 +129,8 @@ impl FormLabelDatabase for ConnectionPool {
                 label_rs
                     .map(|rs| {
                         Ok::<_, InfraError>(FormLabelDto {
-                            id: rs.try_get("", "id")?,
-                            name: rs.try_get("", "name")?,
+                            id: rs.try_get("id")?,
+                            name: rs.try_get("name")?,
                         })
                     })
                     .transpose()
@@ -178,8 +179,8 @@ impl FormLabelDatabase for ConnectionPool {
                     .into_iter()
                     .map(|rs| {
                         Ok::<_, InfraError>(FormLabelDto {
-                            id: rs.try_get("", "id")?,
-                            name: rs.try_get("", "name")?,
+                            id: rs.try_get("id")?,
+                            name: rs.try_get("name")?,
                         })
                     })
                     .collect::<Result<Vec<FormLabelDto>, _>>()
@@ -233,7 +234,7 @@ impl FormLabelDatabase for ConnectionPool {
                 let query = query_one("SELECT COUNT(*) FROM label_for_forms", txn).await?;
 
                 let size = query
-                    .map(|rs| rs.try_get::<i32>("", "COUNT(*)"))
+                    .map(|rs| rs.try_get::<i32, _>("COUNT(*)"))
                     .transpose()?
                     .unwrap_or(0);
 

--- a/server/infra/resource/src/database/forms/message.rs
+++ b/server/infra/resource/src/database/forms/message.rs
@@ -11,6 +11,7 @@ use domain::{
 };
 use errors::infra::InfraError;
 use itertools::Itertools;
+use sqlx::Row;
 use uuid::Uuid;
 
 use crate::{
@@ -92,16 +93,16 @@ impl FormMessageDatabase for ConnectionPool {
                         rs.into_iter()
                             .map(|rs| {
                                 let user = Ok::<_, InfraError>(UserDto {
-                                    name: rs.try_get("", "name")?,
-                                    id: rs.try_get("", "sender")?,
-                                    role: Role::from_str(&rs.try_get::<String>("", "role")?)?,
+                                    name: rs.try_get("name")?,
+                                    id: rs.try_get("sender")?,
+                                    role: Role::from_str(&rs.try_get::<String, _>("role")?)?,
                                 });
 
                                 Ok::<_, InfraError>((
                                     user?,
-                                    Uuid::from_str(&rs.try_get::<String>("", "message_id")?)?,
-                                    rs.try_get::<String>("", "body")?,
-                                    rs.try_get::<DateTime<Utc>>("", "timestamp")?,
+                                    Uuid::from_str(&rs.try_get::<String, _>("message_id")?)?,
+                                    rs.try_get::<String, _>("body")?,
+                                    rs.try_get::<DateTime<Utc>, _>("timestamp")?,
                                 ))
                             })
                             .collect_vec(),
@@ -142,17 +143,17 @@ impl FormMessageDatabase for ConnectionPool {
 
                 rs.map(|rs| {
                     let user = Ok::<_, InfraError>(UserDto {
-                        name: rs.try_get("", "name")?,
-                        id: rs.try_get("", "sender")?,
-                        role: Role::from_str(&rs.try_get::<String>("", "role")?)?,
+                        name: rs.try_get("name")?,
+                        id: rs.try_get("sender")?,
+                        role: Role::from_str(&rs.try_get::<String, _>("role")?)?,
                     })?;
 
                     Ok::<_, InfraError>(MessageDto {
                         id: message_id.to_owned().to_string(),
-                        related_answer: rs.try_get("", "related_answer_id")?,
+                        related_answer: rs.try_get("related_answer_id")?,
                         sender: user,
-                        body: rs.try_get("", "body")?,
-                        timestamp: rs.try_get("", "timestamp")?,
+                        body: rs.try_get("body")?,
+                        timestamp: rs.try_get("timestamp")?,
                     })
                 })
                 .transpose()

--- a/server/infra/resource/src/database/forms/message.rs
+++ b/server/infra/resource/src/database/forms/message.rs
@@ -46,7 +46,6 @@ impl FormMessageDatabase for ConnectionPool {
                 Ok::<_, InfraError>(())
             })
         }).await
-            .map_err(Into::into)
     }
 
     #[tracing::instrument]
@@ -68,7 +67,6 @@ impl FormMessageDatabase for ConnectionPool {
             })
         })
         .await
-        .map_err(Into::into)
     }
 
     #[tracing::instrument]
@@ -161,7 +159,6 @@ impl FormMessageDatabase for ConnectionPool {
             })
         })
         .await
-        .map_err(Into::into)
     }
 
     #[tracing::instrument]
@@ -179,6 +176,5 @@ impl FormMessageDatabase for ConnectionPool {
             })
         })
         .await
-        .map_err(Into::into)
     }
 }

--- a/server/infra/resource/src/database/forms/question.rs
+++ b/server/infra/resource/src/database/forms/question.rs
@@ -78,7 +78,6 @@ impl FormQuestionDatabase for ConnectionPool {
                 Ok::<_, InfraError>(())
             })
         }).await
-            .map_err(Into::into)
     }
 
     #[tracing::instrument]
@@ -87,89 +86,105 @@ impl FormQuestionDatabase for ConnectionPool {
         form_id: FormId,
         questions: Vec<Question>,
     ) -> Result<(), InfraError> {
-        self.read_write_transaction(|txn| Box::pin(async move {
-            let current_form_question_ids = query_all_and_values(
-                r"SELECT question_id FROM form_questions WHERE form_id = ?",
-                [form_id.into_inner().to_string().into()],
-                txn,
-            ).await?
+        self.read_write_transaction(|txn| {
+            Box::pin(async move {
+                let current_form_question_ids = query_all_and_values(
+                    r"SELECT question_id FROM form_questions WHERE form_id = ?",
+                    [form_id.into_inner().to_string().into()],
+                    txn,
+                )
+                .await?
                 .into_iter()
                 .map(|rs| rs.try_get::<i32>("", "question_id"))
                 .collect::<Result<Vec<_>, DbErr>>()?;
 
-            let delete_target_question_ids = current_form_question_ids
-                .into_iter()
-                .filter(|question_id| {
-                    !questions.iter().any(|question| question.id.map(|id| id.into_inner()) == Some(*question_id))
-                }).collect_vec();
+                let delete_target_question_ids = current_form_question_ids
+                    .into_iter()
+                    .filter(|question_id| {
+                        !questions
+                            .iter()
+                            .any(|question| question.id.map(|id| id.into_inner()) == Some(*question_id))
+                    })
+                    .collect_vec();
 
-            multiple_delete(
-                r"DELETE FROM form_questions WHERE question_id IN (?)",
-                delete_target_question_ids.into_iter().map(|id| id.into()),
-                txn,
-            ).await?;
+                multiple_delete(
+                    r"DELETE FROM form_questions WHERE question_id IN (?)",
+                    delete_target_question_ids.into_iter().map(|id| id.into()),
+                    txn,
+                )
+                .await?;
 
-            batch_insert(
-                r"INSERT INTO form_questions (question_id, form_id, title, description, question_type, is_required)
+                batch_insert(
+                    r"INSERT INTO form_questions (question_id, form_id, title, description, question_type, is_required)
                 VALUES (?, ?, ?, ?, ?, ?)
                 ON DUPLICATE KEY UPDATE
                 title = VALUES(title),
                 description = VALUES(description),
                 question_type = VALUES(question_type),
                 is_required = VALUES(is_required)",
-                questions.iter().flat_map(|question| vec![
-                    question.id.map(|id| id.into_inner()).into(),
-                    form_id.into_inner().to_string().into(),
-                    question.title.clone().into(),
-                    question.description.clone().into(),
-                    question.question_type.to_string().into(),
-                    question.is_required.to_owned().into()]),
-                txn,
-            ).await?;
+                    questions.iter().flat_map(|question| {
+                        vec![
+                            question.id.map(|id| id.into_inner()).into(),
+                            form_id.into_inner().to_string().into(),
+                            question.title.clone().into(),
+                            question.description.clone().into(),
+                            question.question_type.to_string().into(),
+                            question.is_required.to_owned().into(),
+                        ]
+                    }),
+                    txn,
+                )
+                .await?;
 
-            let last_insert_id = query_one(
-                "SELECT question_id FROM form_questions ORDER BY question_id DESC LIMIT 1",
-                txn,
-            )
+                let last_insert_id = query_one(
+                    "SELECT question_id FROM form_questions ORDER BY question_id DESC LIMIT 1",
+                    txn,
+                )
                 .await?
                 .unwrap()
                 .try_get("", "question_id")?;
 
-            let choices_active_values = questions
-                .iter()
-                .rev()
-                .zip((1..=last_insert_id).rev())
-                .filter(|(q, _)| {
-                    !q.choices.is_empty() && q.question_type != domain::form::question::models::QuestionType::TEXT
-                })
-                .flat_map(|(question, question_id)| {
-                    question
-                        .choices
+                let choices_active_values = questions
+                    .iter()
+                    .rev()
+                    .zip((1..=last_insert_id).rev())
+                    .filter(|(q, _)| {
+                        !q.choices.is_empty()
+                            && q.question_type != domain::form::question::models::QuestionType::TEXT
+                    })
+                    .flat_map(|(question, question_id)| {
+                        question
+                            .choices
+                            .iter()
+                            .cloned()
+                            .flat_map(|choice| vec![question_id.to_string(), choice])
+                            .collect_vec()
+                    })
+                    .collect_vec();
+
+                // TODO: 現在の API の仕様上、form_choices で割り当てられているidをバックエンドから送信することはないため、
+                //  ON DUPLICATE KEY UPDATE を使用せずに完全に選択肢を上書きしているが、API の仕様を変更して choice_id を公開し、
+                //  それを使って選択肢の更新を行うべきか検討する
+                multiple_delete(
+                    "DELETE FROM form_choices WHERE question_id IN (?)",
+                    questions
                         .iter()
-                        .cloned()
-                        .flat_map(|choice| vec![question_id.to_string(), choice])
-                        .collect_vec()
-                })
-                .collect_vec();
-
-            // TODO: 現在の API の仕様上、form_choices で割り当てられているidをバックエンドから送信することはないため、
-            //  ON DUPLICATE KEY UPDATE を使用せずに完全に選択肢を上書きしているが、API の仕様を変更して choice_id を公開し、
-            //  それを使って選択肢の更新を行うべきか検討する
-            multiple_delete(
-                "DELETE FROM form_choices WHERE question_id IN (?)",
-                questions.iter().map(|question| question.id.map(|id| id.into_inner()).into()),
-                txn,
-            ).await?;
-
-            batch_insert(
-                r"INSERT INTO form_choices (question_id, choice) VALUES (?, ?)",
-                choices_active_values.into_iter().map(|value| value.into()),
-                txn,
-            )
+                        .map(|question| question.id.map(|id| id.into_inner()).into()),
+                    txn,
+                )
                 .await?;
 
-            Ok::<_, InfraError>(())
-        })).await.map_err(Into::into)
+                batch_insert(
+                    r"INSERT INTO form_choices (question_id, choice) VALUES (?, ?)",
+                    choices_active_values.into_iter().map(|value| value.into()),
+                    txn,
+                )
+                .await?;
+
+                Ok::<_, InfraError>(())
+            })
+        })
+        .await
     }
 
     #[tracing::instrument]
@@ -223,6 +238,5 @@ impl FormQuestionDatabase for ConnectionPool {
                     .collect::<Result<Vec<QuestionDto>, _>>()
             })
         }).await
-            .map_err(Into::into)
     }
 }

--- a/server/infra/resource/src/database/forms/question.rs
+++ b/server/infra/resource/src/database/forms/question.rs
@@ -2,6 +2,7 @@ use async_trait::async_trait;
 use domain::form::{models::FormId, question::models::Question};
 use errors::infra::InfraError;
 use itertools::Itertools;
+use sqlx::Row;
 
 use crate::{
     database::{
@@ -49,7 +50,7 @@ impl FormQuestionDatabase for ConnectionPool {
                 )
                     .await?
                     .unwrap()
-                    .try_get("", "question_id")?;
+                    .try_get("question_id")?;
 
                 let choices_active_values = questions
                     .iter()
@@ -95,7 +96,7 @@ impl FormQuestionDatabase for ConnectionPool {
                 )
                 .await?
                 .into_iter()
-                .map(|rs| rs.try_get::<i32>("", "question_id"))
+                .map(|rs| rs.try_get::<i32, _>("question_id"))
                 .collect::<Result<Vec<_>, DbErr>>()?;
 
                 let delete_target_question_ids = current_form_question_ids
@@ -142,7 +143,7 @@ impl FormQuestionDatabase for ConnectionPool {
                 )
                 .await?
                 .unwrap()
-                .try_get("", "question_id")?;
+                .try_get("question_id")?;
 
                 let choices_active_values = questions
                     .iter()
@@ -209,16 +210,16 @@ impl FormQuestionDatabase for ConnectionPool {
                 questions_rs
                     .into_iter()
                     .map(|question_rs| {
-                        let question_id: i32 = question_rs.try_get("", "question_id")?;
+                        let question_id: i32 = question_rs.try_get("question_id")?;
 
                         let choices = choices_rs
                             .iter()
                             .filter_map(|choice_rs| {
                                 if choice_rs
-                                    .try_get::<i32>("", "question_id")
+                                    .try_get::<i32, _>("question_id")
                                     .is_ok_and(|id| id == question_id)
                                 {
-                                    choice_rs.try_get::<String>("", "choice").ok()
+                                    choice_rs.try_get::<String, _>("choice").ok()
                                 } else {
                                     None
                                 }
@@ -227,12 +228,12 @@ impl FormQuestionDatabase for ConnectionPool {
 
                         Ok::<_, InfraError>(QuestionDto {
                             id: Some(question_id),
-                            form_id: question_rs.try_get("", "form_id")?,
-                            title: question_rs.try_get("", "title")?,
-                            description: question_rs.try_get("", "description")?,
-                            question_type: question_rs.try_get("", "question_type")?,
+                            form_id: question_rs.try_get("form_id")?,
+                            title: question_rs.try_get("title")?,
+                            description: question_rs.try_get("description")?,
+                            question_type: question_rs.try_get("question_type")?,
                             choices,
-                            is_required: question_rs.try_get("", "is_required")?,
+                            is_required: question_rs.try_get("is_required")?,
                         })
                     })
                     .collect::<Result<Vec<QuestionDto>, _>>()

--- a/server/infra/resource/src/database/forms/question.rs
+++ b/server/infra/resource/src/database/forms/question.rs
@@ -2,13 +2,12 @@ use async_trait::async_trait;
 use domain::form::{models::FormId, question::models::Question};
 use errors::infra::InfraError;
 use itertools::Itertools;
-use sea_orm::DbErr;
 
 use crate::{
     database::{
         components::FormQuestionDatabase,
         connection::{
-            ConnectionPool, batch_insert, multiple_delete, query_all_and_values, query_one,
+            ConnectionPool, DbErr, batch_insert, multiple_delete, query_all_and_values, query_one,
         },
     },
     dto::QuestionDto,

--- a/server/infra/resource/src/database/notification.rs
+++ b/server/infra/resource/src/database/notification.rs
@@ -3,6 +3,7 @@ use std::str::FromStr;
 use async_trait::async_trait;
 use domain::{notification::models::NotificationPreference, user::models::Role};
 use errors::infra::InfraError;
+use sqlx::Row;
 use uuid::Uuid;
 
 use crate::{
@@ -68,12 +69,12 @@ impl NotificationDatabase for ConnectionPool {
                 rs.map(|rs| {
                     Ok::<_, InfraError>(NotificationSettingsDto {
                         recipient: UserDto {
-                            name: rs.try_get("", "name")?,
+                            name: rs.try_get("name")?,
                             id: recipient_id.to_string(),
-                            role: Role::from_str(&rs.try_get::<String>("", "role")?)?,
+                            role: Role::from_str(&rs.try_get::<String, _>("role")?)?,
                         },
                         is_send_message_notification: rs
-                            .try_get("", "is_send_message_notification")?,
+                            .try_get("is_send_message_notification")?,
                     })
                 })
                 .transpose()

--- a/server/infra/resource/src/database/notification.rs
+++ b/server/infra/resource/src/database/notification.rs
@@ -45,7 +45,6 @@ impl NotificationDatabase for ConnectionPool {
             })
         })
         .await
-        .map_err(Into::into)
     }
 
     #[tracing::instrument]
@@ -63,7 +62,8 @@ impl NotificationDatabase for ConnectionPool {
                     WHERE user_id = ?",
                     [recipient_id.to_string().into()],
                     txn,
-                ).await?;
+                )
+                .await?;
 
                 rs.map(|rs| {
                     Ok::<_, InfraError>(NotificationSettingsDto {
@@ -72,10 +72,13 @@ impl NotificationDatabase for ConnectionPool {
                             id: recipient_id.to_string(),
                             role: Role::from_str(&rs.try_get::<String>("", "role")?)?,
                         },
-                        is_send_message_notification: rs.try_get("", "is_send_message_notification")?,
+                        is_send_message_notification: rs
+                            .try_get("", "is_send_message_notification")?,
                     })
-                }).transpose()
+                })
+                .transpose()
             })
-        }).await.map_err(Into::into)
+        })
+        .await
     }
 }

--- a/server/infra/resource/src/database/user.rs
+++ b/server/infra/resource/src/database/user.rs
@@ -70,7 +70,6 @@ impl UserDatabase for ConnectionPool {
             })
         })
         .await
-        .map_err(Into::into)
     }
 
     async fn patch_user_role(&self, uuid: Uuid, role: Role) -> Result<(), InfraError> {
@@ -87,7 +86,6 @@ impl UserDatabase for ConnectionPool {
             })
         })
         .await
-        .map_err(Into::into)
     }
 
     async fn fetch_all_users(&self) -> Result<Vec<User>, InfraError> {
@@ -110,7 +108,6 @@ impl UserDatabase for ConnectionPool {
             })
         })
         .await
-        .map_err(Into::into)
     }
 
     async fn start_user_session(
@@ -181,7 +178,6 @@ impl UserDatabase for ConnectionPool {
             })
         })
         .await
-        .map_err(Into::into)
     }
 
     async fn unlink_discord_user(&self, user: &User) -> Result<(), InfraError> {
@@ -200,7 +196,6 @@ impl UserDatabase for ConnectionPool {
             })
         })
         .await
-        .map_err(Into::into)
     }
 
     async fn fetch_discord_user(&self, user: &User) -> Result<Option<DiscordUserDto>, InfraError> {
@@ -244,6 +239,5 @@ impl UserDatabase for ConnectionPool {
             })
         })
         .await
-        .map_err(Into::into)
     }
 }

--- a/server/infra/resource/src/database/user.rs
+++ b/server/infra/resource/src/database/user.rs
@@ -6,6 +6,7 @@ use domain::user::models::{DiscordUser, Role, User};
 use errors::infra::InfraError;
 use redis::Commands;
 use sha256::digest;
+use sqlx::Row;
 use uuid::Uuid;
 
 use crate::database::connection::query_one;
@@ -35,9 +36,9 @@ impl UserDatabase for ConnectionPool {
                     let user = query
                         .map(|rs| {
                             Ok::<User, InfraError>(User {
-                                name: rs.try_get("", "name")?,
+                                name: rs.try_get("name")?,
                                 id: uuid,
-                                role: Role::from_str(&rs.try_get::<String>("", "role")?)?,
+                                role: Role::from_str(&rs.try_get::<String, _>("role")?)?,
                             })
                         })
                         .transpose()?;
@@ -97,9 +98,9 @@ impl UserDatabase for ConnectionPool {
                     .into_iter()
                     .map(|rs| {
                         Ok::<User, InfraError>(User {
-                            name: rs.try_get("", "name")?,
-                            id: Uuid::parse_str(&rs.try_get::<String>("", "id")?)?,
-                            role: Role::from_str(&rs.try_get::<String>("", "role")?)?,
+                            name: rs.try_get("name")?,
+                            id: Uuid::parse_str(&rs.try_get::<String, _>("id")?)?,
+                            role: Role::from_str(&rs.try_get::<String, _>("role")?)?,
                         })
                     })
                     .collect::<Result<Vec<User>, InfraError>>()?;
@@ -215,8 +216,8 @@ impl UserDatabase for ConnectionPool {
                     query
                         .map(|rs| {
                             Ok::<_, InfraError>(DiscordUserDto {
-                                user_id: rs.try_get::<String>("", "discord_id")?,
-                                username: rs.try_get::<String>("", "discord_username")?,
+                                user_id: rs.try_get::<String, _>("discord_id")?,
+                                username: rs.try_get::<String, _>("discord_username")?,
                             })
                         })
                         .transpose()
@@ -231,7 +232,7 @@ impl UserDatabase for ConnectionPool {
                 let query = query_one("SELECT COUNT(*) as count FROM users", txn).await?;
 
                 let size = query
-                    .map(|rs| rs.try_get::<i32>("", "count"))
+                    .map(|rs| rs.try_get::<i32, _>("count"))
                     .transpose()?
                     .unwrap_or(0);
 


### PR DESCRIPTION
## 概要
- `ConnectionPool` の RDB 接続を `sea_orm::DatabaseConnection` から `sqlx::MySqlPool` に置き換え、transaction 開始も `START TRANSACTION READ ONLY/READ WRITE` を明示する形へ変更しました。
- 既存 repository の raw SQL は維持したまま、`sqlx` の row / query 実行へ接続する最小ラッパを `connection.rs` に追加し、後続 PR で `query!` 系へ寄せやすい土台を作りました。
- migration だけはこの PR では既存の SeaORM 基盤を残し、`InfraError::Database` は `sqlx::Error` を source に持つよう更新しました。

## 確認事項
- `cd server && cargo build` を実行し、workspace 全体がビルドできることを確認しました。
- `cd server && cargo test` を実行し、既存 unit test と doctest がすべて成功することを確認しました。
- `cd server && cargo clippy --all-targets --all-features -- -D warnings` を実行し、コミットフック相当の警告なし状態を確認しました。
- 実 DB を起動した状態での `ping_db()` / migration / read-only・read-write transaction の疎通確認は、この環境では未実施です。

## 補足
- `read_only_transaction()` / `read_write_transaction()` の戻り値を `InfraError` に寄せたことで既存の `.map_err(Into::into)` が Clippy 上で不要になったため、この PR では `database` モジュール単位で `clippy::useless_conversion` を抑止しています。後続で repository 側の transaction 呼び出しを整理する余地があります。

🤖 Generated with Codex