### PR TITLE
refactor: bulk SQL helperを廃止して呼び出し側で明示する

### DIFF
--- a/server/infra/resource/src/database/connection.rs
+++ b/server/infra/resource/src/database/connection.rs
@@ -1,10 +1,8 @@
 use std::{fmt::Debug, future::Future, pin::Pin};
 
 use async_trait::async_trait;
-use itertools::Itertools;
 use migration::MigratorTrait;
 use redis::Client;
-use regex::Regex;
 use sea_orm::{Database, Value};
 use sqlx::{
     MySql,
@@ -308,78 +306,6 @@ where
     I: IntoIterator<Item = Value>,
 {
     bind_values(sql, values)?.execute(&mut **transaction).await
-}
-
-pub async fn batch_insert<I>(
-    sql: &str,
-    params: I,
-    transaction: &mut DatabaseTransaction,
-) -> Result<Option<ExecResult>, DbErr>
-where
-    I: IntoIterator<Item = Value>,
-{
-    let regex = Regex::new(r"\((\?,\s*)+\?\)").unwrap();
-    let insert_part_opt = regex.find(sql);
-
-    assert!(
-        insert_part_opt.is_some(),
-        "SQL insert params must be exists."
-    );
-
-    let params_vec = params.into_iter().collect::<Vec<_>>();
-
-    if params_vec.is_empty() {
-        Ok(None)
-    } else {
-        let insert_part = insert_part_opt.unwrap().as_str();
-
-        Ok(Some(
-            bind_values(
-                &sql.replace(
-                    insert_part,
-                    &std::iter::repeat_n(
-                        insert_part,
-                        params_vec.len() / insert_part.matches('?').count(),
-                    )
-                    .join(", "),
-                ),
-                params_vec,
-            )?
-            .execute(&mut **transaction)
-            .await?,
-        ))
-    }
-}
-
-pub async fn multiple_delete<I>(
-    sql: &str,
-    params: I,
-    transaction: &mut DatabaseTransaction,
-) -> Result<Option<ExecResult>, DbErr>
-where
-    I: IntoIterator<Item = Value>,
-{
-    let params_vec = params.into_iter().collect::<Vec<_>>();
-
-    if params_vec.is_empty() {
-        Ok(None)
-    } else {
-        Ok(Some(
-            bind_values(
-                &sql.replace(
-                    "(?)",
-                    format!(
-                        "({})",
-                        std::iter::repeat_n("?", params_vec.len()).join(", ")
-                    )
-                    .as_str(),
-                ),
-                params_vec,
-            )?
-            .execute(&mut **transaction)
-            .await?,
-        ))
-    }
 }
 
 pub async fn redis_connection() -> Client {

--- a/server/infra/resource/src/database/forms/answer_label.rs
+++ b/server/infra/resource/src/database/forms/answer_label.rs
@@ -7,10 +7,7 @@ use sqlx::{Row, query};
 use crate::{
     database::{
         components::FormAnswerLabelDatabase,
-        connection::{
-            ConnectionPool, batch_insert, execute_and_values, multiple_delete, query_all,
-            query_all_and_values,
-        },
+        connection::{ConnectionPool, execute_and_values, query_all, query_all_and_values},
         count::count_as_u32,
     },
     dto::AnswerLabelDto,
@@ -211,32 +208,34 @@ impl FormAnswerLabelDatabase for ConnectionPool {
         answer_id: AnswerId,
         label_ids: Vec<AnswerLabelId>,
     ) -> Result<(), InfraError> {
+        let answer_id = answer_id.into_inner().to_string();
+
         self.read_write_transaction(|txn| {
             Box::pin(async move {
-                multiple_delete(
+                execute_and_values(
                     "DELETE FROM label_settings_for_form_answers WHERE answer_id = ?",
-                    vec![answer_id.into_inner().to_string().into()],
+                    [answer_id.clone().into()],
                     txn,
                 )
                 .await?;
 
-                let params = label_ids
-                    .into_iter()
-                    .flat_map(|label_id| {
-                        [
-                            answer_id.into_inner().to_string().into(),
-                            label_id.into_inner().to_string().into(),
-                        ]
-                    })
-                    .collect_vec();
+                if !label_ids.is_empty() {
+                    let label_ids = label_ids
+                        .into_iter()
+                        .map(|label_id| label_id.into_inner().to_string())
+                        .collect_vec();
+                    let sql = format!(
+                        "INSERT INTO label_settings_for_form_answers (answer_id, label_id) VALUES {}",
+                        std::iter::repeat_n("(?, ?)", label_ids.len()).join(", ")
+                    );
 
-                batch_insert(
-                    "INSERT INTO label_settings_for_form_answers (answer_id, label_id) VALUES (?, \
-                     ?)",
-                    params,
-                    txn,
-                )
-                .await?;
+                    label_ids
+                        .into_iter()
+                        .flat_map(|label_id| [answer_id.clone(), label_id])
+                        .fold(query(&sql), |query, value| query.bind(value))
+                        .execute(&mut **txn)
+                        .await?;
+                }
 
                 Ok::<_, InfraError>(())
             })

--- a/server/infra/resource/src/database/forms/answers.rs
+++ b/server/infra/resource/src/database/forms/answers.rs
@@ -18,7 +18,7 @@ use crate::{
     database::{
         components::FormAnswerDatabase,
         connection::{
-            ConnectionPool, DatabaseTransaction, batch_insert, execute_and_values, query_all,
+            ConnectionPool, DatabaseTransaction, execute_and_values, query_all,
             query_all_and_values, query_one_and_values,
         },
         count::count_as_u32,
@@ -64,17 +64,12 @@ impl FormAnswerDatabase for ConnectionPool {
             .contents()
             .as_slice()
             .iter()
-            .flat_map(|content| {
-                [
-                    answer_id.to_owned().into(),
-                    content
-                        .question_id
-                        .to_owned()
-                        .into_inner()
-                        .to_string()
-                        .into(),
-                    content.answer.to_owned().into(),
-                ]
+            .map(|content| {
+                (
+                    answer_id.clone(),
+                    content.question_id.to_owned().into_inner().to_string(),
+                    content.answer.to_owned(),
+                )
             })
             .collect::<Vec<_>>();
 
@@ -93,12 +88,19 @@ impl FormAnswerDatabase for ConnectionPool {
                 )
                 .await?;
 
-                batch_insert(
-                    r"INSERT INTO real_answers (answer_id, question_id, answer) VALUES (?, ?, ?)",
-                    contents,
-                    txn,
-                )
-                .await?;
+                if !contents.is_empty() {
+                    let sql = format!(
+                        "INSERT INTO real_answers (answer_id, question_id, answer) VALUES {}",
+                        std::iter::repeat_n("(?, ?, ?)", contents.len()).join(", ")
+                    );
+
+                    contents
+                        .into_iter()
+                        .flat_map(|(answer_id, question_id, answer)| [answer_id, question_id, answer])
+                        .fold(query(&sql), |query, value| query.bind(value))
+                        .execute(&mut **txn)
+                        .await?;
+                }
 
                 Ok::<_, InfraError>(())
             })

--- a/server/infra/resource/src/database/forms/form_label.rs
+++ b/server/infra/resource/src/database/forms/form_label.rs
@@ -8,8 +8,8 @@ use crate::{
     database::{
         components::FormLabelDatabase,
         connection::{
-            ConnectionPool, batch_insert, execute_and_values, multiple_delete, query_all,
-            query_all_and_values, query_one_and_values,
+            ConnectionPool, execute_and_values, query_all, query_all_and_values,
+            query_one_and_values,
         },
         count::count_as_u32,
     },
@@ -198,31 +198,34 @@ impl FormLabelDatabase for ConnectionPool {
         form_id: FormId,
         label_ids: Vec<FormLabelId>,
     ) -> Result<(), InfraError> {
+        let form_id = form_id.into_inner().to_string();
+
         self.read_write_transaction(|txn| {
             Box::pin(async move {
-                multiple_delete(
+                execute_and_values(
                     "DELETE FROM label_settings_for_forms WHERE form_id = ?",
-                    vec![form_id.into_inner().to_string().into()],
+                    [form_id.clone().into()],
                     txn,
                 )
                 .await?;
 
-                let params = label_ids
-                    .into_iter()
-                    .flat_map(|label_id| {
-                        [
-                            form_id.into_inner().to_string().into(),
-                            label_id.into_inner().to_string().into(),
-                        ]
-                    })
-                    .collect_vec();
+                if !label_ids.is_empty() {
+                    let label_ids = label_ids
+                        .into_iter()
+                        .map(|label_id| label_id.into_inner().to_string())
+                        .collect_vec();
+                    let sql = format!(
+                        "INSERT INTO label_settings_for_forms (form_id, label_id) VALUES {}",
+                        std::iter::repeat_n("(?, ?)", label_ids.len()).join(", ")
+                    );
 
-                batch_insert(
-                    "INSERT INTO label_settings_for_forms (form_id, label_id) VALUES (?, ?)",
-                    params,
-                    txn,
-                )
-                .await?;
+                    label_ids
+                        .into_iter()
+                        .flat_map(|label_id| [form_id.clone(), label_id])
+                        .fold(query(&sql), |query, value| query.bind(value))
+                        .execute(&mut **txn)
+                        .await?;
+                }
 
                 Ok::<_, InfraError>(())
             })

--- a/server/infra/resource/src/database/forms/question.rs
+++ b/server/infra/resource/src/database/forms/question.rs
@@ -2,14 +2,12 @@ use async_trait::async_trait;
 use domain::form::{models::FormId, question::models::Question};
 use errors::infra::InfraError;
 use itertools::Itertools;
-use sqlx::Row;
+use sqlx::{Row, query};
 
 use crate::{
     database::{
         components::FormQuestionDatabase,
-        connection::{
-            ConnectionPool, DbErr, batch_insert, multiple_delete, query_all_and_values, query_one,
-        },
+        connection::{ConnectionPool, DbErr, query_all_and_values, query_one},
     },
     dto::QuestionDto,
 };
@@ -22,59 +20,70 @@ impl FormQuestionDatabase for ConnectionPool {
         form_id: FormId,
         questions: Vec<Question>,
     ) -> Result<(), InfraError> {
-        let form_id = form_id.to_owned();
         let questions = questions.to_owned();
+        let form_id = form_id.into_inner().to_string();
 
         self.read_write_transaction(|txn| {
             Box::pin(async move {
-                batch_insert(
-                    r"INSERT INTO form_questions (form_id, title, description, question_type, is_required) VALUES (?, ?, ?, ?, ?)",
-                    questions
-                        .clone()
-                        .into_iter()
-                        .flat_map(|question|
-                            vec![
-                                form_id.into_inner().to_string().into(),
-                                question.title.clone().into(),
-                                question.description.clone().into(),
-                                question.question_type.to_string().into(),
-                                (*question.is_required()).into()
-                            ]
-                        ).collect_vec(),
-                    txn,
-                ).await?;
+                if !questions.is_empty() {
+                    let sql = format!(
+                        "INSERT INTO form_questions (form_id, title, description, question_type, is_required) VALUES {}",
+                        std::iter::repeat_n("(?, ?, ?, ?, ?)", questions.len()).join(", ")
+                    );
 
-                let last_insert_id = query_one(
-                    "SELECT question_id FROM form_questions ORDER BY question_id DESC LIMIT 1",
-                    txn,
-                )
+                    questions
+                        .iter()
+                        .fold(query(&sql), |query, question| {
+                            query
+                                .bind(form_id.clone())
+                                .bind(question.title.clone())
+                                .bind(question.description.clone())
+                                .bind(question.question_type.to_string())
+                                .bind(*question.is_required())
+                        })
+                        .execute(&mut **txn)
+                        .await?;
+
+                    let last_insert_id = query_one(
+                        "SELECT question_id FROM form_questions ORDER BY question_id DESC LIMIT 1",
+                        txn,
+                    )
                     .await?
                     .unwrap()
                     .try_get("question_id")?;
 
-                let choices_active_values = questions
-                    .iter()
-                    .rev()
-                    .zip((1..=last_insert_id).rev())
-                    .filter(|(q, _)| {
-                        !q.choices.is_empty() && q.question_type != domain::form::question::models::QuestionType::TEXT
-                    })
-                    .flat_map(|(question, question_id)| {
-                        question
-                            .choices
-                            .iter()
-                            .cloned()
-                            .flat_map(|choice| vec![question_id.to_string(), choice])
-                            .collect_vec()
-                    })
-                    .collect_vec();
+                    let choices_active_values = questions
+                        .iter()
+                        .rev()
+                        .zip((1..=last_insert_id).rev())
+                        .filter(|(q, _)| {
+                            !q.choices.is_empty()
+                                && q.question_type
+                                    != domain::form::question::models::QuestionType::TEXT
+                        })
+                        .flat_map(|(question, question_id)| {
+                            question
+                                .choices
+                                .iter()
+                                .cloned()
+                                .map(move |choice| (question_id.to_string(), choice))
+                        })
+                        .collect_vec();
 
-                batch_insert(
-                    "INSERT INTO form_choices (question_id, choice) VALUES (?, ?)",
-                    choices_active_values.into_iter().map(|value| value.into()),
-                    txn,
-                )
-                    .await?;
+                    if !choices_active_values.is_empty() {
+                        let sql = format!(
+                            "INSERT INTO form_choices (question_id, choice) VALUES {}",
+                            std::iter::repeat_n("(?, ?)", choices_active_values.len()).join(", ")
+                        );
+
+                        choices_active_values
+                            .into_iter()
+                            .flat_map(|(question_id, choice)| [question_id, choice])
+                            .fold(query(&sql), |query, value| query.bind(value))
+                            .execute(&mut **txn)
+                            .await?;
+                    }
+                }
 
                 Ok::<_, InfraError>(())
             })
@@ -87,11 +96,13 @@ impl FormQuestionDatabase for ConnectionPool {
         form_id: FormId,
         questions: Vec<Question>,
     ) -> Result<(), InfraError> {
+        let form_id = form_id.into_inner().to_string();
+
         self.read_write_transaction(|txn| {
             Box::pin(async move {
                 let current_form_question_ids = query_all_and_values(
                     r"SELECT question_id FROM form_questions WHERE form_id = ?",
-                    [form_id.into_inner().to_string().into()],
+                    [form_id.clone().into()],
                     txn,
                 )
                 .await?
@@ -108,79 +119,106 @@ impl FormQuestionDatabase for ConnectionPool {
                     })
                     .collect_vec();
 
-                multiple_delete(
-                    r"DELETE FROM form_questions WHERE question_id IN (?)",
-                    delete_target_question_ids.into_iter().map(|id| id.into()),
-                    txn,
-                )
-                .await?;
+                if !delete_target_question_ids.is_empty() {
+                    let sql = format!(
+                        "DELETE FROM form_questions WHERE question_id IN ({})",
+                        std::iter::repeat_n("?", delete_target_question_ids.len()).join(", ")
+                    );
 
-                batch_insert(
-                    r"INSERT INTO form_questions (question_id, form_id, title, description, question_type, is_required)
-                VALUES (?, ?, ?, ?, ?, ?)
+                    delete_target_question_ids
+                        .iter()
+                        .fold(query(&sql), |query, question_id| query.bind(question_id))
+                        .execute(&mut **txn)
+                        .await?;
+                }
+
+                if !questions.is_empty() {
+                    let sql = format!(
+                        r"INSERT INTO form_questions (question_id, form_id, title, description, question_type, is_required)
+                VALUES {}
                 ON DUPLICATE KEY UPDATE
                 title = VALUES(title),
                 description = VALUES(description),
                 question_type = VALUES(question_type),
                 is_required = VALUES(is_required)",
-                    questions.iter().flat_map(|question| {
-                        vec![
-                            question.id.map(|id| id.into_inner()).into(),
-                            form_id.into_inner().to_string().into(),
-                            question.title.clone().into(),
-                            question.description.clone().into(),
-                            question.question_type.to_string().into(),
-                            question.is_required.to_owned().into(),
-                        ]
-                    }),
-                    txn,
-                )
-                .await?;
+                        std::iter::repeat_n("(?, ?, ?, ?, ?, ?)", questions.len()).join(", ")
+                    );
 
-                let last_insert_id = query_one(
-                    "SELECT question_id FROM form_questions ORDER BY question_id DESC LIMIT 1",
-                    txn,
-                )
-                .await?
-                .unwrap()
-                .try_get("question_id")?;
-
-                let choices_active_values = questions
-                    .iter()
-                    .rev()
-                    .zip((1..=last_insert_id).rev())
-                    .filter(|(q, _)| {
-                        !q.choices.is_empty()
-                            && q.question_type != domain::form::question::models::QuestionType::TEXT
-                    })
-                    .flat_map(|(question, question_id)| {
-                        question
-                            .choices
-                            .iter()
-                            .cloned()
-                            .flat_map(|choice| vec![question_id.to_string(), choice])
-                            .collect_vec()
-                    })
-                    .collect_vec();
-
-                // TODO: 現在の API の仕様上、form_choices で割り当てられているidをバックエンドから送信することはないため、
-                //  ON DUPLICATE KEY UPDATE を使用せずに完全に選択肢を上書きしているが、API の仕様を変更して choice_id を公開し、
-                //  それを使って選択肢の更新を行うべきか検討する
-                multiple_delete(
-                    "DELETE FROM form_choices WHERE question_id IN (?)",
                     questions
                         .iter()
-                        .map(|question| question.id.map(|id| id.into_inner()).into()),
-                    txn,
-                )
-                .await?;
+                        .fold(query(&sql), |query, question| {
+                            query
+                                .bind(question.id.map(|id| id.into_inner()))
+                                .bind(form_id.clone())
+                                .bind(question.title.clone())
+                                .bind(question.description.clone())
+                                .bind(question.question_type.to_string())
+                                .bind(*question.is_required())
+                        })
+                        .execute(&mut **txn)
+                        .await?;
 
-                batch_insert(
-                    r"INSERT INTO form_choices (question_id, choice) VALUES (?, ?)",
-                    choices_active_values.into_iter().map(|value| value.into()),
-                    txn,
-                )
-                .await?;
+                    let last_insert_id = query_one(
+                        "SELECT question_id FROM form_questions ORDER BY question_id DESC LIMIT 1",
+                        txn,
+                    )
+                    .await?
+                    .unwrap()
+                    .try_get("question_id")?;
+
+                    let choices_active_values = questions
+                        .iter()
+                        .rev()
+                        .zip((1..=last_insert_id).rev())
+                        .filter(|(q, _)| {
+                            !q.choices.is_empty()
+                                && q.question_type
+                                    != domain::form::question::models::QuestionType::TEXT
+                        })
+                        .flat_map(|(question, question_id)| {
+                            question
+                                .choices
+                                .iter()
+                                .cloned()
+                                .map(move |choice| (question_id.to_string(), choice))
+                        })
+                        .collect_vec();
+
+                    let current_question_ids = questions
+                        .iter()
+                        .filter_map(|question| question.id.map(|id| id.into_inner()))
+                        .collect_vec();
+
+                    // TODO: 現在の API の仕様上、form_choices で割り当てられているidをバックエンドから送信することはないため、
+                    //  ON DUPLICATE KEY UPDATE を使用せずに完全に選択肢を上書きしているが、API の仕様を変更して choice_id を公開し、
+                    //  それを使って選択肢の更新を行うべきか検討する
+                    if !current_question_ids.is_empty() {
+                        let sql = format!(
+                            "DELETE FROM form_choices WHERE question_id IN ({})",
+                            std::iter::repeat_n("?", current_question_ids.len()).join(", ")
+                        );
+
+                        current_question_ids
+                            .iter()
+                            .fold(query(&sql), |query, question_id| query.bind(question_id))
+                            .execute(&mut **txn)
+                            .await?;
+                    }
+
+                    if !choices_active_values.is_empty() {
+                        let sql = format!(
+                            "INSERT INTO form_choices (question_id, choice) VALUES {}",
+                            std::iter::repeat_n("(?, ?)", choices_active_values.len()).join(", ")
+                        );
+
+                        choices_active_values
+                            .into_iter()
+                            .flat_map(|(question_id, choice)| [question_id, choice])
+                            .fold(query(&sql), |query, value| query.bind(value))
+                            .execute(&mut **txn)
+                            .await?;
+                    }
+                }
 
                 Ok::<_, InfraError>(())
             })


### PR DESCRIPTION
## 概要
- sqlx 移行後も残っていた `batch_insert` / `multiple_delete` を削除し、Regex ベースの SQL 書き換えをやめました
- `question` / `form_label` / `answer_label` / `answers` の bulk insert と可変長 `IN` delete を、`sqlx::query(...).fold(...).execute(...)` でその場で構築する形に揃えました
- 空配列入力時は対象 SQL を発行しないようにして、実際に発行する SQL と bind の対応を各 repository から追えるようにしました

## 確認事項
- `cargo build` を実行し、変更後もワークスペース全体がビルドできることを確認しました
- `cargo clippy -- -D warnings` を実行し、warning なしで通ることを確認しました
- `cargo test --all-features` を実行し、ユニットテストと doctest が通ることを確認しました
- `cargo sqlx prepare --check --workspace` は未実行です。今回の変更では `query!` / `query_as!` を追加しておらず、sqlx メタデータ更新の対象がないためです

🤖 Generated with Codex