### PR TITLE
feat: フォーム質問定義と回答整合性を再設計する

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -5062,6 +5062,7 @@ dependencies = [
  "errors",
  "futures",
  "resource",
+ "serde_json",
  "tokio",
  "types",
  "uuid",

--- a/server/domain/Cargo.toml
+++ b/server/domain/Cargo.toml
@@ -11,6 +11,7 @@ deriving_via = { workspace = true }
 errors = { path = "../errors" }
 mockall = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
 types = { path = "../types" }
@@ -24,6 +25,5 @@ common = { path = "../common" }
 chrono = { workspace = true, features = ["arbitrary"] }
 proptest = { workspace = true }
 proptest-derive = { workspace = true }
-serde_json = { workspace = true }
 test-case = { workspace = true }
 types = { path = "../types", features = ["arbitrary"] }

--- a/server/domain/src/form/answer/models.rs
+++ b/server/domain/src/form/answer/models.rs
@@ -1,13 +1,18 @@
 use chrono::{DateTime, Utc};
 use derive_getters::Getters;
 use deriving_via::DerivingVia;
+use errors::domain::DomainError;
 #[cfg(test)]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
+use std::collections::{BTreeSet, HashMap};
 use types::non_empty_string::NonEmptyString;
 
 use crate::{
-    form::{models::FormId, question::models::QuestionId},
+    form::{
+        models::FormId,
+        question::models::{Question, QuestionId, QuestionType},
+    },
     types::authorization_guard::AuthorizationGuardDefinitions,
     user::models::{Role, User},
 };
@@ -27,11 +32,110 @@ impl AnswerTitle {
 
 pub type FormAnswerContentId = types::Id<FormAnswerContent>;
 
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
 pub struct FormAnswerContent {
     pub id: FormAnswerContentId,
     pub question_id: QuestionId,
     pub answer: String,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct PostedAnswerContents(Vec<FormAnswerContent>);
+
+impl PostedAnswerContents {
+    pub fn try_new(
+        questions: &[Question],
+        contents: Vec<FormAnswerContent>,
+    ) -> Result<Self, DomainError> {
+        let questions_by_id = questions
+            .iter()
+            .filter_map(|question| question.id.map(|id| (id.into_inner(), question)))
+            .collect::<HashMap<_, _>>();
+        let answered_question_ids = contents
+            .iter()
+            .map(|answer| answer.question_id.into_inner())
+            .collect::<BTreeSet<_>>();
+
+        if answered_question_ids.len() != contents.len() {
+            return Err(DomainError::InvalidEntity {
+                message: "duplicate answer for the same question".to_string(),
+            });
+        }
+
+        if let Some(error) = contents.iter().find_map(|answer| {
+            let question = questions_by_id
+                .get(&answer.question_id.into_inner())
+                .ok_or_else(|| DomainError::InvalidEntity {
+                    message: format!(
+                        "question {} does not belong to the form",
+                        answer.question_id
+                    ),
+                });
+
+            question
+                .and_then(|question| match question.question_type {
+                    QuestionType::Text => Ok(()),
+                    QuestionType::SingleChoice => question
+                        .choices
+                        .iter()
+                        .flat_map(|choices| choices.iter())
+                        .any(|choice| choice.label == answer.answer)
+                        .then_some(())
+                        .ok_or_else(|| DomainError::InvalidEntity {
+                            message: format!(
+                                "answer for question {} must match one of the available choices",
+                                question.template_key
+                            ),
+                        }),
+                    QuestionType::MultipleChoice => {
+                        let values = parse_multiple_choice_answer(&answer.answer);
+                        (!values.is_empty()
+                            && values.iter().all(|value| {
+                                question
+                                    .choices
+                                    .iter()
+                                    .flat_map(|choices| choices.iter())
+                                    .any(|choice| choice.label == *value)
+                            }))
+                        .then_some(())
+                        .ok_or_else(|| DomainError::InvalidEntity {
+                            message: format!(
+                                "answer for question {} must reference only existing choices",
+                                question.template_key
+                            ),
+                        })
+                    }
+                })
+                .err()
+        }) {
+            return Err(error);
+        }
+
+        if let Some(missing_question) = questions
+            .iter()
+            .filter(|question| question.is_required)
+            .filter_map(|question| question.id.map(|id| (id.into_inner(), question)))
+            .find(|(question_id, _)| !answered_question_ids.contains(question_id))
+            .map(|(_, question)| question)
+        {
+            return Err(DomainError::InvalidEntity {
+                message: format!(
+                    "required question {} is missing",
+                    missing_question.template_key
+                ),
+            });
+        }
+
+        Ok(Self(contents))
+    }
+
+    pub fn as_slice(&self) -> &[FormAnswerContent] {
+        &self.0
+    }
+
+    pub fn into_inner(self) -> Vec<FormAnswerContent> {
+        self.0
+    }
 }
 
 #[derive(Serialize, Deserialize, Getters, PartialEq, Debug)]
@@ -50,7 +154,7 @@ impl AnswerEntry {
         user: User,
         form_id: FormId,
         title: AnswerTitle,
-        contents: Vec<FormAnswerContent>,
+        contents: PostedAnswerContents,
     ) -> Self {
         Self {
             id: AnswerId::new(),
@@ -58,7 +162,7 @@ impl AnswerEntry {
             timestamp: Utc::now(),
             form_id,
             title,
-            contents,
+            contents: contents.into_inner(),
         }
     }
 
@@ -131,5 +235,259 @@ impl AuthorizationGuardDefinitions for AnswerLabel {
 
     fn can_delete(&self, actor: &User) -> bool {
         actor.role == Role::Administrator
+    }
+}
+
+fn parse_multiple_choice_answer(answer: &str) -> Vec<String> {
+    let trimmed = answer.trim();
+    if trimmed.starts_with('[')
+        && trimmed.ends_with(']')
+        && let Ok(values) = serde_json::from_str::<Vec<String>>(trimmed)
+    {
+        return values
+            .into_iter()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty())
+            .collect();
+    }
+
+    trimmed
+        .split(',')
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::form::{
+        models::FormId,
+        question::models::{Choice, QuestionType},
+    };
+    use types::non_empty_vec::NonEmptyVec;
+    use uuid::Uuid;
+
+    fn text_question() -> Question {
+        Question::new(
+            Some(QuestionId::from(1)),
+            FormId::from(Uuid::nil()),
+            "name".to_string(),
+            0,
+            "Name".to_string(),
+            None,
+            QuestionType::Text,
+            None,
+            true,
+        )
+        .unwrap()
+    }
+
+    fn single_choice_question() -> Question {
+        Question::new(
+            Some(QuestionId::from(2)),
+            FormId::from(Uuid::nil()),
+            "role".to_string(),
+            1,
+            "Role".to_string(),
+            None,
+            QuestionType::SingleChoice,
+            Some(
+                NonEmptyVec::try_new(vec![
+                    Choice::new(Some(1.into()), 0, "Admin".to_string()).unwrap(),
+                    Choice::new(Some(2.into()), 1, "User".to_string()).unwrap(),
+                ])
+                .unwrap(),
+            ),
+            true,
+        )
+        .unwrap()
+    }
+
+    fn multiple_choice_question() -> Question {
+        Question::new(
+            Some(QuestionId::from(3)),
+            FormId::from(Uuid::nil()),
+            "tags".to_string(),
+            2,
+            "Tags".to_string(),
+            None,
+            QuestionType::MultipleChoice,
+            Some(
+                NonEmptyVec::try_new(vec![
+                    Choice::new(Some(3.into()), 0, "Admin, Owner".to_string()).unwrap(),
+                    Choice::new(Some(4.into()), 1, "User".to_string()).unwrap(),
+                ])
+                .unwrap(),
+            ),
+            false,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn posted_answer_contents_rejects_duplicate_question_ids() {
+        let questions = vec![text_question()];
+        let answers = vec![
+            FormAnswerContent {
+                id: FormAnswerContentId::new(),
+                question_id: QuestionId::from(1),
+                answer: "Alice".to_string(),
+            },
+            FormAnswerContent {
+                id: FormAnswerContentId::new(),
+                question_id: QuestionId::from(1),
+                answer: "Bob".to_string(),
+            },
+        ];
+
+        assert!(PostedAnswerContents::try_new(&questions, answers).is_err());
+    }
+
+    #[test]
+    fn posted_answer_contents_rejects_question_outside_form() {
+        let questions = vec![text_question()];
+        let answers = vec![FormAnswerContent {
+            id: FormAnswerContentId::new(),
+            question_id: QuestionId::from(999),
+            answer: "Alice".to_string(),
+        }];
+
+        assert!(PostedAnswerContents::try_new(&questions, answers).is_err());
+    }
+
+    #[test]
+    fn posted_answer_contents_rejects_invalid_single_choice() {
+        let questions = vec![text_question(), single_choice_question()];
+        let answers = vec![
+            FormAnswerContent {
+                id: FormAnswerContentId::new(),
+                question_id: QuestionId::from(1),
+                answer: "Alice".to_string(),
+            },
+            FormAnswerContent {
+                id: FormAnswerContentId::new(),
+                question_id: QuestionId::from(2),
+                answer: "Guest".to_string(),
+            },
+        ];
+
+        assert!(PostedAnswerContents::try_new(&questions, answers).is_err());
+    }
+
+    #[test]
+    fn posted_answer_contents_rejects_invalid_multiple_choice_values() {
+        let questions = vec![
+            text_question(),
+            single_choice_question(),
+            multiple_choice_question(),
+        ];
+        let answers = vec![
+            FormAnswerContent {
+                id: FormAnswerContentId::new(),
+                question_id: QuestionId::from(1),
+                answer: "Alice".to_string(),
+            },
+            FormAnswerContent {
+                id: FormAnswerContentId::new(),
+                question_id: QuestionId::from(2),
+                answer: "Admin".to_string(),
+            },
+            FormAnswerContent {
+                id: FormAnswerContentId::new(),
+                question_id: QuestionId::from(3),
+                answer: r#"["Admin","Guest"]"#.to_string(),
+            },
+        ];
+
+        assert!(PostedAnswerContents::try_new(&questions, answers).is_err());
+    }
+
+    #[test]
+    fn posted_answer_contents_rejects_empty_multiple_choice_values() {
+        let questions = vec![
+            text_question(),
+            single_choice_question(),
+            multiple_choice_question(),
+        ];
+        let answers = vec![
+            FormAnswerContent {
+                id: FormAnswerContentId::new(),
+                question_id: QuestionId::from(1),
+                answer: "Alice".to_string(),
+            },
+            FormAnswerContent {
+                id: FormAnswerContentId::new(),
+                question_id: QuestionId::from(2),
+                answer: "Admin".to_string(),
+            },
+            FormAnswerContent {
+                id: FormAnswerContentId::new(),
+                question_id: QuestionId::from(3),
+                answer: "[]".to_string(),
+            },
+        ];
+
+        assert!(PostedAnswerContents::try_new(&questions, answers).is_err());
+    }
+
+    #[test]
+    fn posted_answer_contents_rejects_missing_required_question() {
+        let questions = vec![text_question(), single_choice_question()];
+        let answers = vec![FormAnswerContent {
+            id: FormAnswerContentId::new(),
+            question_id: QuestionId::from(1),
+            answer: "Alice".to_string(),
+        }];
+
+        assert!(PostedAnswerContents::try_new(&questions, answers).is_err());
+    }
+
+    #[test]
+    fn posted_answer_contents_preserves_valid_answers() {
+        let questions = vec![
+            text_question(),
+            single_choice_question(),
+            multiple_choice_question(),
+        ];
+        let answers = vec![
+            FormAnswerContent {
+                id: FormAnswerContentId::new(),
+                question_id: QuestionId::from(1),
+                answer: "Alice".to_string(),
+            },
+            FormAnswerContent {
+                id: FormAnswerContentId::new(),
+                question_id: QuestionId::from(2),
+                answer: "Admin".to_string(),
+            },
+            FormAnswerContent {
+                id: FormAnswerContentId::new(),
+                question_id: QuestionId::from(3),
+                answer: r#"["Admin, Owner","User"]"#.to_string(),
+            },
+        ];
+
+        let posted_answers = PostedAnswerContents::try_new(&questions, answers.clone()).unwrap();
+
+        assert_eq!(posted_answers.as_slice(), answers.as_slice());
+        assert_eq!(posted_answers.into_inner(), answers);
+    }
+
+    #[test]
+    fn parse_multiple_choice_answer_accepts_json_with_commas_in_values() {
+        assert_eq!(
+            parse_multiple_choice_answer(r#"["Admin, Owner","User"]"#),
+            vec!["Admin, Owner".to_string(), "User".to_string()]
+        );
+    }
+
+    #[test]
+    fn parse_multiple_choice_answer_falls_back_to_legacy_csv_format() {
+        assert_eq!(
+            parse_multiple_choice_answer("Admin, User"),
+            vec!["Admin".to_string(), "User".to_string()]
+        );
     }
 }

--- a/server/domain/src/form/message/models.rs
+++ b/server/domain/src/form/message/models.rs
@@ -24,7 +24,10 @@ impl Message {
     /// # Examples
     /// ```
     /// use domain::{
-    ///     form::{answer::models::AnswerEntry, message::models::Message},
+    ///     form::{
+    ///         answer::models::{AnswerEntry, PostedAnswerContents},
+    ///         message::models::Message,
+    ///     },
     ///     user::models::{Role, User},
     /// };
     /// use uuid::Uuid;
@@ -39,7 +42,7 @@ impl Message {
     ///     user.to_owned(),
     ///     Default::default(),
     ///     Default::default(),
-    ///     Default::default(),
+    ///     PostedAnswerContents::try_new(&[], vec![]).unwrap(),
     /// );
     ///
     /// let success_message = Message::try_new(
@@ -52,7 +55,7 @@ impl Message {
     ///     user.to_owned(),
     ///     Default::default(),
     ///     Default::default(),
-    ///     Default::default(),
+    ///     PostedAnswerContents::try_new(&[], vec![]).unwrap(),
     /// );
     /// let message_with_empty_body = Message::try_new(*related_answer.id(), user, "".to_string());
     ///
@@ -84,7 +87,7 @@ impl Message {
     /// use chrono::{DateTime, Utc};
     /// use domain::{
     ///     form::{
-    ///         answer::models::AnswerEntry,
+    ///         answer::models::{AnswerEntry, PostedAnswerContents},
     ///         message::models::{Message, MessageId},
     ///     },
     ///     user::models::{Role, User},
@@ -101,7 +104,7 @@ impl Message {
     ///     user.to_owned(),
     ///     Default::default(),
     ///     Default::default(),
-    ///     Default::default(),
+    ///     PostedAnswerContents::try_new(&[], vec![]).unwrap(),
     /// );
     ///
     /// unsafe {

--- a/server/domain/src/form/message/service.rs
+++ b/server/domain/src/form/message/service.rs
@@ -20,7 +20,7 @@ impl AuthorizationGuardWithContextDefinitions<MessageAuthorizationContext> for M
     /// ```
     /// use domain::{
     ///     form::{
-    ///         answer::models::AnswerEntry,
+    ///         answer::models::{AnswerEntry, PostedAnswerContents},
     ///         message::{models::Message, service::MessageAuthorizationContext},
     ///     },
     ///     types::{
@@ -41,7 +41,7 @@ impl AuthorizationGuardWithContextDefinitions<MessageAuthorizationContext> for M
     ///     respondent.to_owned(),
     ///     Default::default(),
     ///     Default::default(),
-    ///     Default::default(),
+    ///     PostedAnswerContents::try_new(&[], vec![]).unwrap(),
     /// );
     ///
     /// let message = Message::try_new(
@@ -93,7 +93,7 @@ impl AuthorizationGuardWithContextDefinitions<MessageAuthorizationContext> for M
     /// ```
     /// use domain::{
     ///     form::{
-    ///         answer::models::AnswerEntry,
+    ///         answer::models::{AnswerEntry, PostedAnswerContents},
     ///         message::{models::Message, service::MessageAuthorizationContext},
     ///     },
     ///     types::{
@@ -114,7 +114,7 @@ impl AuthorizationGuardWithContextDefinitions<MessageAuthorizationContext> for M
     ///     respondent.to_owned(),
     ///     Default::default(),
     ///     Default::default(),
-    ///     Default::default(),
+    ///     PostedAnswerContents::try_new(&[], vec![]).unwrap(),
     /// );
     ///
     /// let message = Message::try_new(
@@ -166,7 +166,7 @@ impl AuthorizationGuardWithContextDefinitions<MessageAuthorizationContext> for M
     /// ```
     /// use domain::{
     ///     form::{
-    ///         answer::models::AnswerEntry,
+    ///         answer::models::{AnswerEntry, PostedAnswerContents},
     ///         message::{models::Message, service::MessageAuthorizationContext},
     ///     },
     ///     types::{
@@ -187,7 +187,7 @@ impl AuthorizationGuardWithContextDefinitions<MessageAuthorizationContext> for M
     ///     respondent.to_owned(),
     ///     Default::default(),
     ///     Default::default(),
-    ///     Default::default(),
+    ///     PostedAnswerContents::try_new(&[], vec![]).unwrap(),
     /// );
     ///
     /// let message = Message::try_new(
@@ -233,7 +233,7 @@ impl AuthorizationGuardWithContextDefinitions<MessageAuthorizationContext> for M
     /// ```
     /// use domain::{
     ///     form::{
-    ///         answer::models::AnswerEntry,
+    ///         answer::models::{AnswerEntry, PostedAnswerContents},
     ///         message::{models::Message, service::MessageAuthorizationContext},
     ///     },
     ///     types::{
@@ -254,7 +254,7 @@ impl AuthorizationGuardWithContextDefinitions<MessageAuthorizationContext> for M
     ///     respondent.to_owned(),
     ///     Default::default(),
     ///     Default::default(),
-    ///     Default::default(),
+    ///     PostedAnswerContents::try_new(&[], vec![]).unwrap(),
     /// );
     ///
     /// let message = Message::try_new(

--- a/server/domain/src/form/question/models.rs
+++ b/server/domain/src/form/question/models.rs
@@ -71,6 +71,52 @@ pub struct Question {
     pub is_required: bool,
 }
 
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct QuestionSet(Vec<Question>);
+
+impl QuestionSet {
+    pub fn try_new(questions: Vec<Question>) -> Result<Self, DomainError> {
+        let positions = questions
+            .iter()
+            .map(|question| question.position)
+            .collect::<BTreeSet<_>>();
+        if positions.len() != questions.len()
+            || positions
+                .into_iter()
+                .enumerate()
+                .any(|(index, position)| position != index as u16)
+        {
+            return Err(DomainError::InvalidEntity {
+                message: "question.position must be contiguous from 0".to_string(),
+            });
+        }
+
+        let template_keys = questions
+            .iter()
+            .map(|question| question.template_key.as_str())
+            .collect::<BTreeSet<_>>();
+        if template_keys.len() != questions.len() {
+            return Err(DomainError::InvalidEntity {
+                message: "question.template_key must be unique within a form".to_string(),
+            });
+        }
+
+        Ok(Self(questions))
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &Question> {
+        self.0.iter()
+    }
+
+    pub fn as_slice(&self) -> &[Question] {
+        &self.0
+    }
+
+    pub fn into_inner(self) -> Vec<Question> {
+        self.0
+    }
+}
+
 impl Question {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
@@ -122,35 +168,6 @@ impl Question {
             choices,
             is_required,
         )
-    }
-
-    pub fn validate_set(questions: &[Question]) -> Result<(), DomainError> {
-        let positions = questions
-            .iter()
-            .map(|question| question.position)
-            .collect::<BTreeSet<_>>();
-        if positions.len() != questions.len()
-            || positions
-                .into_iter()
-                .enumerate()
-                .any(|(index, position)| position != index as u16)
-        {
-            return Err(DomainError::InvalidEntity {
-                message: "question.position must be contiguous from 0".to_string(),
-            });
-        }
-
-        let template_keys = questions
-            .iter()
-            .map(|question| question.template_key.as_str())
-            .collect::<BTreeSet<_>>();
-        if template_keys.len() != questions.len() {
-            return Err(DomainError::InvalidEntity {
-                message: "question.template_key must be unique within a form".to_string(),
-            });
-        }
-
-        Ok(())
     }
 
     fn validate(&self) -> Result<(), DomainError> {
@@ -307,7 +324,114 @@ mod test {
     }
 
     #[test]
-    fn validate_question_set_requires_unique_template_keys_and_contiguous_positions() {
+    fn question_set_accepts_unique_template_keys_and_contiguous_positions() {
+        let form_id = FormId::from(Uuid::nil());
+        let questions = vec![
+            Question::new(
+                Some(1.into()),
+                form_id,
+                "first".to_string(),
+                0,
+                "Question 1".to_string(),
+                None,
+                QuestionType::Text,
+                None,
+                true,
+            )
+            .unwrap(),
+            Question::new(
+                Some(2.into()),
+                form_id,
+                "second".to_string(),
+                1,
+                "Question 2".to_string(),
+                None,
+                QuestionType::Text,
+                None,
+                false,
+            )
+            .unwrap(),
+        ];
+
+        let result = QuestionSet::try_new(questions);
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn question_set_rejects_duplicate_position() {
+        let form_id = FormId::from(Uuid::nil());
+        let questions = vec![
+            Question::new(
+                Some(1.into()),
+                form_id,
+                "first".to_string(),
+                0,
+                "Question 1".to_string(),
+                None,
+                QuestionType::Text,
+                None,
+                true,
+            )
+            .unwrap(),
+            Question::new(
+                Some(2.into()),
+                form_id,
+                "second".to_string(),
+                0,
+                "Question 2".to_string(),
+                None,
+                QuestionType::Text,
+                None,
+                false,
+            )
+            .unwrap(),
+        ];
+
+        assert!(matches!(
+            QuestionSet::try_new(questions),
+            Err(DomainError::InvalidEntity { .. })
+        ));
+    }
+
+    #[test]
+    fn question_set_rejects_non_contiguous_position() {
+        let form_id = FormId::from(Uuid::nil());
+        let questions = vec![
+            Question::new(
+                Some(1.into()),
+                form_id,
+                "first".to_string(),
+                0,
+                "Question 1".to_string(),
+                None,
+                QuestionType::Text,
+                None,
+                true,
+            )
+            .unwrap(),
+            Question::new(
+                Some(2.into()),
+                form_id,
+                "second".to_string(),
+                2,
+                "Question 2".to_string(),
+                None,
+                QuestionType::Text,
+                None,
+                false,
+            )
+            .unwrap(),
+        ];
+
+        assert!(matches!(
+            QuestionSet::try_new(questions),
+            Err(DomainError::InvalidEntity { .. })
+        ));
+    }
+
+    #[test]
+    fn question_set_rejects_duplicate_template_keys() {
         let form_id = FormId::from(Uuid::nil());
         let questions = vec![
             Question::new(
@@ -326,7 +450,7 @@ mod test {
                 Some(2.into()),
                 form_id,
                 "same".to_string(),
-                2,
+                1,
                 "Question 2".to_string(),
                 None,
                 QuestionType::Text,
@@ -337,7 +461,7 @@ mod test {
         ];
 
         assert!(matches!(
-            Question::validate_set(&questions),
+            QuestionSet::try_new(questions),
             Err(DomainError::InvalidEntity { .. })
         ));
     }

--- a/server/domain/src/form/question/models.rs
+++ b/server/domain/src/form/question/models.rs
@@ -1,11 +1,11 @@
-#[cfg(test)]
-use common::test_utils::arbitrary_with_size;
 use derive_getters::Getters;
 use errors::domain::DomainError;
 #[cfg(test)]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
-use strum_macros::{Display, EnumString};
+use std::collections::BTreeSet;
+use strum_macros::EnumString;
+use types::non_empty_vec::NonEmptyVec;
 
 use crate::{
     form::models::FormId,
@@ -14,6 +14,46 @@ use crate::{
 };
 
 pub type QuestionId = types::IntegerId<Question>;
+pub type ChoiceId = types::IntegerId<Choice>;
+
+#[cfg_attr(test, derive(Arbitrary))]
+#[derive(Serialize, Deserialize, Clone, Getters, Debug, PartialEq)]
+pub struct Choice {
+    #[serde(default)]
+    pub id: Option<ChoiceId>,
+    pub position: u16,
+    pub label: String,
+}
+
+impl Choice {
+    pub fn new(id: Option<ChoiceId>, position: u16, label: String) -> Result<Self, DomainError> {
+        let choice = Self {
+            id,
+            position,
+            label,
+        };
+        choice.validate()?;
+        Ok(choice)
+    }
+
+    pub fn from_raw_parts(
+        id: Option<ChoiceId>,
+        position: u16,
+        label: String,
+    ) -> Result<Self, DomainError> {
+        Self::new(id, position, label)
+    }
+
+    fn validate(&self) -> Result<(), DomainError> {
+        if self.label.trim().is_empty() {
+            return Err(DomainError::InvalidEntity {
+                message: "choice.label must not be empty".to_string(),
+            });
+        }
+
+        Ok(())
+    }
+}
 
 #[cfg_attr(test, derive(Arbitrary))]
 #[derive(Serialize, Deserialize, Clone, Getters, Debug, PartialEq)]
@@ -21,54 +61,149 @@ pub struct Question {
     #[serde(default)]
     pub id: Option<QuestionId>,
     pub form_id: FormId,
+    pub template_key: String,
+    pub position: u16,
     pub title: String,
     pub description: Option<String>,
     pub question_type: QuestionType,
-    #[cfg_attr(test, proptest(strategy = "arbitrary_with_size(1..100)"))]
     #[serde(default)]
-    pub choices: Vec<String>,
+    pub choices: Option<NonEmptyVec<Choice>>,
     pub is_required: bool,
 }
 
 impl Question {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         id: Option<QuestionId>,
         form_id: FormId,
+        template_key: String,
+        position: u16,
         title: String,
         description: Option<String>,
         question_type: QuestionType,
-        choices: Vec<String>,
+        choices: Option<NonEmptyVec<Choice>>,
         is_required: bool,
-    ) -> Self {
-        Self {
+    ) -> Result<Self, DomainError> {
+        let question = Self {
             id,
             form_id,
+            template_key,
+            position,
             title,
             description,
             question_type,
             choices,
             is_required,
-        }
+        };
+        question.validate()?;
+        Ok(question)
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn from_raw_parts(
         id: Option<QuestionId>,
         form_id: FormId,
+        template_key: String,
+        position: u16,
         title: String,
         description: Option<String>,
         question_type: QuestionType,
-        choices: Vec<String>,
+        choices: Option<NonEmptyVec<Choice>>,
         is_required: bool,
-    ) -> Self {
-        Self {
+    ) -> Result<Self, DomainError> {
+        Self::new(
             id,
             form_id,
+            template_key,
+            position,
             title,
             description,
             question_type,
             choices,
             is_required,
+        )
+    }
+
+    pub fn validate_set(questions: &[Question]) -> Result<(), DomainError> {
+        let positions = questions
+            .iter()
+            .map(|question| question.position)
+            .collect::<BTreeSet<_>>();
+        if positions.len() != questions.len()
+            || positions
+                .into_iter()
+                .enumerate()
+                .any(|(index, position)| position != index as u16)
+        {
+            return Err(DomainError::InvalidEntity {
+                message: "question.position must be contiguous from 0".to_string(),
+            });
         }
+
+        let template_keys = questions
+            .iter()
+            .map(|question| question.template_key.as_str())
+            .collect::<BTreeSet<_>>();
+        if template_keys.len() != questions.len() {
+            return Err(DomainError::InvalidEntity {
+                message: "question.template_key must be unique within a form".to_string(),
+            });
+        }
+
+        Ok(())
+    }
+
+    fn validate(&self) -> Result<(), DomainError> {
+        if self.template_key.trim().is_empty() {
+            return Err(DomainError::InvalidEntity {
+                message: "question.template_key must not be empty".to_string(),
+            });
+        }
+
+        if self.title.trim().is_empty() {
+            return Err(DomainError::InvalidEntity {
+                message: "question.title must not be empty".to_string(),
+            });
+        }
+
+        let choice_positions = self
+            .choices
+            .iter()
+            .flat_map(|choices| choices.iter().map(|choice| choice.position))
+            .collect::<BTreeSet<_>>();
+
+        match self.question_type {
+            QuestionType::Text => {
+                if self.choices.is_some() {
+                    return Err(DomainError::InvalidEntity {
+                        message: "text question must not have choices".to_string(),
+                    });
+                }
+            }
+            QuestionType::SingleChoice | QuestionType::MultipleChoice => {
+                let Some(choices) = &self.choices else {
+                    return Err(DomainError::InvalidEntity {
+                        message: "choice question must have at least one choice".to_string(),
+                    });
+                };
+
+                if choice_positions.len() != choices.len()
+                    || choice_positions
+                        .into_iter()
+                        .enumerate()
+                        .any(|(index, position)| position != index as u16)
+                {
+                    return Err(DomainError::InvalidEntity {
+                        message: format!(
+                            "choice.position must be contiguous from 0 for question {}",
+                            self.template_key
+                        ),
+                    });
+                }
+            }
+        }
+
+        Ok(())
     }
 }
 
@@ -91,14 +226,35 @@ impl AuthorizationGuardDefinitions for Question {
 }
 
 #[cfg_attr(test, derive(Arbitrary))]
-#[derive(
-    Debug, Serialize, Deserialize, Clone, Copy, EnumString, PartialOrd, PartialEq, Display,
-)]
-#[strum(ascii_case_insensitive)]
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialOrd, PartialEq, Eq, EnumString)]
 pub enum QuestionType {
-    TEXT,
-    SINGLE,
-    MULTIPLE,
+    #[strum(serialize = "Text", serialize = "TEXT", ascii_case_insensitive)]
+    Text,
+    #[strum(
+        serialize = "SingleChoice",
+        serialize = "SINGLE",
+        serialize = "SINGLE_CHOICE",
+        ascii_case_insensitive
+    )]
+    SingleChoice,
+    #[strum(
+        serialize = "MultipleChoice",
+        serialize = "MULTIPLE",
+        serialize = "MULTIPLE_CHOICE",
+        ascii_case_insensitive
+    )]
+    MultipleChoice,
+}
+
+impl std::fmt::Display for QuestionType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let value = match self {
+            Self::Text => "Text",
+            Self::SingleChoice => "SingleChoice",
+            Self::MultipleChoice => "MultipleChoice",
+        };
+        f.write_str(value)
+    }
 }
 
 impl TryFrom<String> for QuestionType {
@@ -113,17 +269,76 @@ impl TryFrom<String> for QuestionType {
 #[cfg(test)]
 mod test {
     use test_case::test_case;
+    use uuid::Uuid;
 
     use super::*;
     use crate::form::question::models::QuestionType;
 
-    #[test_case("TEXT"     => Ok(QuestionType::TEXT); "upper: TEXT")]
-    #[test_case("text"     => Ok(QuestionType::TEXT); "lower: text")]
-    #[test_case("SINGLE" => Ok(QuestionType::SINGLE); "upper: SINGLE")]
-    #[test_case("single" => Ok(QuestionType::SINGLE); "lower: single")]
-    #[test_case("MULTIPLE" => Ok(QuestionType::MULTIPLE); "upper: MULTIPLE")]
-    #[test_case("multiple" => Ok(QuestionType::MULTIPLE); "lower: multiple")]
+    #[test_case("TEXT" => Ok(QuestionType::Text); "legacy upper text")]
+    #[test_case("text" => Ok(QuestionType::Text); "legacy lower text")]
+    #[test_case("Text" => Ok(QuestionType::Text); "new text")]
+    #[test_case("SINGLE" => Ok(QuestionType::SingleChoice); "legacy upper single")]
+    #[test_case("single" => Ok(QuestionType::SingleChoice); "legacy lower single")]
+    #[test_case("SingleChoice" => Ok(QuestionType::SingleChoice); "new single")]
+    #[test_case("MULTIPLE" => Ok(QuestionType::MultipleChoice); "legacy upper multiple")]
+    #[test_case("multiple" => Ok(QuestionType::MultipleChoice); "legacy lower multiple")]
+    #[test_case("MultipleChoice" => Ok(QuestionType::MultipleChoice); "new multiple")]
     fn string_to_question_type(input: &str) -> Result<QuestionType, DomainError> {
         input.to_owned().try_into()
+    }
+
+    #[test]
+    fn text_question_rejects_choices() {
+        let result = Question::new(
+            Some(1.into()),
+            FormId::from(Uuid::nil()),
+            "template".to_string(),
+            0,
+            "Question".to_string(),
+            None,
+            QuestionType::Text,
+            Some(
+                NonEmptyVec::try_new(vec![Choice::new(None, 0, "A".to_string()).unwrap()]).unwrap(),
+            ),
+            true,
+        );
+
+        assert!(matches!(result, Err(DomainError::InvalidEntity { .. })));
+    }
+
+    #[test]
+    fn validate_question_set_requires_unique_template_keys_and_contiguous_positions() {
+        let form_id = FormId::from(Uuid::nil());
+        let questions = vec![
+            Question::new(
+                Some(1.into()),
+                form_id,
+                "same".to_string(),
+                0,
+                "Question 1".to_string(),
+                None,
+                QuestionType::Text,
+                None,
+                true,
+            )
+            .unwrap(),
+            Question::new(
+                Some(2.into()),
+                form_id,
+                "same".to_string(),
+                2,
+                "Question 2".to_string(),
+                None,
+                QuestionType::Text,
+                None,
+                false,
+            )
+            .unwrap(),
+        ];
+
+        assert!(matches!(
+            Question::validate_set(&questions),
+            Err(DomainError::InvalidEntity { .. })
+        ));
     }
 }

--- a/server/domain/src/form/service.rs
+++ b/server/domain/src/form/service.rs
@@ -1,5 +1,6 @@
 use errors::{Error, domain::DomainError};
 use regex::Regex;
+use std::collections::HashMap;
 
 use crate::{
     form::{
@@ -8,6 +9,7 @@ use crate::{
             settings::models::DefaultAnswerTitle,
         },
         models::FormId,
+        question::models::Question,
     },
     repository::form::{
         answer_repository::AnswerRepository, form_repository::FormRepository,
@@ -32,27 +34,39 @@ impl<FormRepo: FormRepository, QuestionRepo: QuestionRepository, AnswerRepo: Ans
 {
     fn generate_embedded_answer_title(
         default_answer_title: DefaultAnswerTitle,
+        questions: &[Question],
         answers: &[FormAnswerContent],
         actor: &User,
     ) -> Result<AnswerTitle, Error> {
         match default_answer_title.into_inner() {
             Some(default_answer_title) => {
                 let default_answer_title = default_answer_title.to_string();
-                let regex = Regex::new(r"\$\d+").unwrap();
+                let regex = Regex::new(r"\{\{question\.([A-Za-z0-9_-]+)\}\}").unwrap();
+                let question_template_key_by_id = questions
+                    .iter()
+                    .filter_map(|question| {
+                        question
+                            .id
+                            .map(|id| (id.into_inner(), question.template_key.as_str()))
+                    })
+                    .collect::<HashMap<_, _>>();
+                let answers_by_template_key = answers
+                    .iter()
+                    .filter_map(|answer| {
+                        question_template_key_by_id
+                            .get(&answer.question_id.into_inner())
+                            .map(|template_key| (*template_key, answer.answer.as_str()))
+                    })
+                    .collect::<HashMap<_, _>>();
 
                 let answer_replaced_title: String = regex
-                    .find_iter(default_answer_title.to_owned().as_str())
-                    .fold(default_answer_title, |replaced_title, question_id| {
-                        let answer_opt = answers.iter().find(|answer| {
-                            answer.question_id.to_string() == question_id.as_str().replace('$', "")
-                        });
-                        replaced_title.replace(
-                            question_id.as_str(),
-                            &answer_opt
-                                .map(|answer| answer.answer.to_owned().to_string())
-                                .unwrap_or_default(),
-                        )
-                    });
+                    .replace_all(default_answer_title.as_str(), |caps: &regex::Captures| {
+                        answers_by_template_key
+                            .get(&caps[1])
+                            .copied()
+                            .unwrap_or_default()
+                    })
+                    .into_owned();
 
                 let username_replaced_title =
                     answer_replaced_title.replace("$username", actor.name.as_str());
@@ -81,8 +95,15 @@ impl<FormRepo: FormRepository, QuestionRepo: QuestionRepository, AnswerRepo: Ans
             .answer_settings()
             .default_answer_title()
             .to_owned();
+        let questions = self
+            .question_repo
+            .get_questions(form_id)
+            .await?
+            .into_iter()
+            .map(|question| question.try_into_read(actor))
+            .collect::<Result<Vec<_>, _>>()?;
 
-        Self::generate_embedded_answer_title(default_answer_title, answers, actor)
+        Self::generate_embedded_answer_title(default_answer_title, &questions, answers, actor)
     }
 }
 
@@ -107,12 +128,50 @@ mod tests {
         let third_question_id = QuestionId::from(2);
 
         let default_answer_title = DefaultAnswerTitle::new(Some(
-            NonEmptyString::try_new(format!(
-                "Answer to ${}, ${}, ${} by $username($username)",
-                first_question_id, second_question_id, third_question_id
-            ))
+            NonEmptyString::try_new(
+                "Answer to {{question.first}}, {{question.second}}, {{question.third}} by $username($username)"
+                    .to_string(),
+            )
             .unwrap(),
         ));
+        let questions = vec![
+            Question::from_raw_parts(
+                Some(first_question_id),
+                Default::default(),
+                "first".to_string(),
+                0,
+                "First".to_string(),
+                None,
+                crate::form::question::models::QuestionType::Text,
+                None,
+                true,
+            )
+            .unwrap(),
+            Question::from_raw_parts(
+                Some(second_question_id),
+                Default::default(),
+                "second".to_string(),
+                1,
+                "Second".to_string(),
+                None,
+                crate::form::question::models::QuestionType::Text,
+                None,
+                true,
+            )
+            .unwrap(),
+            Question::from_raw_parts(
+                Some(third_question_id),
+                Default::default(),
+                "third".to_string(),
+                2,
+                "Third".to_string(),
+                None,
+                crate::form::question::models::QuestionType::Text,
+                None,
+                true,
+            )
+            .unwrap(),
+        ];
         let answers = vec![
             FormAnswerContent {
                 id: FormAnswerContentId::new(),
@@ -142,7 +201,10 @@ mod tests {
             MockQuestionRepository,
             MockAnswerRepository,
         >::generate_embedded_answer_title(
-            default_answer_title, answers.as_slice(), &actor
+            default_answer_title,
+            questions.as_slice(),
+            answers.as_slice(),
+            &actor,
         )
         .unwrap();
 

--- a/server/domain/src/form/service.rs
+++ b/server/domain/src/form/service.rs
@@ -1,6 +1,7 @@
 use errors::{Error, domain::DomainError};
 use regex::Regex;
 use std::collections::HashMap;
+use std::sync::OnceLock;
 
 use crate::{
     form::{
@@ -41,7 +42,6 @@ impl<FormRepo: FormRepository, QuestionRepo: QuestionRepository, AnswerRepo: Ans
         match default_answer_title.into_inner() {
             Some(default_answer_title) => {
                 let default_answer_title = default_answer_title.to_string();
-                let regex = Regex::new(r"\{\{question\.([A-Za-z0-9_-]+)\}\}").unwrap();
                 let question_template_key_by_id = questions
                     .iter()
                     .filter_map(|question| {
@@ -59,7 +59,7 @@ impl<FormRepo: FormRepository, QuestionRepo: QuestionRepository, AnswerRepo: Ans
                     })
                     .collect::<HashMap<_, _>>();
 
-                let answer_replaced_title: String = regex
+                let answer_replaced_title: String = question_placeholder_regex()
                     .replace_all(default_answer_title.as_str(), |caps: &regex::Captures| {
                         answers_by_template_key
                             .get(&caps[1])
@@ -105,6 +105,11 @@ impl<FormRepo: FormRepository, QuestionRepo: QuestionRepository, AnswerRepo: Ans
 
         Self::generate_embedded_answer_title(default_answer_title, &questions, answers, actor)
     }
+}
+
+fn question_placeholder_regex() -> &'static Regex {
+    static REGEX: OnceLock<Regex> = OnceLock::new();
+    REGEX.get_or_init(|| Regex::new(r"\{\{question\.([A-Za-z0-9_-]+)\}\}").unwrap())
 }
 
 #[cfg(test)]

--- a/server/domain/src/form/service.rs
+++ b/server/domain/src/form/service.rs
@@ -6,7 +6,7 @@ use std::sync::OnceLock;
 use crate::{
     form::{
         answer::{
-            models::{AnswerTitle, FormAnswerContent},
+            models::{AnswerTitle, PostedAnswerContents},
             settings::models::DefaultAnswerTitle,
         },
         models::FormId,
@@ -33,10 +33,10 @@ pub struct DefaultAnswerTitleDomainService<
 impl<FormRepo: FormRepository, QuestionRepo: QuestionRepository, AnswerRepo: AnswerRepository>
     DefaultAnswerTitleDomainService<'_, FormRepo, QuestionRepo, AnswerRepo>
 {
-    fn generate_embedded_answer_title(
+    pub fn to_answer_title_from_questions(
         default_answer_title: DefaultAnswerTitle,
         questions: &[Question],
-        answers: &[FormAnswerContent],
+        answers: &PostedAnswerContents,
         actor: &User,
     ) -> Result<AnswerTitle, Error> {
         match default_answer_title.into_inner() {
@@ -51,6 +51,7 @@ impl<FormRepo: FormRepository, QuestionRepo: QuestionRepository, AnswerRepo: Ans
                     })
                     .collect::<HashMap<_, _>>();
                 let answers_by_template_key = answers
+                    .as_slice()
                     .iter()
                     .filter_map(|answer| {
                         question_template_key_by_id
@@ -81,7 +82,7 @@ impl<FormRepo: FormRepository, QuestionRepo: QuestionRepository, AnswerRepo: Ans
         &self,
         actor: &User,
         form_id: FormId,
-        answers: &[FormAnswerContent],
+        answers: &PostedAnswerContents,
     ) -> Result<AnswerTitle, Error> {
         let form = self
             .form_repo
@@ -103,7 +104,7 @@ impl<FormRepo: FormRepository, QuestionRepo: QuestionRepository, AnswerRepo: Ans
             .map(|question| question.try_into_read(actor))
             .collect::<Result<Vec<_>, _>>()?;
 
-        Self::generate_embedded_answer_title(default_answer_title, &questions, answers, actor)
+        Self::to_answer_title_from_questions(default_answer_title, &questions, answers, actor)
     }
 }
 
@@ -177,23 +178,27 @@ mod tests {
             )
             .unwrap(),
         ];
-        let answers = vec![
-            FormAnswerContent {
-                id: FormAnswerContentId::new(),
-                question_id: first_question_id,
-                answer: "Answer1".to_string(),
-            },
-            FormAnswerContent {
-                id: FormAnswerContentId::new(),
-                question_id: second_question_id,
-                answer: "Answer2".to_string(),
-            },
-            FormAnswerContent {
-                id: FormAnswerContentId::new(),
-                question_id: third_question_id,
-                answer: "Answer3".to_string(),
-            },
-        ];
+        let answers = PostedAnswerContents::try_new(
+            questions.as_slice(),
+            vec![
+                FormAnswerContent {
+                    id: FormAnswerContentId::new(),
+                    question_id: first_question_id,
+                    answer: "Answer1".to_string(),
+                },
+                FormAnswerContent {
+                    id: FormAnswerContentId::new(),
+                    question_id: second_question_id,
+                    answer: "Answer2".to_string(),
+                },
+                FormAnswerContent {
+                    id: FormAnswerContentId::new(),
+                    question_id: third_question_id,
+                    answer: "Answer3".to_string(),
+                },
+            ],
+        )
+        .unwrap();
 
         let actor = User {
             name: "respondent_name".to_string(),
@@ -205,10 +210,10 @@ mod tests {
             MockFormRepository,
             MockQuestionRepository,
             MockAnswerRepository,
-        >::generate_embedded_answer_title(
+        >::to_answer_title_from_questions(
             default_answer_title,
             questions.as_slice(),
-            answers.as_slice(),
+            &answers,
             &actor,
         )
         .unwrap();

--- a/server/entrypoint/src/main.rs
+++ b/server/entrypoint/src/main.rs
@@ -63,7 +63,7 @@ use utoipa_swagger_ui::SwaggerUi;
         presentation::schemas::form::form_response_schemas::FormSchema,
         presentation::schemas::form::form_response_schemas::FormSettingsSchema,
         presentation::schemas::form::form_response_schemas::MessageContentSchema,
-        presentation::schemas::form::form_response_schemas::PutQuestionsResponseSchema,
+        presentation::schemas::form::form_response_schemas::ChoiceResponseSchema,
         presentation::schemas::form::form_response_schemas::QuestionResponseSchema,
         presentation::schemas::form::form_response_schemas::ResponsePeriodSchema,
         presentation::schemas::form::form_response_schemas::Role,
@@ -180,10 +180,7 @@ async fn main() -> anyhow::Result<()> {
             answer_handler::get_answer_by_form_id_handler,
             answer_handler::post_answer_handler
         ))
-        .routes(routes!(
-            question_handler::get_questions_handler,
-            question_handler::put_question_handler
-        ))
+        .routes(routes!(question_handler::get_questions_handler))
         .routes(routes!(answer_handler::get_all_answers))
         .routes(routes!(
             answer_label_handler::get_labels_for_answers,

--- a/server/errors/src/domain.rs
+++ b/server/errors/src/domain.rs
@@ -17,4 +17,6 @@ pub enum DomainError {
     InvalidResponsePeriod,
     #[error("Invalid webhook url.")]
     InvalidWebhookUrl,
+    #[error("Invalid entity: {message}")]
+    InvalidEntity { message: String },
 }

--- a/server/infra/resource/src/database/forms/question.rs
+++ b/server/infra/resource/src/database/forms/question.rs
@@ -234,12 +234,11 @@ async fn insert_new_questions<'a>(
         .execute(&mut *txn)
         .await?;
 
-    let last_insert_id = result.last_insert_id() as i32;
-    let first_insert_id = last_insert_id - questions.len() as i32 + 1;
+    let first_insert_id = result.last_insert_id() as i32;
 
     Ok(questions
         .into_iter()
-        .zip(first_insert_id..=last_insert_id)
+        .zip(first_insert_id..)
         .map(|(question, question_id)| (question_id, question))
         .collect())
 }
@@ -380,6 +379,7 @@ async fn upsert_existing_choices(
     let sql = format!(
         r"INSERT INTO form_choices (id, question_id, position, label) VALUES {}
         ON DUPLICATE KEY UPDATE
+        question_id = VALUES(question_id),
         position = VALUES(position),
         label = VALUES(label)",
         std::iter::repeat_n("(?, ?, ?, ?)", choices.len()).join(", ")

--- a/server/infra/resource/src/database/forms/question.rs
+++ b/server/infra/resource/src/database/forms/question.rs
@@ -1,12 +1,16 @@
 use async_trait::async_trait;
-use domain::form::{models::FormId, question::models::Question};
+use domain::form::{
+    models::FormId,
+    question::models::{Question, QuestionType},
+};
 use errors::infra::InfraError;
 use itertools::Itertools;
-use sqlx::{Row, query};
+use sqlx::{MySqlConnection, Row, query};
+use std::collections::{BTreeMap, BTreeSet};
 
 use crate::{
     database::{components::FormQuestionDatabase, connection::ConnectionPool},
-    dto::QuestionDto,
+    dto::{ChoiceDto, QuestionDto},
 };
 
 #[async_trait]
@@ -17,70 +21,18 @@ impl FormQuestionDatabase for ConnectionPool {
         form_id: FormId,
         questions: Vec<Question>,
     ) -> Result<(), InfraError> {
-        let questions = questions.to_owned();
-        let form_id = form_id.into_inner().to_string();
-
         self.read_write_transaction(|txn| {
             Box::pin(async move {
-                if !questions.is_empty() {
-                    let sql = format!(
-                        "INSERT INTO form_questions (form_id, title, description, question_type, is_required) VALUES {}",
-                        std::iter::repeat_n("(?, ?, ?, ?, ?)", questions.len()).join(", ")
-                    );
-                    questions
-                        .iter()
-                        .fold(query(&sql), |query, question| {
-                            query
-                                .bind(form_id.clone())
-                                .bind(question.title.clone())
-                                .bind(question.description.clone())
-                                .bind(question.question_type.to_string())
-                                .bind(*question.is_required())
-                        })
-                        .execute(&mut **txn)
-                        .await?;
-
-                    let last_insert_id = sqlx::query_scalar!(
-                        "SELECT question_id AS `question_id!: i32` FROM form_questions ORDER BY question_id DESC LIMIT 1"
-                    )
-                    .fetch_one(&mut **txn)
-                    .await?;
-
-                    let choices_active_values = questions
-                        .iter()
-                        .rev()
-                        .zip((1..=last_insert_id).rev())
-                        .filter(|(q, _)| {
-                            !q.choices.is_empty()
-                                && q.question_type
-                                    != domain::form::question::models::QuestionType::TEXT
-                        })
-                        .flat_map(|(question, question_id)| {
-                            question
-                                .choices
-                                .iter()
-                                .cloned()
-                                .map(move |choice| (question_id.to_string(), choice))
-                        })
-                        .collect_vec();
-
-                    if !choices_active_values.is_empty() {
-                        let sql = format!(
-                            "INSERT INTO form_choices (question_id, choice) VALUES {}",
-                            std::iter::repeat_n("(?, ?)", choices_active_values.len()).join(", ")
-                        );
-                        choices_active_values
-                            .into_iter()
-                            .flat_map(|(question_id, choice)| [question_id, choice])
-                            .fold(query(&sql), |query, value| query.bind(value))
-                            .execute(&mut **txn)
-                            .await?;
-                    }
+                if questions.is_empty() {
+                    return Ok::<_, InfraError>(());
                 }
 
-                Ok::<_, InfraError>(())
+                let assigned_questions =
+                    insert_new_questions(txn, &form_id, questions.iter().collect_vec()).await?;
+                sync_choices_for_questions(txn, &assigned_questions).await
             })
-        }).await
+        })
+        .await
     }
 
     #[tracing::instrument]
@@ -89,125 +41,42 @@ impl FormQuestionDatabase for ConnectionPool {
         form_id: FormId,
         questions: Vec<Question>,
     ) -> Result<(), InfraError> {
-        let form_id = form_id.into_inner().to_string();
-
         self.read_write_transaction(|txn| {
             Box::pin(async move {
-                let current_form_question_ids = sqlx::query(
-                    "SELECT question_id FROM form_questions WHERE form_id = ?",
-                )
-                .bind(form_id.clone())
-                .fetch_all(&mut **txn)
-                .await?
-                .into_iter()
-                .map(|row| row.try_get::<i32, _>("question_id"))
-                .collect::<Result<Vec<_>, _>>()?;
+                let form_id_string = form_id.into_inner().to_string();
+                let existing_question_ids = fetch_question_ids(txn, &form_id_string).await?;
 
-                let delete_target_question_ids = current_form_question_ids
-                    .into_iter()
-                    .filter(|question_id| {
-                        !questions
+                let (existing_questions, new_questions): (Vec<_>, Vec<_>) =
+                    questions.iter().partition(|question| question.id.is_some());
+
+                upsert_existing_questions(txn, &form_id_string, &existing_questions).await?;
+                let inserted_questions = insert_new_questions(txn, &form_id, new_questions).await?;
+
+                let retained_question_ids = existing_questions
+                    .iter()
+                    .filter_map(|question| question.id.map(|id| id.into_inner()))
+                    .chain(
+                        inserted_questions
                             .iter()
-                            .any(|question| question.id.map(|id| id.into_inner()) == Some(*question_id))
-                    })
+                            .map(|(question_id, _)| *question_id),
+                    )
+                    .collect::<BTreeSet<_>>();
+                delete_questions(
+                    txn,
+                    existing_question_ids
+                        .into_iter()
+                        .filter(|question_id| !retained_question_ids.contains(question_id))
+                        .collect_vec(),
+                )
+                .await?;
+
+                let assigned_questions = existing_questions
+                    .into_iter()
+                    .filter_map(|question| question.id.map(|id| (id.into_inner(), question)))
+                    .chain(inserted_questions)
                     .collect_vec();
 
-                if !delete_target_question_ids.is_empty() {
-                    let sql = format!(
-                        "DELETE FROM form_questions WHERE question_id IN ({})",
-                        std::iter::repeat_n("?", delete_target_question_ids.len()).join(", ")
-                    );
-                    delete_target_question_ids
-                        .iter()
-                        .fold(query(&sql), |query, question_id| query.bind(question_id))
-                        .execute(&mut **txn)
-                        .await?;
-                }
-
-                if !questions.is_empty() {
-                    let sql = format!(
-                        r"INSERT INTO form_questions (question_id, form_id, title, description, question_type, is_required)
-                        VALUES {}
-                        ON DUPLICATE KEY UPDATE
-                        title = VALUES(title),
-                        description = VALUES(description),
-                        question_type = VALUES(question_type),
-                        is_required = VALUES(is_required)",
-                        std::iter::repeat_n("(?, ?, ?, ?, ?, ?)", questions.len()).join(", ")
-                    );
-                    questions
-                        .iter()
-                        .fold(query(&sql), |query, question| {
-                            query
-                                .bind(question.id.map(|id| id.into_inner()))
-                                .bind(form_id.clone())
-                                .bind(question.title.clone())
-                                .bind(question.description.clone())
-                                .bind(question.question_type.to_string())
-                                .bind(*question.is_required())
-                        })
-                        .execute(&mut **txn)
-                        .await?;
-
-                    let last_insert_id = sqlx::query_scalar!(
-                        "SELECT question_id AS `question_id!: i32` FROM form_questions ORDER BY question_id DESC LIMIT 1"
-                    )
-                    .fetch_one(&mut **txn)
-                    .await?;
-
-                    let choices_active_values = questions
-                        .iter()
-                        .rev()
-                        .zip((1..=last_insert_id).rev())
-                        .filter(|(q, _)| {
-                            !q.choices.is_empty()
-                                && q.question_type
-                                    != domain::form::question::models::QuestionType::TEXT
-                        })
-                        .flat_map(|(question, question_id)| {
-                            question
-                                .choices
-                                .iter()
-                                .cloned()
-                                .map(move |choice| (question_id.to_string(), choice))
-                        })
-                        .collect_vec();
-
-                    let current_question_ids = questions
-                        .iter()
-                        .filter_map(|question| question.id.map(|id| id.into_inner()))
-                        .collect_vec();
-
-                    // TODO: 現在の API の仕様上、form_choices で割り当てられているidをバックエンドから送信することはないため、
-                    //  ON DUPLICATE KEY UPDATE を使用せずに完全に選択肢を上書きしているが、API の仕様を変更して choice_id を公開し、
-                    //  それを使って選択肢の更新を行うべきか検討する
-                    if !current_question_ids.is_empty() {
-                        let sql = format!(
-                            "DELETE FROM form_choices WHERE question_id IN ({})",
-                            std::iter::repeat_n("?", current_question_ids.len()).join(", ")
-                        );
-                        current_question_ids
-                            .iter()
-                            .fold(query(&sql), |query, question_id| query.bind(question_id))
-                            .execute(&mut **txn)
-                            .await?;
-                    }
-
-                    if !choices_active_values.is_empty() {
-                        let sql = format!(
-                            "INSERT INTO form_choices (question_id, choice) VALUES {}",
-                            std::iter::repeat_n("(?, ?)", choices_active_values.len()).join(", ")
-                        );
-                        choices_active_values
-                            .into_iter()
-                            .flat_map(|(question_id, choice)| [question_id, choice])
-                            .fold(query(&sql), |query, value| query.bind(value))
-                            .execute(&mut **txn)
-                            .await?;
-                    }
-                }
-
-                Ok::<_, InfraError>(())
+                sync_choices_for_questions(txn, &assigned_questions).await
             })
         })
         .await
@@ -219,46 +88,57 @@ impl FormQuestionDatabase for ConnectionPool {
             Box::pin(async move {
                 let form_id = form_id.into_inner().to_string();
                 let questions_rs = sqlx::query(
-                    r"SELECT question_id AS `question_id!: i32`, form_id, title, description, question_type, is_required
-                    FROM form_questions WHERE form_id = ?",
+                    r"SELECT question_id, form_id, template_key, position, title, description, question_type, is_required
+                    FROM form_questions
+                    WHERE form_id = ?
+                    ORDER BY position ASC, question_id ASC",
                 )
                 .bind(form_id.clone())
                 .fetch_all(&mut **txn)
                 .await?;
 
-                let choices_rs = sqlx::query(
-                    r"SELECT form_choices.question_id, choice FROM form_choices
+                let choices_by_question_id = sqlx::query(
+                    r"SELECT form_choices.id, form_choices.question_id, form_choices.position, form_choices.label
+                    FROM form_choices
                     INNER JOIN form_questions ON form_choices.question_id = form_questions.question_id
-                    WHERE form_id = ?",
+                    WHERE form_questions.form_id = ?
+                    ORDER BY form_choices.position ASC, form_choices.id ASC",
                 )
                 .bind(form_id)
                 .fetch_all(&mut **txn)
-                .await?;
+                .await?
+                .into_iter()
+                .map(|choice_rs| {
+                    Ok::<_, InfraError>((
+                        choice_rs.try_get::<i32, _>("question_id")?,
+                        ChoiceDto {
+                            id: Some(choice_rs.try_get("id")?),
+                            position: choice_rs.try_get::<u16, _>("position")?,
+                            label: choice_rs.try_get("label")?,
+                        },
+                    ))
+                })
+                .collect::<Result<Vec<_>, _>>()?
+                .into_iter()
+                .into_group_map();
 
                 questions_rs
                     .into_iter()
                     .map(|question_rs| {
                         let question_id = question_rs.try_get::<i32, _>("question_id")?;
 
-                        let choices = choices_rs
-                            .iter()
-                            .filter(|choice_rs| {
-                                choice_rs
-                                    .try_get::<i32, _>("question_id")
-                                    .is_ok_and(|id| id == question_id)
-                            })
-                            .filter_map(|choice_rs| choice_rs.try_get::<String, _>("choice").ok())
-                            .collect_vec();
-
                         Ok::<_, InfraError>(QuestionDto {
                             id: Some(question_id),
                             form_id: question_rs.try_get("form_id")?,
+                            template_key: question_rs.try_get("template_key")?,
+                            position: question_rs.try_get::<u16, _>("position")?,
                             title: question_rs.try_get("title")?,
                             description: question_rs.try_get("description")?,
-                            question_type: question_rs
-                                .try_get::<Option<String>, _>("question_type")?
+                            question_type: question_rs.try_get::<String, _>("question_type")?,
+                            choices: choices_by_question_id
+                                .get(&question_id)
+                                .cloned()
                                 .unwrap_or_default(),
-                            choices,
                             is_required: question_rs
                                 .try_get::<Option<bool>, _>("is_required")?
                                 .unwrap_or(false),
@@ -266,6 +146,298 @@ impl FormQuestionDatabase for ConnectionPool {
                     })
                     .collect::<Result<Vec<QuestionDto>, _>>()
             })
-        }).await
+        })
+        .await
+    }
+}
+
+async fn fetch_question_ids(
+    txn: &mut MySqlConnection,
+    form_id: &str,
+) -> Result<Vec<i32>, InfraError> {
+    sqlx::query("SELECT question_id FROM form_questions WHERE form_id = ? ORDER BY position ASC")
+        .bind(form_id)
+        .fetch_all(&mut *txn)
+        .await?
+        .into_iter()
+        .map(|row| row.try_get::<i32, _>("question_id"))
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(Into::into)
+}
+
+async fn upsert_existing_questions(
+    txn: &mut MySqlConnection,
+    form_id: &str,
+    questions: &[&Question],
+) -> Result<(), InfraError> {
+    if questions.is_empty() {
+        return Ok(());
+    }
+
+    let sql = format!(
+        r"INSERT INTO form_questions (question_id, form_id, template_key, position, title, description, question_type, is_required)
+        VALUES {}
+        ON DUPLICATE KEY UPDATE
+        template_key = VALUES(template_key),
+        position = VALUES(position),
+        title = VALUES(title),
+        description = VALUES(description),
+        question_type = VALUES(question_type),
+        is_required = VALUES(is_required)",
+        std::iter::repeat_n("(?, ?, ?, ?, ?, ?, ?, ?)", questions.len()).join(", ")
+    );
+
+    questions
+        .iter()
+        .fold(query(&sql), |query, question| {
+            query
+                .bind(question.id.map(|id| id.into_inner()))
+                .bind(form_id)
+                .bind(question.template_key.clone())
+                .bind(question.position)
+                .bind(question.title.clone())
+                .bind(question.description.clone())
+                .bind(question.question_type.to_string())
+                .bind(question.is_required)
+        })
+        .execute(&mut *txn)
+        .await?;
+
+    Ok(())
+}
+
+async fn insert_new_questions<'a>(
+    txn: &mut MySqlConnection,
+    form_id: &FormId,
+    questions: Vec<&'a Question>,
+) -> Result<Vec<(i32, &'a Question)>, InfraError> {
+    if questions.is_empty() {
+        return Ok(vec![]);
+    }
+
+    let sql = format!(
+        "INSERT INTO form_questions (form_id, template_key, position, title, description, question_type, is_required) VALUES {}",
+        std::iter::repeat_n("(?, ?, ?, ?, ?, ?, ?)", questions.len()).join(", ")
+    );
+    let result = questions
+        .iter()
+        .fold(query(&sql), |query, question| {
+            query
+                .bind(form_id.to_owned().into_inner().to_string())
+                .bind(question.template_key.clone())
+                .bind(question.position)
+                .bind(question.title.clone())
+                .bind(question.description.clone())
+                .bind(question.question_type.to_string())
+                .bind(question.is_required)
+        })
+        .execute(&mut *txn)
+        .await?;
+
+    let last_insert_id = result.last_insert_id() as i32;
+    let first_insert_id = last_insert_id - questions.len() as i32 + 1;
+
+    Ok(questions
+        .into_iter()
+        .zip(first_insert_id..=last_insert_id)
+        .map(|(question, question_id)| (question_id, question))
+        .collect())
+}
+
+async fn delete_questions(
+    txn: &mut MySqlConnection,
+    question_ids: Vec<i32>,
+) -> Result<(), InfraError> {
+    if question_ids.is_empty() {
+        return Ok(());
+    }
+
+    let sql = format!(
+        "DELETE FROM form_questions WHERE question_id IN ({})",
+        std::iter::repeat_n("?", question_ids.len()).join(", ")
+    );
+    question_ids
+        .iter()
+        .fold(query(&sql), |query, question_id| query.bind(question_id))
+        .execute(&mut *txn)
+        .await?;
+
+    Ok(())
+}
+
+async fn sync_choices_for_questions(
+    txn: &mut MySqlConnection,
+    assigned_questions: &[(i32, &Question)],
+) -> Result<(), InfraError> {
+    let question_ids = assigned_questions
+        .iter()
+        .map(|(question_id, _)| *question_id)
+        .collect_vec();
+    if question_ids.is_empty() {
+        return Ok(());
+    }
+
+    let existing_choice_by_id = fetch_existing_choices(txn, &question_ids).await?;
+    let retained_choice_ids = assigned_questions
+        .iter()
+        .flat_map(|(_, question)| {
+            question.choices.iter().flat_map(|choices| {
+                choices
+                    .iter()
+                    .filter_map(|choice| choice.id.map(|id| id.into_inner()))
+            })
+        })
+        .collect::<BTreeSet<_>>();
+
+    delete_choices(
+        txn,
+        existing_choice_by_id
+            .keys()
+            .filter(|choice_id| !retained_choice_ids.contains(choice_id))
+            .copied()
+            .collect_vec(),
+    )
+    .await?;
+
+    let existing_choices = assigned_questions
+        .iter()
+        .flat_map(|(question_id, question)| {
+            question.choices.iter().flat_map(|choices| {
+                choices.iter().filter_map(|choice| {
+                    choice.id.map(|id| {
+                        (
+                            id.into_inner(),
+                            *question_id,
+                            choice.position,
+                            choice.label.clone(),
+                        )
+                    })
+                })
+            })
+        })
+        .collect_vec();
+    upsert_existing_choices(txn, existing_choices).await?;
+
+    let new_choices = assigned_questions
+        .iter()
+        .filter(|(_, question)| question.question_type != QuestionType::Text)
+        .flat_map(|(question_id, question)| {
+            question.choices.iter().flat_map(|choices| {
+                choices
+                    .iter()
+                    .filter(|choice| choice.id.is_none())
+                    .map(|choice| (*question_id, choice.position, choice.label.clone()))
+            })
+        })
+        .collect_vec();
+    insert_new_choices(txn, new_choices).await
+}
+
+async fn fetch_existing_choices(
+    txn: &mut MySqlConnection,
+    question_ids: &[i32],
+) -> Result<BTreeMap<i32, i32>, InfraError> {
+    let sql = format!(
+        "SELECT id, question_id FROM form_choices WHERE question_id IN ({})",
+        std::iter::repeat_n("?", question_ids.len()).join(", ")
+    );
+
+    sqlx::query(&sql)
+        .bind_all(question_ids.iter().copied())
+        .fetch_all(&mut *txn)
+        .await?
+        .into_iter()
+        .map(|row| Ok::<_, InfraError>((row.try_get("id")?, row.try_get("question_id")?)))
+        .collect::<Result<BTreeMap<_, _>, _>>()
+}
+
+async fn delete_choices(txn: &mut MySqlConnection, choice_ids: Vec<i32>) -> Result<(), InfraError> {
+    if choice_ids.is_empty() {
+        return Ok(());
+    }
+
+    let sql = format!(
+        "DELETE FROM form_choices WHERE id IN ({})",
+        std::iter::repeat_n("?", choice_ids.len()).join(", ")
+    );
+    choice_ids
+        .iter()
+        .fold(query(&sql), |query, choice_id| query.bind(choice_id))
+        .execute(&mut *txn)
+        .await?;
+
+    Ok(())
+}
+
+async fn upsert_existing_choices(
+    txn: &mut MySqlConnection,
+    choices: Vec<(i32, i32, u16, String)>,
+) -> Result<(), InfraError> {
+    if choices.is_empty() {
+        return Ok(());
+    }
+
+    let sql = format!(
+        r"INSERT INTO form_choices (id, question_id, position, label) VALUES {}
+        ON DUPLICATE KEY UPDATE
+        position = VALUES(position),
+        label = VALUES(label)",
+        std::iter::repeat_n("(?, ?, ?, ?)", choices.len()).join(", ")
+    );
+    choices
+        .iter()
+        .fold(
+            query(&sql),
+            |query, (choice_id, question_id, position, label)| {
+                query
+                    .bind(choice_id)
+                    .bind(question_id)
+                    .bind(position)
+                    .bind(label)
+            },
+        )
+        .execute(&mut *txn)
+        .await?;
+
+    Ok(())
+}
+
+async fn insert_new_choices(
+    txn: &mut MySqlConnection,
+    choices: Vec<(i32, u16, String)>,
+) -> Result<(), InfraError> {
+    if choices.is_empty() {
+        return Ok(());
+    }
+
+    let sql = format!(
+        "INSERT INTO form_choices (question_id, position, label) VALUES {}",
+        std::iter::repeat_n("(?, ?, ?)", choices.len()).join(", ")
+    );
+    choices
+        .iter()
+        .fold(query(&sql), |query, (question_id, position, label)| {
+            query.bind(question_id).bind(position).bind(label)
+        })
+        .execute(&mut *txn)
+        .await?;
+
+    Ok(())
+}
+
+trait BindAll<'a> {
+    fn bind_all<T>(self, values: T) -> Self
+    where
+        T: IntoIterator<Item = i32>;
+}
+
+impl<'a> BindAll<'a> for sqlx::query::Query<'a, sqlx::MySql, sqlx::mysql::MySqlArguments> {
+    fn bind_all<T>(self, values: T) -> Self
+    where
+        T: IntoIterator<Item = i32>,
+    {
+        values
+            .into_iter()
+            .fold(self, |query, value| query.bind(value))
     }
 }

--- a/server/infra/resource/src/dto.rs
+++ b/server/infra/resource/src/dto.rs
@@ -9,22 +9,46 @@ use domain::{
         },
         comment::models::CommentContent,
         models::{FormDescription, FormId, FormMeta, FormSettings, FormTitle, WebhookUrl},
-        question::models::{Question, QuestionType},
+        question::models::{Choice, Question, QuestionType},
     },
     user::models::{Role, User},
 };
 use errors::infra::InfraError;
 use types::non_empty_string::NonEmptyString;
+use types::non_empty_vec::NonEmptyVec;
 use uuid::Uuid;
+
+#[derive(Clone)]
+pub struct ChoiceDto {
+    pub id: Option<i32>,
+    pub position: u16,
+    pub label: String,
+}
+
+impl TryFrom<ChoiceDto> for Choice {
+    type Error = errors::Error;
+
+    fn try_from(
+        ChoiceDto {
+            id,
+            position,
+            label,
+        }: ChoiceDto,
+    ) -> Result<Self, Self::Error> {
+        Choice::from_raw_parts(id.map(Into::into), position, label).map_err(Into::into)
+    }
+}
 
 #[derive(Clone)]
 pub struct QuestionDto {
     pub id: Option<i32>,
     pub form_id: String,
+    pub template_key: String,
+    pub position: u16,
     pub title: String,
     pub description: Option<String>,
     pub question_type: String,
-    pub choices: Vec<String>,
+    pub choices: Vec<ChoiceDto>,
     pub is_required: bool,
 }
 
@@ -35,6 +59,8 @@ impl TryFrom<QuestionDto> for domain::form::question::models::Question {
         QuestionDto {
             id,
             form_id,
+            template_key,
+            position,
             title,
             description,
             question_type,
@@ -42,15 +68,25 @@ impl TryFrom<QuestionDto> for domain::form::question::models::Question {
             is_required,
         }: QuestionDto,
     ) -> Result<Self, Self::Error> {
-        Ok(Question::from_raw_parts(
+        Question::from_raw_parts(
             id.map(Into::into),
             FormId::from(Uuid::from_str(&form_id).map_err(Into::<InfraError>::into)?),
+            template_key,
+            position,
             title,
             description,
             QuestionType::from_str(&question_type).map_err(Into::<InfraError>::into)?,
-            choices,
+            choices
+                .into_iter()
+                .map(TryInto::try_into)
+                .collect::<Result<Vec<_>, _>>()
+                .map(|choices| {
+                    (!choices.is_empty())
+                        .then(|| NonEmptyVec::try_new(choices).expect("non-empty choices"))
+                })?,
             is_required,
-        ))
+        )
+        .map_err(Into::into)
     }
 }
 

--- a/server/migration/migrations/20220101000001_create_table.up.sql
+++ b/server/migration/migrations/20220101000001_create_table.up.sql
@@ -34,17 +34,23 @@ CREATE TABLE IF NOT EXISTS form_meta_data(
 CREATE TABLE IF NOT EXISTS form_questions(
     question_id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
     form_id CHAR(36) NOT NULL,
+    template_key VARCHAR(255) NOT NULL,
+    position SMALLINT UNSIGNED NOT NULL,
     title TEXT NOT NULL,
     description TEXT,
-    question_type ENUM('TEXT', 'SINGLE', 'MULTIPLE'),
+    question_type VARCHAR(32) NOT NULL,
     is_required BOOL DEFAULT FALSE,
+    UNIQUE KEY uk_form_questions_form_id_template_key(form_id, template_key),
+    UNIQUE KEY uk_form_questions_form_id_position(form_id, position),
     FOREIGN KEY fk_form_questions_form_id(form_id) REFERENCES form_meta_data(id) ON DELETE CASCADE
 );
 
 CREATE TABLE IF NOT EXISTS form_choices(
     id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
     question_id INT NOT NULL,
-    choice TEXT NOT NULL,
+    position SMALLINT UNSIGNED NOT NULL,
+    label TEXT NOT NULL,
+    UNIQUE KEY uk_form_choices_question_id_position(question_id, position),
     FOREIGN KEY fk_form_choices_question_id(question_id) REFERENCES form_questions(question_id) ON DELETE CASCADE
 );
 

--- a/server/presentation/src/handlers/error_handler.rs
+++ b/server/presentation/src/handlers/error_handler.rs
@@ -67,6 +67,12 @@ fn handle_domain_error(err: DomainError) -> impl IntoResponse {
             "Invalid webhook url. (Seichi-Portal only supports Discord webhook)",
             "INVALID_WEBHOOK_URL",
         ),
+        DomainError::InvalidEntity { message } => problem_response(
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "Unprocessable Entity",
+            &message,
+            "INVALID_ENTITY",
+        ),
     }
 }
 

--- a/server/presentation/src/handlers/form/form_handler.rs
+++ b/server/presentation/src/handlers/form/form_handler.rs
@@ -6,7 +6,11 @@ use axum::{
     http::{HeaderValue, StatusCode, header},
     response::IntoResponse,
 };
-use domain::{form::models::FormId, repository::Repositories, user::models::User};
+use domain::{
+    form::{models::FormId, question::models::QuestionSet},
+    repository::Repositories,
+    user::models::User,
+};
 use itertools::Itertools;
 use resource::repository::RealInfrastructureRepository;
 use serde_json::json;
@@ -385,6 +389,7 @@ pub async fn update_form_handler(
                     )
                 })
                 .collect::<Result<Vec<_>, _>>()
+                .and_then(QuestionSet::try_new)
         })
         .transpose()
         .map_err(errors::Error::from)

--- a/server/presentation/src/handlers/form/form_handler.rs
+++ b/server/presentation/src/handlers/form/form_handler.rs
@@ -16,11 +16,14 @@ use crate::handlers::error_handler::handle_error;
 use crate::schemas::error_responses::*;
 use crate::schemas::form::{
     form_request_schemas::{FormCreateSchema, FormUpdateSchema, OffsetAndLimit},
-    form_response_schemas::{FormMetaSchema, FormSchema, FormSettingsSchema},
+    form_response_schemas::{
+        FormMetaSchema, FormSchema, FormSettingsSchema, QuestionResponseSchema,
+    },
 };
 use axum::extract::rejection::PathRejection;
 use domain::form::models::FormDescription;
 use errors::ErrorExtra;
+use types::non_empty_vec::NonEmptyVec;
 
 #[derive(utoipa::IntoResponses)]
 pub enum CreateFormResponse {
@@ -116,6 +119,7 @@ pub async fn create_form_handler(
         notification_repository: repository.notification_repository(),
         question_repository: repository.form_question_repository(),
         form_label_repository: repository.form_label_repository(),
+        answer_repository: repository.form_answer_repository(),
     };
 
     let Json(form) = json.map_err_to_error().map_err(handle_error)?;
@@ -166,6 +170,7 @@ pub async fn form_list_handler(
         notification_repository: repository.notification_repository(),
         question_repository: repository.form_question_repository(),
         form_label_repository: repository.form_label_repository(),
+        answer_repository: repository.form_answer_repository(),
     };
 
     let forms = form_use_case
@@ -181,7 +186,10 @@ pub async fn form_list_handler(
             description: form.description().to_owned(),
             settings: FormSettingsSchema::from_settings_ref(&user, form.settings()),
             metadata: FormMetaSchema::from_meta_ref(form.metadata()),
-            questions,
+            questions: questions
+                .into_iter()
+                .map(QuestionResponseSchema::from)
+                .collect(),
             labels,
         })
         .collect_vec();
@@ -217,6 +225,7 @@ pub async fn get_form_handler(
         notification_repository: repository.notification_repository(),
         question_repository: repository.form_question_repository(),
         form_label_repository: repository.form_label_repository(),
+        answer_repository: repository.form_answer_repository(),
     };
 
     let Path(form_id) = path.map_err_to_error().map_err(handle_error)?;
@@ -236,7 +245,10 @@ pub async fn get_form_handler(
         description: form.description().to_owned(),
         settings: FormSettingsSchema::from_settings_ref(&user, form.settings()),
         metadata: FormMetaSchema::from_meta_ref(form.metadata()),
-        questions,
+        questions: questions
+            .into_iter()
+            .map(QuestionResponseSchema::from)
+            .collect(),
         labels,
     }))
 }
@@ -269,6 +281,7 @@ pub async fn delete_form_handler(
         notification_repository: repository.notification_repository(),
         question_repository: repository.form_question_repository(),
         form_label_repository: repository.form_label_repository(),
+        answer_repository: repository.form_answer_repository(),
     };
 
     let Path(form_id) = path.map_err_to_error().map_err(handle_error)?;
@@ -282,7 +295,7 @@ pub async fn delete_form_handler(
 }
 
 #[utoipa::path(
-    patch,
+    put,
     path = "/forms/{id}",
     summary = "フォームの更新",
     params(
@@ -312,6 +325,7 @@ pub async fn update_form_handler(
         notification_repository: repository.notification_repository(),
         question_repository: repository.form_question_repository(),
         form_label_repository: repository.form_label_repository(),
+        answer_repository: repository.form_answer_repository(),
     };
 
     let Path(form_id) = path.map_err_to_error().map_err(handle_error)?;
@@ -340,6 +354,41 @@ pub async fn update_form_handler(
         } else {
             (None, None, None, None, None)
         };
+    let questions = targets
+        .questions
+        .map(|questions| {
+            questions
+                .into_iter()
+                .map(|question| {
+                    let choices = question
+                        .choices
+                        .into_iter()
+                        .map(|choice| {
+                            domain::form::question::models::Choice::new(
+                                choice.id,
+                                choice.position,
+                                choice.label,
+                            )
+                        })
+                        .collect::<Result<Vec<_>, _>>()?;
+                    domain::form::question::models::Question::new(
+                        question.id,
+                        form_id,
+                        question.template_key,
+                        question.position,
+                        question.title,
+                        question.description,
+                        question.question_type,
+                        (!choices.is_empty())
+                            .then(|| NonEmptyVec::try_new(choices).expect("non-empty choices")),
+                        question.is_required,
+                    )
+                })
+                .collect::<Result<Vec<_>, _>>()
+        })
+        .transpose()
+        .map_err(errors::Error::from)
+        .map_err(handle_error)?;
 
     let (updated_form, questions, labels) = form_use_case
         .update_form(
@@ -352,6 +401,7 @@ pub async fn update_form_handler(
             default_answer_title,
             visibility,
             answer_visibility,
+            questions,
         )
         .await
         .map_err(handle_error)?;
@@ -362,7 +412,10 @@ pub async fn update_form_handler(
         description: updated_form.description().to_owned(),
         settings: FormSettingsSchema::from_settings_ref(&user, updated_form.settings()),
         metadata: FormMetaSchema::from_meta_ref(updated_form.metadata()),
-        questions,
+        questions: questions
+            .into_iter()
+            .map(QuestionResponseSchema::from)
+            .collect(),
         labels,
     }))
 }

--- a/server/presentation/src/handlers/form/question_handler.rs
+++ b/server/presentation/src/handlers/form/question_handler.rs
@@ -1,25 +1,18 @@
 use axum::extract::rejection::PathRejection;
 use axum::{
     Extension, Json,
-    extract::{Path, State, rejection::JsonRejection},
+    extract::{Path, State},
     http::StatusCode,
     response::{IntoResponse, Response},
 };
-use domain::form::question::models::Question;
 use domain::{form::models::FormId, repository::Repositories, user::models::User};
 use errors::ErrorExtra;
-use itertools::Itertools;
 use resource::repository::RealInfrastructureRepository;
 use usecase::forms::question::QuestionUseCase;
 
+use crate::handlers::error_handler::handle_error;
 use crate::schemas::error_responses::*;
-use crate::schemas::form::form_response_schemas::{
-    PutQuestionsResponseSchema, QuestionResponseSchema,
-};
-use crate::{
-    handlers::error_handler::handle_error,
-    schemas::form::form_request_schemas::FormQuestionPutSchema,
-};
+use crate::schemas::form::form_response_schemas::QuestionResponseSchema;
 
 #[derive(utoipa::IntoResponses)]
 pub enum GetQuestionsResponse {
@@ -28,20 +21,6 @@ pub enum GetQuestionsResponse {
 }
 
 impl IntoResponse for GetQuestionsResponse {
-    fn into_response(self) -> Response {
-        match self {
-            Self::Ok(body) => (StatusCode::OK, Json(body)).into_response(),
-        }
-    }
-}
-
-#[derive(utoipa::IntoResponses)]
-pub enum PutQuestionsResponse {
-    #[response(status = 200, description = "The request has succeeded.")]
-    Ok(PutQuestionsResponseSchema),
-}
-
-impl IntoResponse for PutQuestionsResponse {
     fn into_response(self) -> Response {
         match self {
             Self::Ok(body) => (StatusCode::OK, Json(body)).into_response(),
@@ -85,63 +64,4 @@ pub async fn get_questions_handler(
     Ok(GetQuestionsResponse::Ok(
         questions.into_iter().map(Into::into).collect(),
     ))
-}
-
-#[utoipa::path(
-    put,
-    path = "/forms/{id}/questions",
-    summary = "質問の上書き",
-    params(
-        ("id" = String, Path, description = "Form ID"),
-    ),
-    request_body = FormQuestionPutSchema,
-    responses(
-        PutQuestionsResponse,
-        BadRequest,
-        Unauthorized,
-        Forbidden,
-        NotFound,
-        UnprocessableEntity,
-        InternalServerError,
-    ),
-    security(("bearer" = [])),
-    tag = "Questions"
-)]
-pub async fn put_question_handler(
-    Extension(user): Extension<User>,
-    State(repository): State<RealInfrastructureRepository>,
-    path: Result<Path<FormId>, PathRejection>,
-    json: Result<Json<FormQuestionPutSchema>, JsonRejection>,
-) -> Result<PutQuestionsResponse, Response> {
-    let question_use_case = QuestionUseCase {
-        question_repository: repository.form_question_repository(),
-    };
-
-    let Path(form_id) = path.map_err_to_error().map_err(handle_error)?;
-    let Json(schema) = json.map_err_to_error().map_err(handle_error)?;
-
-    let questions = schema
-        .questions
-        .iter()
-        .map(|question| {
-            Question::new(
-                question.id,
-                form_id,
-                question.title.clone(),
-                question.description.clone(),
-                question.question_type,
-                question.choices.clone(),
-                question.is_required,
-            )
-        })
-        .collect_vec();
-
-    let questions = question_use_case
-        .put_questions(&user, form_id, questions)
-        .await
-        .map_err(handle_error)?;
-
-    Ok(PutQuestionsResponse::Ok(PutQuestionsResponseSchema {
-        questions: questions.into_iter().map(Into::into).collect(),
-    }))
 }

--- a/server/presentation/src/schemas/form/form_request_schemas.rs
+++ b/server/presentation/src/schemas/form/form_request_schemas.rs
@@ -1,4 +1,4 @@
-use domain::form::question::models::{QuestionId, QuestionType};
+use domain::form::question::models::{ChoiceId, QuestionId, QuestionType};
 use domain::form::{
     answer::{
         models::{AnswerLabelId, AnswerTitle},
@@ -85,6 +85,8 @@ pub struct FormUpdateSchema {
     pub description: Option<String>,
     #[serde(default)]
     pub settings: Option<FormSettingsSchema>,
+    #[serde(default)]
+    pub questions: Option<Vec<QuestionSchema>>,
 }
 
 #[derive(Deserialize, Debug, utoipa::ToSchema)]
@@ -107,22 +109,26 @@ pub struct AnswerUpdateSchema {
 }
 
 #[derive(Deserialize, Debug, utoipa::ToSchema)]
+pub struct ChoiceSchema {
+    #[schema(value_type = Option<i32>)]
+    pub id: Option<ChoiceId>,
+    pub position: u16,
+    pub label: String,
+}
+
+#[derive(Deserialize, Debug, utoipa::ToSchema)]
 pub struct QuestionSchema {
     #[schema(value_type = Option<i32>)]
     pub id: Option<QuestionId>,
+    pub template_key: String,
+    pub position: u16,
     pub title: String,
     #[schema(value_type = String)]
     pub question_type: QuestionType,
     pub description: Option<String>,
     #[serde(default)]
-    pub choices: Vec<String>,
+    pub choices: Vec<ChoiceSchema>,
     pub is_required: bool,
-}
-
-#[derive(Deserialize, Debug, utoipa::ToSchema)]
-pub struct FormQuestionPutSchema {
-    #[serde(default)]
-    pub questions: Vec<QuestionSchema>,
 }
 
 #[derive(Deserialize, Debug, utoipa::ToSchema)]

--- a/server/presentation/src/schemas/form/form_response_schemas.rs
+++ b/server/presentation/src/schemas/form/form_response_schemas.rs
@@ -3,7 +3,7 @@ use domain::form::answer::settings::models::AnswerSettings;
 use domain::form::{
     answer::settings::models::DefaultAnswerTitle,
     models::{FormDescription, FormId, FormLabel, FormMeta, FormSettings, FormTitle, Visibility},
-    question::models::Question,
+    question::models::Choice,
 };
 use itertools::Itertools;
 use serde::Serialize;
@@ -107,8 +107,7 @@ pub struct FormSchema {
     pub description: FormDescription,
     pub settings: FormSettingsSchema,
     pub metadata: FormMetaSchema,
-    #[schema(value_type = Vec<QuestionResponseSchema>)]
-    pub questions: Vec<Question>,
+    pub questions: Vec<QuestionResponseSchema>,
     #[schema(value_type = Vec<FormLabelResponseSchema>)]
     pub labels: Vec<FormLabel>,
 }
@@ -117,10 +116,12 @@ pub struct FormSchema {
 pub struct QuestionResponseSchema {
     pub id: Option<i32>,
     pub form_id: String,
+    pub template_key: String,
+    pub position: u16,
     pub title: String,
     pub description: Option<String>,
     pub question_type: String,
-    pub choices: Vec<String>,
+    pub choices: Vec<ChoiceResponseSchema>,
     pub is_required: bool,
 }
 
@@ -129,11 +130,36 @@ impl From<domain::form::question::models::Question> for QuestionResponseSchema {
         QuestionResponseSchema {
             id: val.id.map(|id| id.into_inner()),
             form_id: val.form_id.into_inner().to_string(),
+            template_key: val.template_key,
+            position: val.position,
             title: val.title,
             description: val.description,
             question_type: val.question_type.to_string(),
-            choices: val.choices,
+            choices: val
+                .choices
+                .map(|choices| choices.into_inner())
+                .unwrap_or_default()
+                .into_iter()
+                .map(Into::into)
+                .collect(),
             is_required: val.is_required,
+        }
+    }
+}
+
+#[derive(Serialize, Debug, utoipa::ToSchema)]
+pub struct ChoiceResponseSchema {
+    pub id: Option<i32>,
+    pub position: u16,
+    pub label: String,
+}
+
+impl From<Choice> for ChoiceResponseSchema {
+    fn from(val: Choice) -> Self {
+        Self {
+            id: val.id.map(|id| id.into_inner()),
+            position: val.position,
+            label: val.label,
         }
     }
 }
@@ -166,11 +192,6 @@ impl From<domain::form::answer::models::AnswerLabel> for AnswerLabelResponseSche
             name: val.name().to_string(),
         }
     }
-}
-
-#[derive(Serialize, Debug, utoipa::ToSchema)]
-pub struct PutQuestionsResponseSchema {
-    pub questions: Vec<QuestionResponseSchema>,
 }
 
 #[derive(Serialize, Debug, utoipa::ToSchema)]

--- a/server/types/src/lib.rs
+++ b/server/types/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod natural_f32;
 pub mod non_empty_string;
+pub mod non_empty_vec;
 
 #[cfg(feature = "arbitrary")]
 use common::test_utils::arbitrary_uuid_v7;

--- a/server/types/src/non_empty_vec.rs
+++ b/server/types/src/non_empty_vec.rs
@@ -1,0 +1,83 @@
+use std::ops::Deref;
+
+use errors::validation::{ValidationError, ValidationError::EmptyValue};
+#[cfg(any(test, feature = "arbitrary"))]
+use proptest::{
+    arbitrary::Arbitrary,
+    collection::SizeRange,
+    strategy::{BoxedStrategy, Strategy},
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, PartialEq, PartialOrd)]
+pub struct NonEmptyVec<T>(Vec<T>);
+
+impl<T> NonEmptyVec<T> {
+    pub fn try_new(value: Vec<T>) -> Result<Self, ValidationError> {
+        if value.is_empty() {
+            return Err(EmptyValue);
+        }
+
+        Ok(Self(value))
+    }
+
+    pub fn into_inner(self) -> Vec<T> {
+        self.0
+    }
+}
+
+impl<T> Deref for NonEmptyVec<T> {
+    type Target = Vec<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T: Serialize> Serialize for NonEmptyVec<T> {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.0.serialize(serializer)
+    }
+}
+
+impl<'de, T: Deserialize<'de>> Deserialize<'de> for NonEmptyVec<T> {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        Vec::<T>::deserialize(deserializer)
+            .and_then(|value| NonEmptyVec::try_new(value).map_err(serde::de::Error::custom))
+    }
+}
+
+#[cfg(any(test, feature = "arbitrary"))]
+impl<T> Arbitrary for NonEmptyVec<T>
+where
+    T: Arbitrary + 'static,
+    T::Strategy: 'static,
+{
+    type Parameters = (SizeRange, T::Parameters);
+    type Strategy = BoxedStrategy<Self>;
+
+    fn arbitrary_with(args: Self::Parameters) -> Self::Strategy {
+        Vec::<T>::arbitrary_with(args)
+            .prop_filter_map("non-empty vec", |value| NonEmptyVec::try_new(value).ok())
+            .boxed()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn non_empty_vec_rejects_empty_vec() {
+        assert_eq!(NonEmptyVec::<i32>::try_new(vec![]), Err(EmptyValue));
+    }
+
+    #[test]
+    fn serialize_deserialize() {
+        let value = NonEmptyVec::try_new(vec![1, 2, 3]).unwrap();
+        let serialized = serde_json::to_string(&value).unwrap();
+        let deserialized: NonEmptyVec<i32> = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(value, deserialized);
+    }
+}

--- a/server/usecase/Cargo.toml
+++ b/server/usecase/Cargo.toml
@@ -13,3 +13,4 @@ futures = { workspace = true }
 tokio = { workspace = true }
 common = { path = "../common" }
 async-trait = { workspace = true }
+serde_json = { workspace = true }

--- a/server/usecase/src/forms/answer.rs
+++ b/server/usecase/src/forms/answer.rs
@@ -464,10 +464,13 @@ fn validate_posted_answers(
 
 fn parse_multiple_choice_answer(answer: &str) -> Vec<String> {
     let trimmed = answer.trim();
-    if trimmed.starts_with('[') && trimmed.ends_with(']') {
-        return trimmed[1..trimmed.len() - 1]
-            .split(',')
-            .map(|value| value.trim().trim_matches('"').to_string())
+    if trimmed.starts_with('[')
+        && trimmed.ends_with(']')
+        && let Ok(values) = serde_json::from_str::<Vec<String>>(trimmed)
+    {
+        return values
+            .into_iter()
+            .map(|value| value.trim().to_string())
             .filter(|value| !value.is_empty())
             .collect();
     }
@@ -563,5 +566,21 @@ mod tests {
         ];
 
         assert!(validate_posted_answers(&questions, &answers).is_err());
+    }
+
+    #[test]
+    fn parse_multiple_choice_answer_accepts_json_with_commas_in_values() {
+        assert_eq!(
+            parse_multiple_choice_answer(r#"["Admin, Owner","User"]"#),
+            vec!["Admin, Owner".to_string(), "User".to_string()]
+        );
+    }
+
+    #[test]
+    fn parse_multiple_choice_answer_falls_back_to_legacy_csv_format() {
+        assert_eq!(
+            parse_multiple_choice_answer("Admin, User"),
+            vec!["Admin".to_string(), "User".to_string()]
+        );
     }
 }

--- a/server/usecase/src/forms/answer.rs
+++ b/server/usecase/src/forms/answer.rs
@@ -6,6 +6,7 @@ use domain::{
         },
         comment::service::CommentAuthorizationContext,
         models::FormId,
+        question::models::{Question, QuestionType},
         service::DefaultAnswerTitleDomainService,
     },
     repository::form::{
@@ -18,9 +19,11 @@ use domain::{
 };
 use errors::{
     Error,
+    domain::DomainError,
     usecase::UseCaseError::{AnswerNotFound, FormNotFound},
 };
 use futures::{StreamExt, stream, try_join};
+use std::collections::{BTreeSet, HashMap};
 
 use crate::dto::AnswerDto;
 
@@ -59,12 +62,18 @@ impl<
             answer_repo: self.answer_repository,
         };
 
-        let (form, title) = try_join!(
+        let (form, question_guards, title) = try_join!(
             self.form_repository.get(form_id),
+            self.question_repository.get_questions(form_id),
             form_service.to_answer_title(&user, form_id, answers.as_slice())
         )?;
 
         let form = form.ok_or(Error::from(FormNotFound))?;
+        let questions = question_guards
+            .into_iter()
+            .map(|question| question.try_into_read(&user))
+            .collect::<Result<Vec<_>, _>>()?;
+        validate_posted_answers(&questions, &answers)?;
 
         let form_settings = form.try_read(&user)?.settings();
 
@@ -363,5 +372,196 @@ impl<
             labels,
             comments,
         })
+    }
+}
+
+fn validate_posted_answers(
+    questions: &[Question],
+    answers: &[FormAnswerContent],
+) -> Result<(), Error> {
+    let questions_by_id = questions
+        .iter()
+        .filter_map(|question| question.id.map(|id| (id.into_inner(), question)))
+        .collect::<HashMap<_, _>>();
+    let answered_question_ids = answers
+        .iter()
+        .map(|answer| answer.question_id.into_inner())
+        .collect::<BTreeSet<_>>();
+    if answered_question_ids.len() != answers.len() {
+        return Err(DomainError::InvalidEntity {
+            message: "duplicate answer for the same question".to_string(),
+        }
+        .into());
+    }
+
+    if let Some(error) = answers.iter().find_map(|answer| {
+        let question = questions_by_id
+            .get(&answer.question_id.into_inner())
+            .ok_or_else(|| DomainError::InvalidEntity {
+                message: format!(
+                    "question {} does not belong to the form",
+                    answer.question_id
+                ),
+            });
+
+        question
+            .and_then(|question| match question.question_type {
+                QuestionType::Text => Ok(()),
+                QuestionType::SingleChoice => question
+                    .choices
+                    .iter()
+                    .flat_map(|choices| choices.iter())
+                    .any(|choice| choice.label == answer.answer)
+                    .then_some(())
+                    .ok_or_else(|| DomainError::InvalidEntity {
+                        message: format!(
+                            "answer for question {} must match one of the available choices",
+                            question.template_key
+                        ),
+                    }),
+                QuestionType::MultipleChoice => {
+                    let values = parse_multiple_choice_answer(&answer.answer);
+                    (!values.is_empty()
+                        && values.iter().all(|value| {
+                            question
+                                .choices
+                                .iter()
+                                .flat_map(|choices| choices.iter())
+                                .any(|choice| choice.label == *value)
+                        }))
+                    .then_some(())
+                    .ok_or_else(|| DomainError::InvalidEntity {
+                        message: format!(
+                            "answer for question {} must reference only existing choices",
+                            question.template_key
+                        ),
+                    })
+                }
+            })
+            .err()
+    }) {
+        return Err(error.into());
+    }
+
+    if let Some(missing_question) = questions
+        .iter()
+        .filter(|question| question.is_required)
+        .filter_map(|question| question.id.map(|id| (id.into_inner(), question)))
+        .find(|(question_id, _)| !answered_question_ids.contains(question_id))
+        .map(|(_, question)| question)
+    {
+        return Err(DomainError::InvalidEntity {
+            message: format!(
+                "required question {} is missing",
+                missing_question.template_key
+            ),
+        }
+        .into());
+    }
+
+    Ok(())
+}
+
+fn parse_multiple_choice_answer(answer: &str) -> Vec<String> {
+    let trimmed = answer.trim();
+    if trimmed.starts_with('[') && trimmed.ends_with(']') {
+        return trimmed[1..trimmed.len() - 1]
+            .split(',')
+            .map(|value| value.trim().trim_matches('"').to_string())
+            .filter(|value| !value.is_empty())
+            .collect();
+    }
+
+    trimmed
+        .split(',')
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use domain::form::{
+        answer::models::FormAnswerContentId,
+        models::FormId,
+        question::models::{Choice, QuestionId},
+    };
+    use types::non_empty_vec::NonEmptyVec;
+    use uuid::Uuid;
+
+    fn text_question() -> Question {
+        Question::new(
+            Some(QuestionId::from(1)),
+            FormId::from(Uuid::nil()),
+            "name".to_string(),
+            0,
+            "Name".to_string(),
+            None,
+            QuestionType::Text,
+            None,
+            true,
+        )
+        .unwrap()
+    }
+
+    fn single_choice_question() -> Question {
+        Question::new(
+            Some(QuestionId::from(2)),
+            FormId::from(Uuid::nil()),
+            "role".to_string(),
+            1,
+            "Role".to_string(),
+            None,
+            QuestionType::SingleChoice,
+            Some(
+                NonEmptyVec::try_new(vec![
+                    Choice::new(Some(1.into()), 0, "Admin".to_string()).unwrap(),
+                    Choice::new(Some(2.into()), 1, "User".to_string()).unwrap(),
+                ])
+                .unwrap(),
+            ),
+            true,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn validate_posted_answers_rejects_duplicate_question_ids() {
+        let questions = vec![text_question()];
+        let answers = vec![
+            FormAnswerContent {
+                id: FormAnswerContentId::new(),
+                question_id: QuestionId::from(1),
+                answer: "Alice".to_string(),
+            },
+            FormAnswerContent {
+                id: FormAnswerContentId::new(),
+                question_id: QuestionId::from(1),
+                answer: "Bob".to_string(),
+            },
+        ];
+
+        assert!(validate_posted_answers(&questions, &answers).is_err());
+    }
+
+    #[test]
+    fn validate_posted_answers_rejects_invalid_single_choice() {
+        let questions = vec![text_question(), single_choice_question()];
+        let answers = vec![
+            FormAnswerContent {
+                id: FormAnswerContentId::new(),
+                question_id: QuestionId::from(1),
+                answer: "Alice".to_string(),
+            },
+            FormAnswerContent {
+                id: FormAnswerContentId::new(),
+                question_id: QuestionId::from(2),
+                answer: "Guest".to_string(),
+            },
+        ];
+
+        assert!(validate_posted_answers(&questions, &answers).is_err());
     }
 }

--- a/server/usecase/src/forms/answer.rs
+++ b/server/usecase/src/forms/answer.rs
@@ -1,12 +1,11 @@
 use domain::{
     form::{
         answer::{
-            models::{AnswerEntry, AnswerId, AnswerTitle, FormAnswerContent},
+            models::{AnswerEntry, AnswerId, AnswerTitle, FormAnswerContent, PostedAnswerContents},
             service::AnswerEntryAuthorizationContext,
         },
         comment::service::CommentAuthorizationContext,
         models::FormId,
-        question::models::{Question, QuestionType},
         service::DefaultAnswerTitleDomainService,
     },
     repository::form::{
@@ -19,11 +18,9 @@ use domain::{
 };
 use errors::{
     Error,
-    domain::DomainError,
     usecase::UseCaseError::{AnswerNotFound, FormNotFound},
 };
 use futures::{StreamExt, stream, try_join};
-use std::collections::{BTreeSet, HashMap};
 
 use crate::dto::AnswerDto;
 
@@ -56,28 +53,32 @@ impl<
         form_id: FormId,
         answers: Vec<FormAnswerContent>,
     ) -> Result<(), Error> {
-        let form_service = DefaultAnswerTitleDomainService {
-            form_repo: self.form_repository,
-            question_repo: self.question_repository,
-            answer_repo: self.answer_repository,
-        };
-
-        let (form, question_guards, title) = try_join!(
+        let (form, question_guards) = try_join!(
             self.form_repository.get(form_id),
-            self.question_repository.get_questions(form_id),
-            form_service.to_answer_title(&user, form_id, answers.as_slice())
+            self.question_repository.get_questions(form_id)
         )?;
 
-        let form = form.ok_or(Error::from(FormNotFound))?;
+        let form = form
+            .ok_or(Error::from(FormNotFound))?
+            .try_into_read(&user)?;
         let questions = question_guards
             .into_iter()
             .map(|question| question.try_into_read(&user))
             .collect::<Result<Vec<_>, _>>()?;
-        validate_posted_answers(&questions, &answers)?;
+        let posted_answers = PostedAnswerContents::try_new(&questions, answers)?;
+        let title = DefaultAnswerTitleDomainService::<R2, R5, R1>::to_answer_title_from_questions(
+            form.settings()
+                .answer_settings()
+                .default_answer_title()
+                .to_owned(),
+            &questions,
+            &posted_answers,
+            &user,
+        )?;
 
-        let form_settings = form.try_read(&user)?.settings();
+        let form_settings = form.settings();
 
-        let answer_entry = AnswerEntry::new(user.to_owned(), form_id, title, answers);
+        let answer_entry = AnswerEntry::new(user.to_owned(), form_id, title, posted_answers);
         let context = AnswerEntryAuthorizationContext {
             form_visibility: form_settings.visibility().to_owned(),
             response_period: form_settings.answer_settings().response_period().to_owned(),
@@ -372,215 +373,5 @@ impl<
             labels,
             comments,
         })
-    }
-}
-
-fn validate_posted_answers(
-    questions: &[Question],
-    answers: &[FormAnswerContent],
-) -> Result<(), Error> {
-    let questions_by_id = questions
-        .iter()
-        .filter_map(|question| question.id.map(|id| (id.into_inner(), question)))
-        .collect::<HashMap<_, _>>();
-    let answered_question_ids = answers
-        .iter()
-        .map(|answer| answer.question_id.into_inner())
-        .collect::<BTreeSet<_>>();
-    if answered_question_ids.len() != answers.len() {
-        return Err(DomainError::InvalidEntity {
-            message: "duplicate answer for the same question".to_string(),
-        }
-        .into());
-    }
-
-    if let Some(error) = answers.iter().find_map(|answer| {
-        let question = questions_by_id
-            .get(&answer.question_id.into_inner())
-            .ok_or_else(|| DomainError::InvalidEntity {
-                message: format!(
-                    "question {} does not belong to the form",
-                    answer.question_id
-                ),
-            });
-
-        question
-            .and_then(|question| match question.question_type {
-                QuestionType::Text => Ok(()),
-                QuestionType::SingleChoice => question
-                    .choices
-                    .iter()
-                    .flat_map(|choices| choices.iter())
-                    .any(|choice| choice.label == answer.answer)
-                    .then_some(())
-                    .ok_or_else(|| DomainError::InvalidEntity {
-                        message: format!(
-                            "answer for question {} must match one of the available choices",
-                            question.template_key
-                        ),
-                    }),
-                QuestionType::MultipleChoice => {
-                    let values = parse_multiple_choice_answer(&answer.answer);
-                    (!values.is_empty()
-                        && values.iter().all(|value| {
-                            question
-                                .choices
-                                .iter()
-                                .flat_map(|choices| choices.iter())
-                                .any(|choice| choice.label == *value)
-                        }))
-                    .then_some(())
-                    .ok_or_else(|| DomainError::InvalidEntity {
-                        message: format!(
-                            "answer for question {} must reference only existing choices",
-                            question.template_key
-                        ),
-                    })
-                }
-            })
-            .err()
-    }) {
-        return Err(error.into());
-    }
-
-    if let Some(missing_question) = questions
-        .iter()
-        .filter(|question| question.is_required)
-        .filter_map(|question| question.id.map(|id| (id.into_inner(), question)))
-        .find(|(question_id, _)| !answered_question_ids.contains(question_id))
-        .map(|(_, question)| question)
-    {
-        return Err(DomainError::InvalidEntity {
-            message: format!(
-                "required question {} is missing",
-                missing_question.template_key
-            ),
-        }
-        .into());
-    }
-
-    Ok(())
-}
-
-fn parse_multiple_choice_answer(answer: &str) -> Vec<String> {
-    let trimmed = answer.trim();
-    if trimmed.starts_with('[')
-        && trimmed.ends_with(']')
-        && let Ok(values) = serde_json::from_str::<Vec<String>>(trimmed)
-    {
-        return values
-            .into_iter()
-            .map(|value| value.trim().to_string())
-            .filter(|value| !value.is_empty())
-            .collect();
-    }
-
-    trimmed
-        .split(',')
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(ToOwned::to_owned)
-        .collect()
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use domain::form::{
-        answer::models::FormAnswerContentId,
-        models::FormId,
-        question::models::{Choice, QuestionId},
-    };
-    use types::non_empty_vec::NonEmptyVec;
-    use uuid::Uuid;
-
-    fn text_question() -> Question {
-        Question::new(
-            Some(QuestionId::from(1)),
-            FormId::from(Uuid::nil()),
-            "name".to_string(),
-            0,
-            "Name".to_string(),
-            None,
-            QuestionType::Text,
-            None,
-            true,
-        )
-        .unwrap()
-    }
-
-    fn single_choice_question() -> Question {
-        Question::new(
-            Some(QuestionId::from(2)),
-            FormId::from(Uuid::nil()),
-            "role".to_string(),
-            1,
-            "Role".to_string(),
-            None,
-            QuestionType::SingleChoice,
-            Some(
-                NonEmptyVec::try_new(vec![
-                    Choice::new(Some(1.into()), 0, "Admin".to_string()).unwrap(),
-                    Choice::new(Some(2.into()), 1, "User".to_string()).unwrap(),
-                ])
-                .unwrap(),
-            ),
-            true,
-        )
-        .unwrap()
-    }
-
-    #[test]
-    fn validate_posted_answers_rejects_duplicate_question_ids() {
-        let questions = vec![text_question()];
-        let answers = vec![
-            FormAnswerContent {
-                id: FormAnswerContentId::new(),
-                question_id: QuestionId::from(1),
-                answer: "Alice".to_string(),
-            },
-            FormAnswerContent {
-                id: FormAnswerContentId::new(),
-                question_id: QuestionId::from(1),
-                answer: "Bob".to_string(),
-            },
-        ];
-
-        assert!(validate_posted_answers(&questions, &answers).is_err());
-    }
-
-    #[test]
-    fn validate_posted_answers_rejects_invalid_single_choice() {
-        let questions = vec![text_question(), single_choice_question()];
-        let answers = vec![
-            FormAnswerContent {
-                id: FormAnswerContentId::new(),
-                question_id: QuestionId::from(1),
-                answer: "Alice".to_string(),
-            },
-            FormAnswerContent {
-                id: FormAnswerContentId::new(),
-                question_id: QuestionId::from(2),
-                answer: "Guest".to_string(),
-            },
-        ];
-
-        assert!(validate_posted_answers(&questions, &answers).is_err());
-    }
-
-    #[test]
-    fn parse_multiple_choice_answer_accepts_json_with_commas_in_values() {
-        assert_eq!(
-            parse_multiple_choice_answer(r#"["Admin, Owner","User"]"#),
-            vec!["Admin, Owner".to_string(), "User".to_string()]
-        );
-    }
-
-    #[test]
-    fn parse_multiple_choice_answer_falls_back_to_legacy_csv_format() {
-        assert_eq!(
-            parse_multiple_choice_answer("Admin, User"),
-            vec!["Admin".to_string(), "User".to_string()]
-        );
     }
 }

--- a/server/usecase/src/forms/form.rs
+++ b/server/usecase/src/forms/form.rs
@@ -6,14 +6,15 @@ use domain::{
     },
     repository::{
         form::{
-            form_label_repository::FormLabelRepository, form_repository::FormRepository,
-            question_repository::QuestionRepository,
+            answer_repository::AnswerRepository, form_label_repository::FormLabelRepository,
+            form_repository::FormRepository, question_repository::QuestionRepository,
         },
         notification_repository::NotificationRepository,
     },
     user::models::User,
 };
-use errors::{Error, usecase::UseCaseError::FormNotFound};
+use errors::{Error, domain::DomainError, usecase::UseCaseError::FormNotFound};
+use std::collections::{BTreeSet, HashMap};
 
 use crate::dto::FormDto;
 
@@ -23,11 +24,13 @@ pub struct FormUseCase<
     NotificationRepo: NotificationRepository,
     QuestionRepo: QuestionRepository,
     FormLabelRepo: FormLabelRepository,
+    AnswerRepo: AnswerRepository,
 > {
     pub form_repository: &'a FormRepo,
     pub notification_repository: &'a NotificationRepo,
     pub question_repository: &'a QuestionRepo,
     pub form_label_repository: &'a FormLabelRepo,
+    pub answer_repository: &'a AnswerRepo,
 }
 
 impl<
@@ -35,7 +38,8 @@ impl<
     R2: NotificationRepository,
     R3: QuestionRepository,
     R4: FormLabelRepository,
-> FormUseCase<'_, R1, R2, R3, R4>
+    R5: AnswerRepository,
+> FormUseCase<'_, R1, R2, R3, R4, R5>
 {
     pub async fn create_form(
         &self,
@@ -159,12 +163,60 @@ impl<
         default_answer_title: Option<DefaultAnswerTitle>,
         visibility: Option<Visibility>,
         answer_visibility: Option<AnswerVisibility>,
+        questions: Option<Vec<Question>>,
     ) -> Result<(Form, Vec<Question>, Vec<FormLabel>), Error> {
         let current_form = self
             .form_repository
             .get(form_id)
             .await?
             .ok_or(Error::from(FormNotFound))?;
+        let current_questions = self
+            .question_repository
+            .get_questions(form_id)
+            .await?
+            .into_iter()
+            .map(|question| question.try_into_read(actor))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        if let Some(questions) = &questions {
+            Question::validate_set(questions)?;
+
+            let existing_question_ids = current_questions
+                .iter()
+                .filter_map(|question| question.id.map(|id| id.into_inner()))
+                .collect::<BTreeSet<_>>();
+            if let Some(invalid_question) = questions
+                .iter()
+                .find(|question| question.form_id != form_id)
+            {
+                return Err(DomainError::InvalidEntity {
+                    message: format!(
+                        "question.form_id must match the target form: {}",
+                        invalid_question.template_key
+                    ),
+                }
+                .into());
+            }
+            if let Some(invalid_id) = questions
+                .iter()
+                .filter_map(|question| question.id.map(|id| id.into_inner()))
+                .find(|id| !existing_question_ids.contains(id))
+            {
+                return Err(DomainError::InvalidEntity {
+                    message: format!("question id {} does not belong to the form", invalid_id),
+                }
+                .into());
+            }
+
+            let has_answers = !self
+                .answer_repository
+                .get_answers_by_form_id(form_id)
+                .await?
+                .is_empty();
+            if has_answers {
+                validate_answered_form_question_update(&current_questions, questions)?;
+            }
+        }
 
         let updated_form = current_form.into_update().map(|form| {
             let current_answer_settings = form.settings().answer_settings().to_owned();
@@ -210,6 +262,15 @@ impl<
         self.form_repository
             .update_form(actor, updated_form)
             .await?;
+        if let Some(questions) = questions {
+            self.question_repository
+                .put_questions(
+                    actor,
+                    form_id,
+                    questions.into_iter().map(Into::into).collect(),
+                )
+                .await?;
+        }
 
         let updated_form_guard = self
             .form_repository
@@ -238,4 +299,143 @@ impl<
 
         Ok((updated_form, questions, labels))
     }
+}
+
+fn validate_answered_form_question_update(
+    current_questions: &[Question],
+    updated_questions: &[Question],
+) -> Result<(), Error> {
+    let current_by_id = current_questions
+        .iter()
+        .filter_map(|question| question.id.map(|id| (id.into_inner(), question)))
+        .collect::<HashMap<_, _>>();
+    let updated_by_id = updated_questions
+        .iter()
+        .filter_map(|question| question.id.map(|id| (id.into_inner(), question)))
+        .collect::<HashMap<_, _>>();
+
+    if let Some(error) = current_questions
+        .iter()
+        .filter_map(|current_question| {
+            current_question
+                .id
+                .map(|id| (id.into_inner(), current_question))
+        })
+        .find_map(|(current_id, current_question)| {
+            let updated_question =
+                updated_by_id
+                    .get(&current_id)
+                    .ok_or_else(|| DomainError::InvalidEntity {
+                        message: format!(
+                            "cannot delete question {} from a form that already has answers",
+                            current_question.template_key
+                        ),
+                    });
+
+            updated_question
+                .and_then(|updated_question| {
+                    (current_question.template_key == updated_question.template_key)
+                        .then_some(updated_question)
+                        .ok_or_else(|| DomainError::InvalidEntity {
+                            message: format!(
+                                "cannot change template_key for answered question {}",
+                                current_question.template_key
+                            ),
+                        })
+                })
+                .and_then(|updated_question| {
+                    (current_question.question_type == updated_question.question_type)
+                        .then_some((current_question, updated_question))
+                        .ok_or_else(|| DomainError::InvalidEntity {
+                            message: format!(
+                                "cannot change question_type for answered question {}",
+                                current_question.template_key
+                            ),
+                        })
+                })
+                .and_then(|(current_question, updated_question)| {
+                    let current_choice_ids = current_question
+                        .choices
+                        .iter()
+                        .flat_map(|choices| {
+                            choices
+                                .iter()
+                                .filter_map(|choice| choice.id.map(|id| id.into_inner()))
+                        })
+                        .collect::<BTreeSet<_>>();
+                    let updated_choice_ids = updated_question
+                        .choices
+                        .iter()
+                        .flat_map(|choices| {
+                            choices
+                                .iter()
+                                .filter_map(|choice| choice.id.map(|id| id.into_inner()))
+                        })
+                        .collect::<BTreeSet<_>>();
+
+                    current_choice_ids
+                        .into_iter()
+                        .find(|choice_id| !updated_choice_ids.contains(choice_id))
+                        .map(|choice_id| DomainError::InvalidEntity {
+                            message: format!(
+                                "cannot delete choice {} from answered question {}",
+                                choice_id, current_question.template_key
+                            ),
+                        })
+                        .map_or(Ok(()), Err)
+                })
+                .err()
+        })
+    {
+        return Err(error.into());
+    }
+
+    if let Some(error) = updated_questions
+        .iter()
+        .filter_map(|updated_question| {
+            updated_question
+                .id
+                .map(|id| (id.into_inner(), updated_question))
+        })
+        .find_map(|(updated_id, updated_question)| {
+            current_by_id
+                .get(&updated_id)
+                .ok_or_else(|| DomainError::InvalidEntity {
+                    message: format!("question id {} does not belong to the form", updated_id),
+                })
+                .and_then(|current_question| {
+                    let current_choice_ids = current_question
+                        .choices
+                        .iter()
+                        .flat_map(|choices| {
+                            choices
+                                .iter()
+                                .filter_map(|choice| choice.id.map(|id| id.into_inner()))
+                        })
+                        .collect::<BTreeSet<_>>();
+
+                    updated_question
+                        .choices
+                        .iter()
+                        .flat_map(|choices| {
+                            choices
+                                .iter()
+                                .filter_map(|choice| choice.id.map(|id| id.into_inner()))
+                        })
+                        .find(|choice_id| !current_choice_ids.contains(choice_id))
+                        .map(|choice_id| DomainError::InvalidEntity {
+                            message: format!(
+                                "cannot regenerate choice id {} for answered question {}",
+                                choice_id, updated_question.template_key
+                            ),
+                        })
+                        .map_or(Ok(()), Err)
+                })
+                .err()
+        })
+    {
+        return Err(error.into());
+    }
+
+    Ok(())
 }

--- a/server/usecase/src/forms/form.rs
+++ b/server/usecase/src/forms/form.rs
@@ -1,4 +1,4 @@
-use domain::form::question::models::Question;
+use domain::form::question::models::{Question, QuestionSet};
 use domain::{
     form::{
         answer::settings::models::{AnswerVisibility, DefaultAnswerTitle, ResponsePeriod},
@@ -163,7 +163,7 @@ impl<
         default_answer_title: Option<DefaultAnswerTitle>,
         visibility: Option<Visibility>,
         answer_visibility: Option<AnswerVisibility>,
-        questions: Option<Vec<Question>>,
+        questions: Option<QuestionSet>,
     ) -> Result<(Form, Vec<Question>, Vec<FormLabel>), Error> {
         let current_form = self
             .form_repository
@@ -179,8 +179,6 @@ impl<
             .collect::<Result<Vec<_>, _>>()?;
 
         if let Some(questions) = &questions {
-            Question::validate_set(questions)?;
-
             let existing_question_ids = current_questions
                 .iter()
                 .filter_map(|question| question.id.map(|id| id.into_inner()))
@@ -214,7 +212,7 @@ impl<
                 .await?
                 .is_empty();
             if has_answers {
-                validate_answered_form_question_update(&current_questions, questions)?;
+                validate_answered_form_question_update(&current_questions, questions.as_slice())?;
             }
         }
 
@@ -267,7 +265,7 @@ impl<
                 .put_questions(
                     actor,
                     form_id,
-                    questions.into_iter().map(Into::into).collect(),
+                    questions.into_inner().into_iter().map(Into::into).collect(),
                 )
                 .await?;
         }


### PR DESCRIPTION
## 概要
- form question / choice のモデル・API・永続化を最終 shape に揃え、`template_key` / `position` / stable choice ID を導入
- question 更新経路を `PUT /forms/{id}` に統合し、回答整合性検証と回答済み form の更新制約を追加
- question/choice 更新処理を bulk query ベースへ組み直し、`NonEmptyVec` 導入で choice 非空制約を型へ寄せた

## 確認事項
- `cd server && cargo build` を実行し、workspace 全体のビルド成功を確認
- `cd server && cargo test` を実行し、追加した domain/usecase テストを含めて成功を確認
- 初期 migration を直接更新する方針に合わせ、追加 migration は削除済み
- `makers pretty` は `cargo-nextest` の install 要件で最後まで完走しなかったが、`cargo fmt --all` を適用後にコミット前チェックは通過

## 補足
- `MultipleChoice` の回答 payload 自体は現行 `answer: String` のままで、解釈可能な範囲で整合性検証を追加している

close #1035 
close #1036 

🤖 Generated with Codex