### PR TITLE
fix: form_questions 更新時の unique 衝突を回避する

### DIFF
--- a/server/infra/resource/src/database/forms/question.rs
+++ b/server/infra/resource/src/database/forms/question.rs
@@ -196,16 +196,15 @@ async fn fetch_existing_questions(
 }
 
 fn temporary_template_key_prefix(existing_template_keys: &[String]) -> String {
-    let mut prefix = "__tmp_form_question__".to_string();
-
-    while existing_template_keys
-        .iter()
-        .any(|template_key| template_key.starts_with(&prefix))
-    {
-        prefix.push('_');
-    }
-
-    prefix
+    std::iter::successors(Some("__tmp_form_question__".to_string()), |prefix| {
+        Some(format!("{prefix}_"))
+    })
+    .find(|prefix| {
+        existing_template_keys
+            .iter()
+            .all(|template_key| !template_key.starts_with(prefix))
+    })
+    .expect("successors yields at least one prefix candidate")
 }
 
 async fn temporarily_relocate_existing_questions(
@@ -227,29 +226,66 @@ async fn temporarily_relocate_existing_questions(
             .map(|question| question.template_key.clone())
             .collect_vec(),
     );
-
-    for question in existing_questions {
-        let temporary_position =
+    let temporary_questions = existing_questions
+        .into_iter()
+        .map(|question| {
             question
                 .position
                 .checked_add(position_offset)
+                .map(|temporary_position| {
+                    (
+                        question.question_id,
+                        format!("{temporary_prefix}{}", question.question_id),
+                        temporary_position,
+                    )
+                })
                 .ok_or_else(|| InfraError::Unexpected {
                     cause: format!(
                         "temporary position overflow for question_id {}",
                         question.question_id
                     ),
-                })?;
-        let temporary_template_key = format!("{temporary_prefix}{}", question.question_id);
+                })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
 
-        sqlx::query(
-            "UPDATE form_questions SET template_key = ?, position = ? WHERE question_id = ?",
+    let template_key_cases = temporary_questions
+        .iter()
+        .map(|_| "WHEN ? THEN ?".to_string())
+        .join(" ");
+    let position_cases = temporary_questions
+        .iter()
+        .map(|_| "WHEN ? THEN ?")
+        .join(" ");
+    let question_ids = temporary_questions
+        .iter()
+        .map(|(question_id, _, _)| *question_id)
+        .collect_vec();
+    let where_placeholders = std::iter::repeat_n("?", question_ids.len()).join(", ");
+    let sql = format!(
+        "UPDATE form_questions \
+         SET template_key = CASE question_id {template_key_cases} END, \
+         position = CASE question_id {position_cases} END \
+         WHERE question_id IN ({where_placeholders})"
+    );
+
+    temporary_questions
+        .iter()
+        .fold(
+            query(&sql),
+            |query, (question_id, temporary_template_key, _)| {
+                query.bind(question_id).bind(temporary_template_key)
+            },
         )
-        .bind(temporary_template_key)
-        .bind(temporary_position)
-        .bind(question.question_id)
+        .bind_all(
+            temporary_questions
+                .iter()
+                .flat_map(|(question_id, _, temporary_position)| {
+                    [*question_id, i32::from(*temporary_position)]
+                }),
+        )
+        .bind_all(question_ids)
         .execute(&mut *txn)
         .await?;
-    }
 
     Ok(())
 }

--- a/server/infra/resource/src/database/forms/question.rs
+++ b/server/infra/resource/src/database/forms/question.rs
@@ -49,6 +49,7 @@ impl FormQuestionDatabase for ConnectionPool {
                 let (existing_questions, new_questions): (Vec<_>, Vec<_>) =
                     questions.iter().partition(|question| question.id.is_some());
 
+                temporarily_relocate_existing_questions(txn, &form_id_string).await?;
                 upsert_existing_questions(txn, &form_id_string, &existing_questions).await?;
                 let inserted_questions = insert_new_questions(txn, &form_id, new_questions).await?;
 
@@ -163,6 +164,94 @@ async fn fetch_question_ids(
         .map(|row| row.try_get::<i32, _>("question_id"))
         .collect::<Result<Vec<_>, _>>()
         .map_err(Into::into)
+}
+
+#[derive(Debug, Clone)]
+struct ExistingQuestionRow {
+    question_id: i32,
+    template_key: String,
+    position: u16,
+}
+
+async fn fetch_existing_questions(
+    txn: &mut MySqlConnection,
+    form_id: &str,
+) -> Result<Vec<ExistingQuestionRow>, InfraError> {
+    sqlx::query(
+        "SELECT question_id, template_key, position FROM form_questions WHERE form_id = ? ORDER BY position ASC, question_id ASC",
+    )
+    .bind(form_id)
+    .fetch_all(&mut *txn)
+    .await?
+    .into_iter()
+    .map(|row| {
+        Ok(ExistingQuestionRow {
+            question_id: row.try_get("question_id")?,
+            template_key: row.try_get("template_key")?,
+            position: row.try_get("position")?,
+        })
+    })
+    .collect::<Result<Vec<_>, sqlx::Error>>()
+    .map_err(Into::into)
+}
+
+fn temporary_template_key_prefix(existing_template_keys: &[String]) -> String {
+    let mut prefix = "__tmp_form_question__".to_string();
+
+    while existing_template_keys
+        .iter()
+        .any(|template_key| template_key.starts_with(&prefix))
+    {
+        prefix.push('_');
+    }
+
+    prefix
+}
+
+async fn temporarily_relocate_existing_questions(
+    txn: &mut MySqlConnection,
+    form_id: &str,
+) -> Result<(), InfraError> {
+    let existing_questions = fetch_existing_questions(txn, form_id).await?;
+    if existing_questions.is_empty() {
+        return Ok(());
+    }
+
+    let position_offset =
+        u16::try_from(existing_questions.len()).map_err(|_| InfraError::Unexpected {
+            cause: "too many questions to relocate temporarily".to_string(),
+        })?;
+    let temporary_prefix = temporary_template_key_prefix(
+        &existing_questions
+            .iter()
+            .map(|question| question.template_key.clone())
+            .collect_vec(),
+    );
+
+    for question in existing_questions {
+        let temporary_position =
+            question
+                .position
+                .checked_add(position_offset)
+                .ok_or_else(|| InfraError::Unexpected {
+                    cause: format!(
+                        "temporary position overflow for question_id {}",
+                        question.question_id
+                    ),
+                })?;
+        let temporary_template_key = format!("{temporary_prefix}{}", question.question_id);
+
+        sqlx::query(
+            "UPDATE form_questions SET template_key = ?, position = ? WHERE question_id = ?",
+        )
+        .bind(temporary_template_key)
+        .bind(temporary_position)
+        .bind(question.question_id)
+        .execute(&mut *txn)
+        .await?;
+    }
+
+    Ok(())
 }
 
 async fn upsert_existing_questions(

--- a/server/infra/resource/src/database/forms/question.rs
+++ b/server/infra/resource/src/database/forms/question.rs
@@ -226,66 +226,30 @@ async fn temporarily_relocate_existing_questions(
             .map(|question| question.template_key.clone())
             .collect_vec(),
     );
-    let temporary_questions = existing_questions
-        .into_iter()
-        .map(|question| {
-            question
-                .position
-                .checked_add(position_offset)
-                .map(|temporary_position| {
-                    (
-                        question.question_id,
-                        format!("{temporary_prefix}{}", question.question_id),
-                        temporary_position,
-                    )
-                })
-                .ok_or_else(|| InfraError::Unexpected {
-                    cause: format!(
-                        "temporary position overflow for question_id {}",
-                        question.question_id
-                    ),
-                })
-        })
-        .collect::<Result<Vec<_>, _>>()?;
+    existing_questions.iter().try_for_each(|question| {
+        question
+            .position
+            .checked_add(position_offset)
+            .ok_or_else(|| InfraError::Unexpected {
+                cause: format!(
+                    "temporary position overflow for question_id {}",
+                    question.question_id
+                ),
+            })
+            .map(|_| ())
+    })?;
 
-    let template_key_cases = temporary_questions
-        .iter()
-        .map(|_| "WHEN ? THEN ?".to_string())
-        .join(" ");
-    let position_cases = temporary_questions
-        .iter()
-        .map(|_| "WHEN ? THEN ?")
-        .join(" ");
-    let question_ids = temporary_questions
-        .iter()
-        .map(|(question_id, _, _)| *question_id)
-        .collect_vec();
-    let where_placeholders = std::iter::repeat_n("?", question_ids.len()).join(", ");
-    let sql = format!(
-        "UPDATE form_questions \
-         SET template_key = CASE question_id {template_key_cases} END, \
-         position = CASE question_id {position_cases} END \
-         WHERE question_id IN ({where_placeholders})"
-    );
-
-    temporary_questions
-        .iter()
-        .fold(
-            query(&sql),
-            |query, (question_id, temporary_template_key, _)| {
-                query.bind(question_id).bind(temporary_template_key)
-            },
-        )
-        .bind_all(
-            temporary_questions
-                .iter()
-                .flat_map(|(question_id, _, temporary_position)| {
-                    [*question_id, i32::from(*temporary_position)]
-                }),
-        )
-        .bind_all(question_ids)
-        .execute(&mut *txn)
-        .await?;
+    sqlx::query(
+        "UPDATE form_questions
+         SET template_key = CONCAT(?, question_id),
+             position = position + ?
+         WHERE form_id = ?",
+    )
+    .bind(temporary_prefix)
+    .bind(position_offset)
+    .bind(form_id)
+    .execute(&mut *txn)
+    .await?;
 
     Ok(())
 }


### PR DESCRIPTION
## 概要
- Issue 1041 の原因だった `form_questions` 更新時の unique 制約衝突を、既存行を一時退避してから最終値へ反映する 2 段階更新で解消
- `position` は既存件数ぶんのオフセット、`template_key` は form 内既存キーと前方一致しない専用 prefix を使って退避し、入れ替えや削除予定行の値再利用でも同一トランザクション内で衝突しないようにした
- 変更範囲は `server/infra/resource` の質問更新ロジックに限定し、公開 API やドメイン型は変更していない

## 確認事項
- `cd server && cargo test -p resource` を実行し、ビルドとテストが通ることを確認
- このリポジトリには現状 DB テスト基盤がなく、Issue 1041 の回帰ケースを自動テストとしては追加していない

## 補足
- 回帰防止は今後 DB テスト基盤を整えたうえで、`form_questions` の swap / 再配置ケースを integration test 化するのが次の対応になる

🤖 Generated with Codex