### PR TITLE
refactor: forms read系の動的IN句をbindベースに統一する

### DIFF
--- a/server/infra/resource/src/database/forms/answer_label.rs
+++ b/server/infra/resource/src/database/forms/answer_label.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use domain::form::answer::models::{AnswerId, AnswerLabel, AnswerLabelId};
 use errors::infra::InfraError;
 use itertools::Itertools;
-use sqlx::Row;
+use sqlx::{Row, query};
 
 use crate::{
     database::{
@@ -104,17 +104,21 @@ impl FormAnswerLabelDatabase for ConnectionPool {
         let label_ids = label_ids
             .into_iter()
             .map(|id| id.into_inner().to_string())
-            .collect_vec()
-            .join(", ");
+            .collect_vec();
 
         self.read_only_transaction(|txn| {
             Box::pin(async move {
-                let labels_rs = query_all(
-                    format!("SELECT id, name FROM label_for_form_answers WHERE id IN {label_ids}")
-                        .as_str(),
-                    txn,
-                )
-                .await?;
+                let placeholders = std::iter::repeat_n("?", label_ids.len())
+                    .collect_vec()
+                    .join(", ");
+                let sql = format!(
+                    "SELECT id, name FROM label_for_form_answers WHERE id IN ({placeholders})"
+                );
+                let labels_rs = label_ids
+                    .iter()
+                    .fold(query(&sql), |query, label_id| query.bind(label_id))
+                    .fetch_all(&mut **txn)
+                    .await?;
 
                 labels_rs
                     .into_iter()

--- a/server/infra/resource/src/database/forms/answers.rs
+++ b/server/infra/resource/src/database/forms/answers.rs
@@ -10,7 +10,7 @@ use domain::{
 };
 use errors::infra::InfraError;
 use itertools::Itertools;
-use sqlx::Row;
+use sqlx::{Row, query};
 use types::non_empty_string::NonEmptyString;
 use uuid::Uuid;
 
@@ -18,13 +18,37 @@ use crate::{
     database::{
         components::FormAnswerDatabase,
         connection::{
-            ConnectionPool, batch_insert, execute_and_values, query_all, query_all_and_values,
-            query_one_and_values,
+            ConnectionPool, DatabaseTransaction, batch_insert, execute_and_values, query_all,
+            query_all_and_values, query_one_and_values,
         },
         count::count_as_u32,
     },
     dto::{FormAnswerContentDto, FormAnswerDto},
 };
+
+async fn fetch_real_answers_by_answer_ids<T>(
+    txn: &mut DatabaseTransaction,
+    answer_ids: &[T],
+) -> Result<Vec<sqlx::mysql::MySqlRow>, InfraError>
+where
+    T: AsRef<str>,
+{
+    if answer_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let placeholders = std::iter::repeat_n("?", answer_ids.len())
+        .collect_vec()
+        .join(", ");
+    let sql = format!(
+        "SELECT id, question_id, answer, answer_id FROM real_answers WHERE answer_id IN ({placeholders})"
+    );
+    let query = answer_ids.iter().fold(query(&sql), |query, answer_id| {
+        query.bind(answer_id.as_ref())
+    });
+
+    Ok(query.fetch_all(&mut **txn).await?)
+}
 
 #[async_trait]
 impl FormAnswerDatabase for ConnectionPool {
@@ -165,15 +189,7 @@ impl FormAnswerDatabase for ConnectionPool {
 
                 let answer_ids = form_answer_dtos.iter().map(|dto| dto.id.to_owned()).collect_vec();
 
-                let contents = if answer_ids.is_empty() {
-                    Vec::new()
-                } else {
-                    query_all_and_values(
-                        format!("SELECT id, question_id, answer, answer_id FROM real_answers WHERE answer_id IN ({})", vec!["?"; answer_ids.len()].join(",")).as_str(),
-                        answer_ids.into_iter().map(|id| id.to_string().into()),
-                        txn,
-                    ).await?
-                };
+                let contents = fetch_real_answers_by_answer_ids(txn, &answer_ids).await?;
 
 
                 let answer_id_with_content_dto = contents
@@ -288,19 +304,23 @@ impl FormAnswerDatabase for ConnectionPool {
 
         let ids = answer_ids
             .iter()
-            .map(|id| id.into_inner().to_string().into())
+            .map(|id| id.into_inner().to_string())
             .collect_vec();
 
         self.read_only_transaction(|txn| {
             Box::pin(async move {
-                let answers = query_all_and_values(
-                    format!("SELECT form_id, answers.id AS answer_id, title, user, name, role, timestamp FROM answers
+                let placeholders = std::iter::repeat_n("?", ids.len())
+                    .collect_vec()
+                    .join(", ");
+                let sql = format!(
+                    "SELECT form_id, answers.id AS answer_id, title, user, name, role, timestamp FROM answers
                         INNER JOIN users ON answers.user = users.id
-                        WHERE answers.id IN ({})
-                        ORDER BY answers.timestamp", &vec!["?"; ids.len()].iter().join(", ")).as_str(),
-                    ids,
-                    txn,
-                ).await?;
+                        WHERE answers.id IN ({placeholders})
+                        ORDER BY answers.timestamp"
+                );
+                let answers = ids.iter().fold(query(&sql), |query, id| query.bind(id))
+                    .fetch_all(&mut **txn)
+                    .await?;
 
                 let form_answer_dtos = answers
                     .iter()
@@ -321,15 +341,7 @@ impl FormAnswerDatabase for ConnectionPool {
 
                 let answer_ids = form_answer_dtos.iter().map(|dto| dto.id.to_owned()).collect_vec();
 
-                let contents = if answer_ids.is_empty() {
-                    Vec::new()
-                } else {
-                    query_all_and_values(
-                        format!("SELECT id, question_id, answer, answer_id FROM real_answers WHERE answer_id IN ({})", vec!["?"; answer_ids.len()].join(",")).as_str(),
-                        answer_ids.into_iter().map(|id| id.to_string().into()),
-                        txn,
-                    ).await?
-                };
+                let contents = fetch_real_answers_by_answer_ids(txn, &answer_ids).await?;
 
 
                 let answer_id_with_content_dto = contents

--- a/server/infra/resource/src/database/forms/form_label.rs
+++ b/server/infra/resource/src/database/forms/form_label.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use domain::form::models::{FormId, FormLabel, FormLabelId, FormLabelName};
 use errors::infra::InfraError;
 use itertools::Itertools;
-use sqlx::Row;
+use sqlx::{Row, query};
 
 use crate::{
     database::{
@@ -71,18 +71,21 @@ impl FormLabelDatabase for ConnectionPool {
 
         let label_ids = ids
             .into_iter()
-            .map(|id| format!("'{}'", id.into_inner()))
-            .collect_vec()
-            .join(", ");
+            .map(|id| id.into_inner().to_string())
+            .collect_vec();
 
         self.read_only_transaction(|txn| {
             Box::pin(async move {
-                let labels_rs = query_all(
-                    format!("SELECT id, name FROM label_for_forms WHERE id IN ({label_ids})")
-                        .as_str(),
-                    txn,
-                )
-                .await?;
+                let placeholders = std::iter::repeat_n("?", label_ids.len())
+                    .collect_vec()
+                    .join(", ");
+                let sql =
+                    format!("SELECT id, name FROM label_for_forms WHERE id IN ({placeholders})");
+                let labels_rs = label_ids
+                    .iter()
+                    .fold(query(&sql), |query, label_id| query.bind(label_id))
+                    .fetch_all(&mut **txn)
+                    .await?;
 
                 labels_rs
                     .into_iter()


### PR DESCRIPTION
## 概要
- forms 関連の read クエリで、動的な IN 句に使っていた ID の文字列連結をやめ、プレースホルダと bind を組み合わせる形に統一しました。
- `answers.rs` では `real_answers` 取得を private helper に寄せ、複数 answer 指定時の `ORDER BY answers.timestamp` はそのまま維持しています。
- `answer_label.rs` と `form_label.rs` でも空配列時の early return を維持したまま、安全な可変長 IN 条件へ置き換えています。

## 確認事項
- `cd server && cargo build` を実行し、変更後の forms 関連クエリ実装を含めてビルドが通ることを確認しました。
- `cd server && cargo test --all-features` を実行し、既存の unit test と doctest が全件成功することを確認しました。
- 追加の DB integration test はこのリポジトリに既存パターンが見当たらず、今回は導入していません。レビューでは複数 ID 指定時の取得結果が従来どおりかを重点的に見てもらえると助かります。

## 補足
- `QueryBuilder` 案から、プレースホルダ文字列と `sqlx::query(...).bind(...)` の組み合わせへ実装方針を調整しています。

🤖 Generated with Codex
