### PR TITLE
refactor: forms write系を sqlx に統一する

### DIFF
--- a/server/.sqlx/query-07ac0cce4e5c2f55033622ac0f5c519be0e43251e1e8290d82dbe6c35980ab14.json
+++ b/server/.sqlx/query-07ac0cce4e5c2f55033622ac0f5c519be0e43251e1e8290d82dbe6c35980ab14.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "MySQL",
+  "query": "DELETE FROM label_settings_for_forms WHERE form_id = ?",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": []
+  },
+  "hash": "07ac0cce4e5c2f55033622ac0f5c519be0e43251e1e8290d82dbe6c35980ab14"
+}

--- a/server/.sqlx/query-160286bbed082be2b3bf152be15ba2654c59247fc04befd49a9dfac7e9fdad59.json
+++ b/server/.sqlx/query-160286bbed082be2b3bf152be15ba2654c59247fc04befd49a9dfac7e9fdad59.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "MySQL",
+  "query": "UPDATE label_for_forms SET name = ? WHERE id = ?",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": []
+  },
+  "hash": "160286bbed082be2b3bf152be15ba2654c59247fc04befd49a9dfac7e9fdad59"
+}

--- a/server/.sqlx/query-1a11d223e4370e5fc504ca5180df3c2ac3df90addd95df32825c89785a8d8c03.json
+++ b/server/.sqlx/query-1a11d223e4370e5fc504ca5180df3c2ac3df90addd95df32825c89785a8d8c03.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "MySQL",
+  "query": "INSERT INTO form_answer_comments (id, answer_id, commented_by, content)\n                        VALUES (?, ?, ?, ?)\n                        ON DUPLICATE KEY UPDATE\n                        content = VALUES(content)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 4
+    },
+    "nullable": []
+  },
+  "hash": "1a11d223e4370e5fc504ca5180df3c2ac3df90addd95df32825c89785a8d8c03"
+}

--- a/server/.sqlx/query-1a53cae351874480841323474e5cac07f3d5c65ede8e716faff639a9c89dfae5.json
+++ b/server/.sqlx/query-1a53cae351874480841323474e5cac07f3d5c65ede8e716faff639a9c89dfae5.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "MySQL",
+  "query": "INSERT INTO messages (id, related_answer_id, sender, body, timestamp) VALUES (?, ?, ?, ?, ?)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 5
+    },
+    "nullable": []
+  },
+  "hash": "1a53cae351874480841323474e5cac07f3d5c65ede8e716faff639a9c89dfae5"
+}

--- a/server/.sqlx/query-42082bf024bc86aff3a805aaddf1f5dcaeadaf7fc2fc659db82dee60d1eb86e8.json
+++ b/server/.sqlx/query-42082bf024bc86aff3a805aaddf1f5dcaeadaf7fc2fc659db82dee60d1eb86e8.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "MySQL",
+  "query": "DELETE FROM form_meta_data WHERE id = ?",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": []
+  },
+  "hash": "42082bf024bc86aff3a805aaddf1f5dcaeadaf7fc2fc659db82dee60d1eb86e8"
+}

--- a/server/.sqlx/query-56f29d67b203f9c1a9e4b7d8896389d101d139cca09c77fb06dcf78011cab6c1.json
+++ b/server/.sqlx/query-56f29d67b203f9c1a9e4b7d8896389d101d139cca09c77fb06dcf78011cab6c1.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "MySQL",
+  "query": "INSERT INTO form_meta_data (id, title, description, created_by, updated_by)\n                            VALUES (?, ?, ?, ?, ?)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 5
+    },
+    "nullable": []
+  },
+  "hash": "56f29d67b203f9c1a9e4b7d8896389d101d139cca09c77fb06dcf78011cab6c1"
+}

--- a/server/.sqlx/query-675e161d1a4b6559171b40afefce83370aa4408d8d44b23b7c9c31eb3f1c396c.json
+++ b/server/.sqlx/query-675e161d1a4b6559171b40afefce83370aa4408d8d44b23b7c9c31eb3f1c396c.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "MySQL",
+  "query": "INSERT INTO label_for_forms (id, name) VALUES (?, ?)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": []
+  },
+  "hash": "675e161d1a4b6559171b40afefce83370aa4408d8d44b23b7c9c31eb3f1c396c"
+}

--- a/server/.sqlx/query-694abbbdff1afed7d8db6c0baf769044c34af478d521cb6177fd838dc5fd25da.json
+++ b/server/.sqlx/query-694abbbdff1afed7d8db6c0baf769044c34af478d521cb6177fd838dc5fd25da.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "MySQL",
+  "query": "DELETE FROM label_for_form_answers WHERE id = ?",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": []
+  },
+  "hash": "694abbbdff1afed7d8db6c0baf769044c34af478d521cb6177fd838dc5fd25da"
+}

--- a/server/.sqlx/query-6ac654e6bddfa24c74bde58b512a2c7f0bb788f337141376571dd93cc2c653df.json
+++ b/server/.sqlx/query-6ac654e6bddfa24c74bde58b512a2c7f0bb788f337141376571dd93cc2c653df.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "MySQL",
+  "query": "DELETE FROM messages WHERE id = ?",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": []
+  },
+  "hash": "6ac654e6bddfa24c74bde58b512a2c7f0bb788f337141376571dd93cc2c653df"
+}

--- a/server/.sqlx/query-7010422134954f5766bb078c8bb450bb90e9a463d48dfb5ab15ee9c524b72c92.json
+++ b/server/.sqlx/query-7010422134954f5766bb078c8bb450bb90e9a463d48dfb5ab15ee9c524b72c92.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "MySQL",
+  "query": "UPDATE form_meta_data SET\n                    title = ?,\n                    description = ?,\n                    visibility = ?,\n                    answer_visibility = ?,\n                    updated_by = ?\n                    WHERE id = ?\n                    ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 6
+    },
+    "nullable": []
+  },
+  "hash": "7010422134954f5766bb078c8bb450bb90e9a463d48dfb5ab15ee9c524b72c92"
+}

--- a/server/.sqlx/query-82421e55a0f9a1a4b3bafd49392970da5892a7efa06e14aa5cc6a6eb04e9758f.json
+++ b/server/.sqlx/query-82421e55a0f9a1a4b3bafd49392970da5892a7efa06e14aa5cc6a6eb04e9758f.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "MySQL",
+  "query": "UPDATE messages SET body = ? WHERE id = ?",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": []
+  },
+  "hash": "82421e55a0f9a1a4b3bafd49392970da5892a7efa06e14aa5cc6a6eb04e9758f"
+}

--- a/server/.sqlx/query-8fb3e69485549fb9bdf3c25a9e8040958825609fd5ae9aced313c05ed4f3974f.json
+++ b/server/.sqlx/query-8fb3e69485549fb9bdf3c25a9e8040958825609fd5ae9aced313c05ed4f3974f.json
@@ -1,0 +1,24 @@
+{
+  "db_name": "MySQL",
+  "query": "SELECT question_id AS `question_id!: i32` FROM form_questions ORDER BY question_id DESC LIMIT 1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "question_id!: i32",
+        "type_info": {
+          "type": "Long",
+          "flags": "NOT_NULL | PRIMARY_KEY | AUTO_INCREMENT",
+          "max_size": 11
+        }
+      }
+    ],
+    "parameters": {
+      "Right": 0
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "8fb3e69485549fb9bdf3c25a9e8040958825609fd5ae9aced313c05ed4f3974f"
+}

--- a/server/.sqlx/query-934eef7426c4e1ac3681df269053ecb7478cca001ce3197088b05095bfa0cb61.json
+++ b/server/.sqlx/query-934eef7426c4e1ac3681df269053ecb7478cca001ce3197088b05095bfa0cb61.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "MySQL",
+  "query": "INSERT INTO answers (id, form_id, user, title)\n                    VALUES (?, ?, ?, ?)\n                    ON DUPLICATE KEY UPDATE\n                    title = VALUES(title)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 4
+    },
+    "nullable": []
+  },
+  "hash": "934eef7426c4e1ac3681df269053ecb7478cca001ce3197088b05095bfa0cb61"
+}

--- a/server/.sqlx/query-95867ae34d9797c050b08c2e6f7fbd7c451f45ff28a49c47cb334c91e88e3b35.json
+++ b/server/.sqlx/query-95867ae34d9797c050b08c2e6f7fbd7c451f45ff28a49c47cb334c91e88e3b35.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "MySQL",
+  "query": "DELETE FROM label_settings_for_form_answers WHERE answer_id = ?",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": []
+  },
+  "hash": "95867ae34d9797c050b08c2e6f7fbd7c451f45ff28a49c47cb334c91e88e3b35"
+}

--- a/server/.sqlx/query-9be430b8f989ac720f0fa12772fca1c1fa6a935c621653d20abb5d93febe5da9.json
+++ b/server/.sqlx/query-9be430b8f989ac720f0fa12772fca1c1fa6a935c621653d20abb5d93febe5da9.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "MySQL",
+  "query": "INSERT INTO default_answer_titles (form_id, title) VALUES (?, NULL)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": []
+  },
+  "hash": "9be430b8f989ac720f0fa12772fca1c1fa6a935c621653d20abb5d93febe5da9"
+}

--- a/server/.sqlx/query-a18e7ffad9ac7dbc4f1de0623ca370da9e67c5b6be20fa9de9993967fd6eddf2.json
+++ b/server/.sqlx/query-a18e7ffad9ac7dbc4f1de0623ca370da9e67c5b6be20fa9de9993967fd6eddf2.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "MySQL",
+  "query": "INSERT INTO label_for_form_answers (id, name) VALUES (?, ?)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": []
+  },
+  "hash": "a18e7ffad9ac7dbc4f1de0623ca370da9e67c5b6be20fa9de9993967fd6eddf2"
+}

--- a/server/.sqlx/query-a496aba50cba51370c7c0afcedd07bce1b37ee4dbd9dbeac11dcb4bb563d126e.json
+++ b/server/.sqlx/query-a496aba50cba51370c7c0afcedd07bce1b37ee4dbd9dbeac11dcb4bb563d126e.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "MySQL",
+  "query": "INSERT INTO form_webhooks (form_id, url) VALUES (?, NULL)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": []
+  },
+  "hash": "a496aba50cba51370c7c0afcedd07bce1b37ee4dbd9dbeac11dcb4bb563d126e"
+}

--- a/server/.sqlx/query-b268e0b0894878830caef23bef8f6c63eb71614047477221d0e758c9842713c5.json
+++ b/server/.sqlx/query-b268e0b0894878830caef23bef8f6c63eb71614047477221d0e758c9842713c5.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "MySQL",
+  "query": "INSERT INTO answers (id, form_id, user, title, timestamp) VALUES (?, ?, ?, ?, ?)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 5
+    },
+    "nullable": []
+  },
+  "hash": "b268e0b0894878830caef23bef8f6c63eb71614047477221d0e758c9842713c5"
+}

--- a/server/.sqlx/query-b9c724d55f8d18324eebf8a894c675395a52f1fb5043d737415f9c33b777105c.json
+++ b/server/.sqlx/query-b9c724d55f8d18324eebf8a894c675395a52f1fb5043d737415f9c33b777105c.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "MySQL",
+  "query": "DELETE FROM label_for_forms WHERE id = ?",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": []
+  },
+  "hash": "b9c724d55f8d18324eebf8a894c675395a52f1fb5043d737415f9c33b777105c"
+}

--- a/server/.sqlx/query-c00259015f47ad69b5345d121094b20da708a776e5b7950ae098e4aba24fbfda.json
+++ b/server/.sqlx/query-c00259015f47ad69b5345d121094b20da708a776e5b7950ae098e4aba24fbfda.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "MySQL",
+  "query": "INSERT INTO response_period (form_id, start_at, end_at) VALUES (?, NULL, NULL)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": []
+  },
+  "hash": "c00259015f47ad69b5345d121094b20da708a776e5b7950ae098e4aba24fbfda"
+}

--- a/server/.sqlx/query-d8fb709be44782d6a19bae5babf3df017dca7d5d24498814de3afc806f6ecdb1.json
+++ b/server/.sqlx/query-d8fb709be44782d6a19bae5babf3df017dca7d5d24498814de3afc806f6ecdb1.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "MySQL",
+  "query": "UPDATE label_for_form_answers SET name = ? WHERE id = ?",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": []
+  },
+  "hash": "d8fb709be44782d6a19bae5babf3df017dca7d5d24498814de3afc806f6ecdb1"
+}

--- a/server/.sqlx/query-eb1555b6c2a10cd32e5dacb91202fd730065bc85c5dd125b99600fdbcfe7d50a.json
+++ b/server/.sqlx/query-eb1555b6c2a10cd32e5dacb91202fd730065bc85c5dd125b99600fdbcfe7d50a.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "MySQL",
+  "query": "DELETE FROM form_answer_comments WHERE id = ?",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": []
+  },
+  "hash": "eb1555b6c2a10cd32e5dacb91202fd730065bc85c5dd125b99600fdbcfe7d50a"
+}

--- a/server/.sqlx/query-f0c0b6e0ea08a6824cfe9fee45360daaada699fe6520c5796beff653bcf9e65d.json
+++ b/server/.sqlx/query-f0c0b6e0ea08a6824cfe9fee45360daaada699fe6520c5796beff653bcf9e65d.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "MySQL",
+  "query": "INSERT INTO form_webhooks (form_id, url) VALUES (?, ?)\n                    ON DUPLICATE KEY UPDATE\n                    url = VALUES(url)\n                    ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": []
+  },
+  "hash": "f0c0b6e0ea08a6824cfe9fee45360daaada699fe6520c5796beff653bcf9e65d"
+}

--- a/server/infra/resource/src/database/forms/answer_label.rs
+++ b/server/infra/resource/src/database/forms/answer_label.rs
@@ -7,7 +7,7 @@ use sqlx::{Row, query};
 use crate::{
     database::{
         components::FormAnswerLabelDatabase,
-        connection::{ConnectionPool, execute_and_values, query_all, query_all_and_values},
+        connection::{ConnectionPool, query_all, query_all_and_values},
         count::count_as_u32,
     },
     dto::AnswerLabelDto,
@@ -17,18 +17,17 @@ use crate::{
 impl FormAnswerLabelDatabase for ConnectionPool {
     #[tracing::instrument]
     async fn create_label_for_answers(&self, label: &AnswerLabel) -> Result<(), InfraError> {
-        let params = [
-            label.id().into_inner().to_string().into(),
-            label.name().to_owned().into_inner().into(),
-        ];
+        let label_id = label.id().into_inner().to_string();
+        let label_name = label.name().to_owned().into_inner();
 
         self.read_write_transaction(|txn| {
             Box::pin(async move {
-                execute_and_values(
+                sqlx::query!(
                     "INSERT INTO label_for_form_answers (id, name) VALUES (?, ?)",
-                    params,
-                    txn,
+                    label_id,
+                    label_name,
                 )
+                .execute(&mut **txn)
                 .await?;
 
                 Ok::<_, InfraError>(())
@@ -167,11 +166,11 @@ impl FormAnswerLabelDatabase for ConnectionPool {
     async fn delete_label_for_answers(&self, label_id: AnswerLabelId) -> Result<(), InfraError> {
         self.read_write_transaction(|txn| {
             Box::pin(async move {
-                execute_and_values(
+                sqlx::query!(
                     "DELETE FROM label_for_form_answers WHERE id = ?",
-                    [label_id.into_inner().to_string().into()],
-                    txn,
+                    label_id.into_inner().to_string(),
                 )
+                .execute(&mut **txn)
                 .await?;
 
                 Ok::<_, InfraError>(())
@@ -182,18 +181,17 @@ impl FormAnswerLabelDatabase for ConnectionPool {
 
     #[tracing::instrument]
     async fn edit_label_for_answers(&self, label: &AnswerLabel) -> Result<(), InfraError> {
-        let params = [
-            label.name().to_owned().into_inner().into(),
-            label.id().to_string().into(),
-        ];
+        let label_name = label.name().to_owned().into_inner();
+        let label_id = label.id().to_string();
 
         self.read_write_transaction(|txn| {
             Box::pin(async move {
-                execute_and_values(
+                sqlx::query!(
                     "UPDATE label_for_form_answers SET name = ? WHERE id = ?",
-                    params,
-                    txn,
+                    label_name,
+                    label_id,
                 )
+                .execute(&mut **txn)
                 .await?;
 
                 Ok::<_, InfraError>(())
@@ -212,11 +210,11 @@ impl FormAnswerLabelDatabase for ConnectionPool {
 
         self.read_write_transaction(|txn| {
             Box::pin(async move {
-                execute_and_values(
+                sqlx::query!(
                     "DELETE FROM label_settings_for_form_answers WHERE answer_id = ?",
-                    [answer_id.clone().into()],
-                    txn,
+                    answer_id.clone(),
                 )
+                .execute(&mut **txn)
                 .await?;
 
                 if !label_ids.is_empty() {

--- a/server/infra/resource/src/database/forms/answers.rs
+++ b/server/infra/resource/src/database/forms/answers.rs
@@ -18,8 +18,8 @@ use crate::{
     database::{
         components::FormAnswerDatabase,
         connection::{
-            ConnectionPool, DatabaseTransaction, execute_and_values, query_all,
-            query_all_and_values, query_one_and_values,
+            ConnectionPool, DatabaseTransaction, query_all, query_all_and_values,
+            query_one_and_values,
         },
         count::count_as_u32,
     },
@@ -75,17 +75,15 @@ impl FormAnswerDatabase for ConnectionPool {
 
         self.read_write_transaction(move |txn| {
             Box::pin(async move {
-                execute_and_values(
+                sqlx::query!(
                     r"INSERT INTO answers (id, form_id, user, title, timestamp) VALUES (?, ?, ?, ?, ?)",
-                    [
-                        answer_id.into(),
-                        form_id.into(),
-                        user_id.into(),
-                        title.into(),
-                        timestamp.into(),
-                    ],
-                    txn,
+                    answer_id,
+                    form_id,
+                    user_id,
+                    title,
+                    timestamp,
                 )
+                .execute(&mut **txn)
                 .await?;
 
                 if !contents.is_empty() {
@@ -96,7 +94,9 @@ impl FormAnswerDatabase for ConnectionPool {
 
                     contents
                         .into_iter()
-                        .flat_map(|(answer_id, question_id, answer)| [answer_id, question_id, answer])
+                        .flat_map(|(answer_id, question_id, answer)| {
+                            [answer_id, question_id, answer]
+                        })
                         .fold(query(&sql), |query, value| query.bind(value))
                         .execute(&mut **txn)
                         .await?;
@@ -387,14 +387,17 @@ impl FormAnswerDatabase for ConnectionPool {
 
         self.read_write_transaction(|txn| {
             Box::pin(async move {
-                execute_and_values(
+                sqlx::query!(
                     r#"INSERT INTO answers (id, form_id, user, title)
                     VALUES (?, ?, ?, ?)
                     ON DUPLICATE KEY UPDATE
                     title = VALUES(title)"#,
-                    [answer_id.into(), form_id.into(), user.into(), title.into()],
-                    txn,
+                    answer_id,
+                    form_id,
+                    user,
+                    title,
                 )
+                .execute(&mut **txn)
                 .await?;
                 Ok::<_, InfraError>(())
             })

--- a/server/infra/resource/src/database/forms/comment.rs
+++ b/server/infra/resource/src/database/forms/comment.rs
@@ -1,9 +1,5 @@
 use crate::{
-    database::{
-        components::FormCommentDatabase,
-        connection::{ConnectionPool, execute_and_values},
-        count::count_as_u32,
-    },
+    database::{components::FormCommentDatabase, connection::ConnectionPool, count::count_as_u32},
     dto::CommentDto,
 };
 use async_trait::async_trait;
@@ -82,28 +78,24 @@ impl FormCommentDatabase for ConnectionPool {
         answer_id: AnswerId,
         comment: &Comment,
     ) -> Result<(), InfraError> {
-        let params = [
-            comment.comment_id().into_inner().to_string().into(),
-            answer_id.into_inner().to_string().into(),
-            comment.commented_by().id.to_string().into(),
-            comment
-                .content()
-                .to_owned()
-                .into_inner()
-                .into_inner()
-                .into(),
-        ];
+        let comment_id = comment.comment_id().into_inner().to_string();
+        let answer_id = answer_id.into_inner().to_string();
+        let commented_by = comment.commented_by().id.to_string();
+        let content = comment.content().to_owned().into_inner().into_inner();
 
         self.read_write_transaction(|txn| {
             Box::pin(async move {
-                execute_and_values(
+                sqlx::query!(
                     r"INSERT INTO form_answer_comments (id, answer_id, commented_by, content)
                         VALUES (?, ?, ?, ?)
                         ON DUPLICATE KEY UPDATE
                         content = VALUES(content)",
-                    params,
-                    txn,
+                    comment_id,
+                    answer_id,
+                    commented_by,
+                    content,
                 )
+                .execute(&mut **txn)
                 .await?;
 
                 Ok::<_, InfraError>(())
@@ -116,11 +108,11 @@ impl FormCommentDatabase for ConnectionPool {
     async fn delete_comment(&self, comment_id: CommentId) -> Result<(), InfraError> {
         self.read_write_transaction(|txn| {
             Box::pin(async move {
-                execute_and_values(
+                sqlx::query!(
                     "DELETE FROM form_answer_comments WHERE id = ?",
-                    [comment_id.into_inner().to_string().into()],
-                    txn,
+                    comment_id.into_inner().to_string(),
                 )
+                .execute(&mut **txn)
                 .await?;
 
                 Ok::<_, InfraError>(())

--- a/server/infra/resource/src/database/forms/form.rs
+++ b/server/infra/resource/src/database/forms/form.rs
@@ -8,11 +8,7 @@ use errors::infra::InfraError;
 use types::non_empty_string::NonEmptyString;
 
 use crate::{
-    database::{
-        components::FormDatabase,
-        connection::{ConnectionPool, execute_and_values},
-        count::count_as_u32,
-    },
+    database::{components::FormDatabase, connection::ConnectionPool, count::count_as_u32},
     dto::FormDto,
 };
 
@@ -27,39 +23,37 @@ impl FormDatabase for ConnectionPool {
 
         self.read_write_transaction(|txn| {
             Box::pin(async move {
-                execute_and_values(
+                sqlx::query!(
                     r#"INSERT INTO form_meta_data (id, title, description, created_by, updated_by)
                             VALUES (?, ?, ?, ?, ?)"#,
-                    [
-                        form_id.into_inner().to_string().into(),
-                        form_title.to_string().into(),
-                        description.to_owned().into(),
-                        user_id.to_string().into(),
-                        user_id.to_string().into(),
-                    ],
-                    txn,
+                    form_id.into_inner().to_string(),
+                    form_title.to_string(),
+                    description.to_owned(),
+                    user_id.to_string(),
+                    user_id.to_string(),
                 )
+                .execute(&mut **txn)
                 .await?;
 
-                execute_and_values(
+                sqlx::query!(
                     r"INSERT INTO default_answer_titles (form_id, title) VALUES (?, NULL)",
-                    [form_id.to_owned().into_inner().to_string().into()],
-                    txn,
+                    form_id.to_owned().into_inner().to_string(),
                 )
+                .execute(&mut **txn)
                 .await?;
 
-                execute_and_values(
+                sqlx::query!(
                     r"INSERT INTO response_period (form_id, start_at, end_at) VALUES (?, NULL, NULL)",
-                    [form_id.to_owned().into_inner().to_string().into()],
-                    txn,
+                    form_id.to_owned().into_inner().to_string(),
                 )
+                .execute(&mut **txn)
                 .await?;
 
-                execute_and_values(
+                sqlx::query!(
                     r"INSERT INTO form_webhooks (form_id, url) VALUES (?, NULL)",
-                    [form_id.to_owned().into_inner().to_string().into()],
-                    txn,
+                    form_id.to_owned().into_inner().to_string(),
                 )
+                .execute(&mut **txn)
                 .await?;
 
                 Ok::<_, InfraError>(())
@@ -124,11 +118,11 @@ impl FormDatabase for ConnectionPool {
     async fn delete(&self, form_id: FormId) -> Result<(), InfraError> {
         self.read_write_transaction(|txn| {
             Box::pin(async move {
-                execute_and_values(
+                sqlx::query!(
                     "DELETE FROM form_meta_data WHERE id = ?",
-                    [form_id.into_inner().to_string().into()],
-                    txn,
+                    form_id.into_inner().to_string(),
                 )
+                .execute(&mut **txn)
                 .await?;
 
                 Ok::<_, InfraError>(())
@@ -139,18 +133,12 @@ impl FormDatabase for ConnectionPool {
 
     #[tracing::instrument]
     async fn update(&self, form: &Form, updated_by: &User) -> Result<(), InfraError> {
-        let form_meta_update_params = [
-            form.title().to_owned().into_inner().into_inner().into(),
-            form.description().to_owned().into_inner().into(),
-            form.settings().visibility().to_string().into(),
-            form.settings()
-                .answer_settings()
-                .visibility()
-                .to_string()
-                .into(),
-            updated_by.id.to_string().into(),
-            form.id().into_inner().to_owned().to_string().into(),
-        ];
+        let title = form.title().to_owned().into_inner().into_inner();
+        let description = form.description().to_owned().into_inner();
+        let visibility = form.settings().visibility().to_string();
+        let answer_visibility = form.settings().answer_settings().visibility().to_string();
+        let updated_by_id = updated_by.id.to_string();
+        let form_id = form.id().into_inner().to_owned().to_string();
 
         let webhook_url = form
             .settings()
@@ -160,14 +148,9 @@ impl FormDatabase for ConnectionPool {
             .and_then(WebhookUrl::into_inner)
             .map(NonEmptyString::into_inner);
 
-        let update_form_webhooks_params = [
-            form.id().into_inner().to_string().to_owned().into(),
-            webhook_url.into(),
-        ];
-
         self.read_write_transaction(|txn| {
             Box::pin(async move {
-                execute_and_values(
+                sqlx::query!(
                     r#"UPDATE form_meta_data SET
                     title = ?,
                     description = ?,
@@ -176,19 +159,25 @@ impl FormDatabase for ConnectionPool {
                     updated_by = ?
                     WHERE id = ?
                     "#,
-                    form_meta_update_params,
-                    txn,
+                    title,
+                    description,
+                    visibility,
+                    answer_visibility,
+                    updated_by_id,
+                    form_id.clone(),
                 )
+                .execute(&mut **txn)
                 .await?;
 
-                execute_and_values(
+                sqlx::query!(
                     r#"INSERT INTO form_webhooks (form_id, url) VALUES (?, ?)
                     ON DUPLICATE KEY UPDATE
                     url = VALUES(url)
                     "#,
-                    update_form_webhooks_params,
-                    txn,
+                    form_id,
+                    webhook_url,
                 )
+                .execute(&mut **txn)
                 .await?;
 
                 Ok::<_, InfraError>(())

--- a/server/infra/resource/src/database/forms/form_label.rs
+++ b/server/infra/resource/src/database/forms/form_label.rs
@@ -7,10 +7,7 @@ use sqlx::{Row, query};
 use crate::{
     database::{
         components::FormLabelDatabase,
-        connection::{
-            ConnectionPool, execute_and_values, query_all, query_all_and_values,
-            query_one_and_values,
-        },
+        connection::{ConnectionPool, query_all, query_all_and_values, query_one_and_values},
         count::count_as_u32,
     },
     dto::FormLabelDto,
@@ -20,18 +17,17 @@ use crate::{
 impl FormLabelDatabase for ConnectionPool {
     #[tracing::instrument]
     async fn create_label_for_forms(&self, label: &FormLabel) -> Result<(), InfraError> {
-        let params = [
-            label.id().to_owned().into_inner().to_string().into(),
-            label.name().to_string().into(),
-        ];
+        let label_id = label.id().to_owned().into_inner().to_string();
+        let label_name = label.name().to_string();
 
         self.read_write_transaction(|txn| {
             Box::pin(async move {
-                execute_and_values(
+                sqlx::query!(
                     "INSERT INTO label_for_forms (id, name) VALUES (?, ?)",
-                    params,
-                    txn,
+                    label_id,
+                    label_name,
                 )
+                .execute(&mut **txn)
                 .await?;
 
                 Ok::<_, InfraError>(())
@@ -105,11 +101,11 @@ impl FormLabelDatabase for ConnectionPool {
     async fn delete_label_for_forms(&self, label_id: FormLabelId) -> Result<(), InfraError> {
         self.read_write_transaction(|txn| {
             Box::pin(async move {
-                execute_and_values(
+                sqlx::query!(
                     "DELETE FROM label_for_forms WHERE id = ?",
-                    [label_id.to_string().into()],
-                    txn,
+                    label_id.to_string(),
                 )
+                .execute(&mut **txn)
                 .await?;
 
                 Ok::<_, InfraError>(())
@@ -150,11 +146,12 @@ impl FormLabelDatabase for ConnectionPool {
     ) -> Result<(), InfraError> {
         self.read_write_transaction(|txn| {
             Box::pin(async move {
-                execute_and_values(
+                sqlx::query!(
                     "UPDATE label_for_forms SET name = ? WHERE id = ?",
-                    [name.to_string().into(), id.to_string().into()],
-                    txn,
+                    name.to_string(),
+                    id.to_string(),
                 )
+                .execute(&mut **txn)
                 .await?;
 
                 Ok::<_, InfraError>(())
@@ -202,11 +199,11 @@ impl FormLabelDatabase for ConnectionPool {
 
         self.read_write_transaction(|txn| {
             Box::pin(async move {
-                execute_and_values(
+                sqlx::query!(
                     "DELETE FROM label_settings_for_forms WHERE form_id = ?",
-                    [form_id.clone().into()],
-                    txn,
+                    form_id.clone(),
                 )
+                .execute(&mut **txn)
                 .await?;
 
                 if !label_ids.is_empty() {

--- a/server/infra/resource/src/database/forms/message.rs
+++ b/server/infra/resource/src/database/forms/message.rs
@@ -6,10 +6,7 @@ use domain::form::{
 use errors::infra::InfraError;
 
 use crate::{
-    database::{
-        components::FormMessageDatabase,
-        connection::{ConnectionPool, execute_and_values},
-    },
+    database::{components::FormMessageDatabase, connection::ConnectionPool},
     dto::MessageDto,
 };
 
@@ -25,13 +22,16 @@ impl FormMessageDatabase for ConnectionPool {
 
         self.read_write_transaction(|txn| {
             Box::pin(async move {
-                execute_and_values(r"INSERT INTO messages (id, related_answer_id, sender, body, timestamp) VALUES (?, ?, ?, ?, ?)", [
-                    id.into(),
-                    related_answer_id.into(),
-                    sender.into(),
-                    body.into(),
-                    timestamp.into(),
-                ], txn).await?;
+                sqlx::query!(
+                    r"INSERT INTO messages (id, related_answer_id, sender, body, timestamp) VALUES (?, ?, ?, ?, ?)",
+                    id,
+                    related_answer_id,
+                    sender,
+                    body,
+                    timestamp,
+                )
+                .execute(&mut **txn)
+                .await?;
 
                 Ok::<_, InfraError>(())
             })
@@ -46,11 +46,12 @@ impl FormMessageDatabase for ConnectionPool {
     ) -> Result<(), InfraError> {
         self.read_write_transaction(|txn| {
             Box::pin(async move {
-                execute_and_values(
+                sqlx::query!(
                     "UPDATE messages SET body = ? WHERE id = ?",
-                    [body.into(), message_id.into_inner().into()],
-                    txn,
+                    body,
+                    message_id.into_inner(),
                 )
+                .execute(&mut **txn)
                 .await?;
 
                 Ok::<_, InfraError>(())
@@ -115,12 +116,9 @@ impl FormMessageDatabase for ConnectionPool {
     async fn delete_message(&self, message_id: MessageId) -> Result<(), InfraError> {
         self.read_write_transaction(|txn| {
             Box::pin(async move {
-                execute_and_values(
-                    "DELETE FROM messages WHERE id = ?",
-                    [message_id.to_string().into()],
-                    txn,
-                )
-                .await?;
+                sqlx::query!("DELETE FROM messages WHERE id = ?", message_id.to_string(),)
+                    .execute(&mut **txn)
+                    .await?;
 
                 Ok::<_, InfraError>(())
             })

--- a/server/infra/resource/src/database/forms/question.rs
+++ b/server/infra/resource/src/database/forms/question.rs
@@ -7,7 +7,7 @@ use sqlx::{Row, query};
 use crate::{
     database::{
         components::FormQuestionDatabase,
-        connection::{ConnectionPool, DbErr, query_all_and_values, query_one},
+        connection::{ConnectionPool, DbErr, query_all_and_values},
     },
     dto::QuestionDto,
 };
@@ -44,13 +44,11 @@ impl FormQuestionDatabase for ConnectionPool {
                         .execute(&mut **txn)
                         .await?;
 
-                    let last_insert_id = query_one(
-                        "SELECT question_id FROM form_questions ORDER BY question_id DESC LIMIT 1",
-                        txn,
+                    let last_insert_id = sqlx::query_scalar!(
+                        "SELECT question_id AS `question_id!: i32` FROM form_questions ORDER BY question_id DESC LIMIT 1"
                     )
-                    .await?
-                    .unwrap()
-                    .try_get("question_id")?;
+                    .fetch_one(&mut **txn)
+                    .await?;
 
                     let choices_active_values = questions
                         .iter()
@@ -158,13 +156,11 @@ impl FormQuestionDatabase for ConnectionPool {
                         .execute(&mut **txn)
                         .await?;
 
-                    let last_insert_id = query_one(
-                        "SELECT question_id FROM form_questions ORDER BY question_id DESC LIMIT 1",
-                        txn,
+                    let last_insert_id = sqlx::query_scalar!(
+                        "SELECT question_id AS `question_id!: i32` FROM form_questions ORDER BY question_id DESC LIMIT 1"
                     )
-                    .await?
-                    .unwrap()
-                    .try_get("question_id")?;
+                    .fetch_one(&mut **txn)
+                    .await?;
 
                     let choices_active_values = questions
                         .iter()


### PR DESCRIPTION
## 概要
- forms 配下に残っていた write 系 query を `sqlx` ベースへ統一しました
- 可変長の bulk insert / delete も、既存の read 系と同じ `format!` + `bind` の流れに揃えました
- `server/.sqlx` の query metadata を更新し、変更後の query 定義と整合する状態にしました

## 確認事項
- `cargo build` を実行し、ワークスペース全体がビルドできることを確認しました
- `cargo test --all-features` を実行し、既存テストと doctest がすべて成功することを確認しました
- `cargo clippy -- -D warnings` を実行し、警告なしで通ることを確認しました
- `DATABASE_URL=mysql://user:password@localhost:3306/seichi_portal cargo sqlx prepare --check --workspace` を実行し、sqlx metadata が現在の query 定義と一致することを確認しました

## 補足
- 今回の PR は forms write path の統一に絞っており、forms read 系に残る helper 依存の整理は別 PR で扱う前提です

🤖 Generated with Codex