### PR TITLE
refactor: Questionを判別可能なunionへ整理

### DIFF
--- a/server/domain/src/form/answer/models.rs
+++ b/server/domain/src/form/answer/models.rs
@@ -11,7 +11,7 @@ use types::non_empty_string::NonEmptyString;
 use crate::{
     form::{
         models::FormId,
-        question::models::{Question, QuestionId, QuestionType},
+        question::models::{Question, QuestionId},
     },
     types::authorization_guard::AuthorizationGuardDefinitions,
     user::models::{Role, User},
@@ -49,7 +49,7 @@ impl PostedAnswerContents {
     ) -> Result<Self, DomainError> {
         let questions_by_id = questions
             .iter()
-            .filter_map(|question| question.id.map(|id| (id.into_inner(), question)))
+            .filter_map(|question| question.id().map(|id| (id.into_inner(), question)))
             .collect::<HashMap<_, _>>();
         let answered_question_ids = contents
             .iter()
@@ -73,35 +73,33 @@ impl PostedAnswerContents {
                 });
 
             question
-                .and_then(|question| match question.question_type {
-                    QuestionType::Text => Ok(()),
-                    QuestionType::SingleChoice => question
-                        .choices
+                .and_then(|question| match question {
+                    Question::Text(_) => Ok(()),
+                    Question::SingleChoice(choice_question) => choice_question
+                        .choices()
                         .iter()
-                        .flat_map(|choices| choices.iter())
                         .any(|choice| choice.label.as_str() == answer.answer.as_str())
                         .then_some(())
                         .ok_or_else(|| DomainError::InvalidEntity {
                             message: format!(
                                 "answer for question {} must match one of the available choices",
-                                question.template_key.as_str()
+                                question.template_key().as_str()
                             ),
                         }),
-                    QuestionType::MultipleChoice => {
+                    Question::MultipleChoice(choice_question) => {
                         let values = parse_multiple_choice_answer(&answer.answer);
                         (!values.is_empty()
                             && values.iter().all(|value| {
-                                question
-                                    .choices
+                                choice_question
+                                    .choices()
                                     .iter()
-                                    .flat_map(|choices| choices.iter())
                                     .any(|choice| choice.label.as_str() == value.as_str())
                             }))
                         .then_some(())
                         .ok_or_else(|| DomainError::InvalidEntity {
                             message: format!(
                                 "answer for question {} must reference only existing choices",
-                                question.template_key.as_str()
+                                question.template_key().as_str()
                             ),
                         })
                     }
@@ -113,15 +111,15 @@ impl PostedAnswerContents {
 
         if let Some(missing_question) = questions
             .iter()
-            .filter(|question| question.is_required)
-            .filter_map(|question| question.id.map(|id| (id.into_inner(), question)))
+            .filter(|question| question.is_required())
+            .filter_map(|question| question.id().map(|id| (id.into_inner(), question)))
             .find(|(question_id, _)| !answered_question_ids.contains(question_id))
             .map(|(_, question)| question)
         {
             return Err(DomainError::InvalidEntity {
                 message: format!(
                     "required question {} is missing",
-                    missing_question.template_key.as_str()
+                    missing_question.template_key().as_str()
                 ),
             });
         }
@@ -262,22 +260,17 @@ fn parse_multiple_choice_answer(answer: &str) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::form::{
-        models::FormId,
-        question::models::{Choice, QuestionType},
-    };
+    use crate::form::{models::FormId, question::models::Choice};
     use types::non_empty_vec::NonEmptyVec;
     use uuid::Uuid;
 
     fn text_question() -> Question {
-        Question::new(
+        Question::new_text(
             Some(QuestionId::from(1)),
             FormId::from(Uuid::nil()),
             "name".to_string().try_into().unwrap(),
             0,
             "Name".to_string().try_into().unwrap(),
-            None,
-            QuestionType::Text,
             None,
             true,
         )
@@ -285,48 +278,41 @@ mod tests {
     }
 
     fn single_choice_question() -> Question {
-        Question::new(
+        Question::new_single_choice(
             Some(QuestionId::from(2)),
             FormId::from(Uuid::nil()),
             "role".to_string().try_into().unwrap(),
             1,
             "Role".to_string().try_into().unwrap(),
             None,
-            QuestionType::SingleChoice,
-            Some(
-                NonEmptyVec::try_new(vec![
-                    Choice::new(Some(1.into()), 0, "Admin".to_string().try_into().unwrap())
-                        .unwrap(),
-                    Choice::new(Some(2.into()), 1, "User".to_string().try_into().unwrap()).unwrap(),
-                ])
-                .unwrap(),
-            ),
+            NonEmptyVec::try_new(vec![
+                Choice::new(Some(1.into()), 0, "Admin".to_string().try_into().unwrap()).unwrap(),
+                Choice::new(Some(2.into()), 1, "User".to_string().try_into().unwrap()).unwrap(),
+            ])
+            .unwrap(),
             true,
         )
         .unwrap()
     }
 
     fn multiple_choice_question() -> Question {
-        Question::new(
+        Question::new_multiple_choice(
             Some(QuestionId::from(3)),
             FormId::from(Uuid::nil()),
             "tags".to_string().try_into().unwrap(),
             2,
             "Tags".to_string().try_into().unwrap(),
             None,
-            QuestionType::MultipleChoice,
-            Some(
-                NonEmptyVec::try_new(vec![
-                    Choice::new(
-                        Some(3.into()),
-                        0,
-                        "Admin, Owner".to_string().try_into().unwrap(),
-                    )
-                    .unwrap(),
-                    Choice::new(Some(4.into()), 1, "User".to_string().try_into().unwrap()).unwrap(),
-                ])
+            NonEmptyVec::try_new(vec![
+                Choice::new(
+                    Some(3.into()),
+                    0,
+                    "Admin, Owner".to_string().try_into().unwrap(),
+                )
                 .unwrap(),
-            ),
+                Choice::new(Some(4.into()), 1, "User".to_string().try_into().unwrap()).unwrap(),
+            ])
+            .unwrap(),
             false,
         )
         .unwrap()

--- a/server/domain/src/form/question/models.rs
+++ b/server/domain/src/form/question/models.rs
@@ -50,18 +50,98 @@ impl Choice {
 
 #[cfg_attr(test, derive(Arbitrary))]
 #[derive(Serialize, Deserialize, Clone, Getters, Debug, PartialEq)]
-pub struct Question {
+pub struct QuestionDefinition {
     #[serde(default)]
-    pub id: Option<QuestionId>,
-    pub form_id: FormId,
-    pub template_key: NonEmptyString,
-    pub position: u16,
-    pub title: NonEmptyString,
-    pub description: Option<NonEmptyString>,
-    pub question_type: QuestionType,
-    #[serde(default)]
-    pub choices: Option<NonEmptyVec<Choice>>,
-    pub is_required: bool,
+    id: Option<QuestionId>,
+    form_id: FormId,
+    template_key: NonEmptyString,
+    position: u16,
+    title: NonEmptyString,
+    description: Option<NonEmptyString>,
+    is_required: bool,
+}
+
+impl QuestionDefinition {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        id: Option<QuestionId>,
+        form_id: FormId,
+        template_key: NonEmptyString,
+        position: u16,
+        title: NonEmptyString,
+        description: Option<NonEmptyString>,
+        is_required: bool,
+    ) -> Self {
+        Self {
+            id,
+            form_id,
+            template_key,
+            position,
+            title,
+            description,
+            is_required,
+        }
+    }
+}
+
+#[cfg_attr(test, derive(Arbitrary))]
+#[derive(Serialize, Deserialize, Clone, Getters, Debug, PartialEq)]
+pub struct TextQuestion {
+    #[serde(flatten)]
+    definition: QuestionDefinition,
+}
+
+impl TextQuestion {
+    pub fn new(definition: QuestionDefinition) -> Self {
+        Self { definition }
+    }
+}
+
+#[cfg_attr(test, derive(Arbitrary))]
+#[derive(Serialize, Deserialize, Clone, Getters, Debug, PartialEq)]
+pub struct SelectQuestion {
+    #[serde(flatten)]
+    definition: QuestionDefinition,
+    choices: NonEmptyVec<Choice>,
+}
+
+impl SelectQuestion {
+    pub fn try_new(
+        definition: QuestionDefinition,
+        choices: NonEmptyVec<Choice>,
+    ) -> Result<Self, DomainError> {
+        let choice_positions = choices
+            .iter()
+            .map(|choice| choice.position)
+            .collect::<BTreeSet<_>>();
+
+        if choice_positions.len() != choices.len()
+            || choice_positions
+                .into_iter()
+                .enumerate()
+                .any(|(index, position)| position != index as u16)
+        {
+            return Err(DomainError::InvalidEntity {
+                message: format!(
+                    "choice.position must be contiguous from 0 for question {}",
+                    definition.template_key.as_str()
+                ),
+            });
+        }
+
+        Ok(Self {
+            definition,
+            choices,
+        })
+    }
+}
+
+#[cfg_attr(test, derive(Arbitrary))]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub enum Question {
+    Text(TextQuestion),
+    SingleChoice(SelectQuestion),
+    MultipleChoice(SelectQuestion),
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
@@ -71,7 +151,7 @@ impl QuestionSet {
     pub fn try_new(questions: Vec<Question>) -> Result<Self, DomainError> {
         let positions = questions
             .iter()
-            .map(|question| question.position)
+            .map(|question| question.position())
             .collect::<BTreeSet<_>>();
         if positions.len() != questions.len()
             || positions
@@ -86,7 +166,7 @@ impl QuestionSet {
 
         let template_keys = questions
             .iter()
-            .map(|question| question.template_key.as_str())
+            .map(|question| question.template_key().as_str())
             .collect::<BTreeSet<_>>();
         if template_keys.len() != questions.len() {
             return Err(DomainError::InvalidEntity {
@@ -112,30 +192,74 @@ impl QuestionSet {
 
 impl Question {
     #[allow(clippy::too_many_arguments)]
-    pub fn new(
+    pub fn new_text(
         id: Option<QuestionId>,
         form_id: FormId,
         template_key: NonEmptyString,
         position: u16,
         title: NonEmptyString,
         description: Option<NonEmptyString>,
-        question_type: QuestionType,
-        choices: Option<NonEmptyVec<Choice>>,
         is_required: bool,
     ) -> Result<Self, DomainError> {
-        let question = Self {
+        Ok(Self::Text(TextQuestion::new(QuestionDefinition::new(
             id,
             form_id,
             template_key,
             position,
             title,
             description,
-            question_type,
-            choices,
             is_required,
-        };
-        question.validate()?;
-        Ok(question)
+        ))))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_single_choice(
+        id: Option<QuestionId>,
+        form_id: FormId,
+        template_key: NonEmptyString,
+        position: u16,
+        title: NonEmptyString,
+        description: Option<NonEmptyString>,
+        choices: NonEmptyVec<Choice>,
+        is_required: bool,
+    ) -> Result<Self, DomainError> {
+        Ok(Self::SingleChoice(SelectQuestion::try_new(
+            QuestionDefinition::new(
+                id,
+                form_id,
+                template_key,
+                position,
+                title,
+                description,
+                is_required,
+            ),
+            choices,
+        )?))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_multiple_choice(
+        id: Option<QuestionId>,
+        form_id: FormId,
+        template_key: NonEmptyString,
+        position: u16,
+        title: NonEmptyString,
+        description: Option<NonEmptyString>,
+        choices: NonEmptyVec<Choice>,
+        is_required: bool,
+    ) -> Result<Self, DomainError> {
+        Ok(Self::MultipleChoice(SelectQuestion::try_new(
+            QuestionDefinition::new(
+                id,
+                form_id,
+                template_key,
+                position,
+                title,
+                description,
+                is_required,
+            ),
+            choices,
+        )?))
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -150,58 +274,110 @@ impl Question {
         choices: Option<NonEmptyVec<Choice>>,
         is_required: bool,
     ) -> Result<Self, DomainError> {
-        Self::new(
-            id,
-            form_id,
-            template_key,
-            position,
-            title,
-            description,
-            question_type,
-            choices,
-            is_required,
-        )
-    }
-
-    fn validate(&self) -> Result<(), DomainError> {
-        let choice_positions = self
-            .choices
-            .iter()
-            .flat_map(|choices| choices.iter().map(|choice| choice.position))
-            .collect::<BTreeSet<_>>();
-
-        match self.question_type {
+        match question_type {
             QuestionType::Text => {
-                if self.choices.is_some() {
+                if choices.is_some() {
                     return Err(DomainError::InvalidEntity {
                         message: "text question must not have choices".to_string(),
                     });
                 }
+                Self::new_text(
+                    id,
+                    form_id,
+                    template_key,
+                    position,
+                    title,
+                    description,
+                    is_required,
+                )
             }
-            QuestionType::SingleChoice | QuestionType::MultipleChoice => {
-                let Some(choices) = &self.choices else {
+            QuestionType::SingleChoice => {
+                let Some(choices) = choices else {
                     return Err(DomainError::InvalidEntity {
                         message: "choice question must have at least one choice".to_string(),
                     });
                 };
-
-                if choice_positions.len() != choices.len()
-                    || choice_positions
-                        .into_iter()
-                        .enumerate()
-                        .any(|(index, position)| position != index as u16)
-                {
+                Self::new_single_choice(
+                    id,
+                    form_id,
+                    template_key,
+                    position,
+                    title,
+                    description,
+                    choices,
+                    is_required,
+                )
+            }
+            QuestionType::MultipleChoice => {
+                let Some(choices) = choices else {
                     return Err(DomainError::InvalidEntity {
-                        message: format!(
-                            "choice.position must be contiguous from 0 for question {}",
-                            self.template_key.as_str()
-                        ),
+                        message: "choice question must have at least one choice".to_string(),
                     });
-                }
+                };
+                Self::new_multiple_choice(
+                    id,
+                    form_id,
+                    template_key,
+                    position,
+                    title,
+                    description,
+                    choices,
+                    is_required,
+                )
             }
         }
+    }
 
-        Ok(())
+    pub fn definition(&self) -> &QuestionDefinition {
+        match self {
+            Self::Text(question) => &question.definition,
+            Self::SingleChoice(question) | Self::MultipleChoice(question) => &question.definition,
+        }
+    }
+
+    pub fn id(&self) -> Option<QuestionId> {
+        *self.definition().id()
+    }
+
+    pub fn form_id(&self) -> &FormId {
+        self.definition().form_id()
+    }
+
+    pub fn template_key(&self) -> &NonEmptyString {
+        self.definition().template_key()
+    }
+
+    pub fn position(&self) -> u16 {
+        *self.definition().position()
+    }
+
+    pub fn title(&self) -> &NonEmptyString {
+        self.definition().title()
+    }
+
+    pub fn description(&self) -> Option<&NonEmptyString> {
+        self.definition().description().as_ref()
+    }
+
+    pub fn is_required(&self) -> bool {
+        *self.definition().is_required()
+    }
+
+    pub fn question_type(&self) -> QuestionType {
+        match self {
+            Self::Text(_) => QuestionType::Text,
+            Self::SingleChoice(_) => QuestionType::SingleChoice,
+            Self::MultipleChoice(_) => QuestionType::MultipleChoice,
+        }
+    }
+
+    pub fn choices(&self) -> Option<&NonEmptyVec<Choice>> {
+        match self {
+            Self::Text(_) => None,
+            Self::SingleChoice(question) | Self::MultipleChoice(question) => {
+                Some(&question.choices)
+            }
+        }
     }
 }
 
@@ -287,7 +463,7 @@ mod test {
 
     #[test]
     fn text_question_rejects_choices() {
-        let result = Question::new(
+        let result = Question::from_raw_parts(
             Some(1.into()),
             FormId::from(Uuid::nil()),
             "template".to_string().try_into().unwrap(),
@@ -308,29 +484,82 @@ mod test {
     }
 
     #[test]
+    fn text_question_has_no_choices() {
+        let question = Question::new_text(
+            Some(1.into()),
+            FormId::from(Uuid::nil()),
+            "template".to_string().try_into().unwrap(),
+            0,
+            "Question".to_string().try_into().unwrap(),
+            None,
+            true,
+        )
+        .unwrap();
+
+        assert!(matches!(question, Question::Text(_)));
+        assert!(question.choices().is_none());
+    }
+
+    #[test]
+    fn single_choice_question_requires_contiguous_choice_positions() {
+        let result = Question::new_single_choice(
+            Some(1.into()),
+            FormId::from(Uuid::nil()),
+            "template".to_string().try_into().unwrap(),
+            0,
+            "Question".to_string().try_into().unwrap(),
+            None,
+            NonEmptyVec::try_new(vec![
+                Choice::new(None, 0, "A".to_string().try_into().unwrap()).unwrap(),
+                Choice::new(None, 2, "B".to_string().try_into().unwrap()).unwrap(),
+            ])
+            .unwrap(),
+            true,
+        );
+
+        assert!(matches!(result, Err(DomainError::InvalidEntity { .. })));
+    }
+
+    #[test]
+    fn multiple_choice_question_requires_contiguous_choice_positions() {
+        let result = Question::new_multiple_choice(
+            Some(1.into()),
+            FormId::from(Uuid::nil()),
+            "template".to_string().try_into().unwrap(),
+            0,
+            "Question".to_string().try_into().unwrap(),
+            None,
+            NonEmptyVec::try_new(vec![
+                Choice::new(None, 1, "A".to_string().try_into().unwrap()).unwrap(),
+                Choice::new(None, 2, "B".to_string().try_into().unwrap()).unwrap(),
+            ])
+            .unwrap(),
+            true,
+        );
+
+        assert!(matches!(result, Err(DomainError::InvalidEntity { .. })));
+    }
+
+    #[test]
     fn question_set_accepts_unique_template_keys_and_contiguous_positions() {
         let form_id = FormId::from(Uuid::nil());
         let questions = vec![
-            Question::new(
+            Question::new_text(
                 Some(1.into()),
                 form_id,
                 "first".to_string().try_into().unwrap(),
                 0,
                 "Question 1".to_string().try_into().unwrap(),
                 None,
-                QuestionType::Text,
-                None,
                 true,
             )
             .unwrap(),
-            Question::new(
+            Question::new_text(
                 Some(2.into()),
                 form_id,
                 "second".to_string().try_into().unwrap(),
                 1,
                 "Question 2".to_string().try_into().unwrap(),
-                None,
-                QuestionType::Text,
                 None,
                 false,
             )
@@ -346,26 +575,22 @@ mod test {
     fn question_set_rejects_duplicate_position() {
         let form_id = FormId::from(Uuid::nil());
         let questions = vec![
-            Question::new(
+            Question::new_text(
                 Some(1.into()),
                 form_id,
                 "first".to_string().try_into().unwrap(),
                 0,
                 "Question 1".to_string().try_into().unwrap(),
                 None,
-                QuestionType::Text,
-                None,
                 true,
             )
             .unwrap(),
-            Question::new(
+            Question::new_text(
                 Some(2.into()),
                 form_id,
                 "second".to_string().try_into().unwrap(),
                 0,
                 "Question 2".to_string().try_into().unwrap(),
-                None,
-                QuestionType::Text,
                 None,
                 false,
             )
@@ -382,26 +607,22 @@ mod test {
     fn question_set_rejects_non_contiguous_position() {
         let form_id = FormId::from(Uuid::nil());
         let questions = vec![
-            Question::new(
+            Question::new_text(
                 Some(1.into()),
                 form_id,
                 "first".to_string().try_into().unwrap(),
                 0,
                 "Question 1".to_string().try_into().unwrap(),
                 None,
-                QuestionType::Text,
-                None,
                 true,
             )
             .unwrap(),
-            Question::new(
+            Question::new_text(
                 Some(2.into()),
                 form_id,
                 "second".to_string().try_into().unwrap(),
                 2,
                 "Question 2".to_string().try_into().unwrap(),
-                None,
-                QuestionType::Text,
                 None,
                 false,
             )
@@ -418,26 +639,22 @@ mod test {
     fn question_set_rejects_duplicate_template_keys() {
         let form_id = FormId::from(Uuid::nil());
         let questions = vec![
-            Question::new(
+            Question::new_text(
                 Some(1.into()),
                 form_id,
                 "same".to_string().try_into().unwrap(),
                 0,
                 "Question 1".to_string().try_into().unwrap(),
                 None,
-                QuestionType::Text,
-                None,
                 true,
             )
             .unwrap(),
-            Question::new(
+            Question::new_text(
                 Some(2.into()),
                 form_id,
                 "same".to_string().try_into().unwrap(),
                 1,
                 "Question 2".to_string().try_into().unwrap(),
-                None,
-                QuestionType::Text,
                 None,
                 false,
             )

--- a/server/domain/src/form/service.rs
+++ b/server/domain/src/form/service.rs
@@ -46,8 +46,8 @@ impl<FormRepo: FormRepository, QuestionRepo: QuestionRepository, AnswerRepo: Ans
                     .iter()
                     .filter_map(|question| {
                         question
-                            .id
-                            .map(|id| (id.into_inner(), question.template_key.as_str()))
+                            .id()
+                            .map(|id| (id.into_inner(), question.template_key().as_str()))
                     })
                     .collect::<HashMap<_, _>>();
                 let answers_by_template_key = answers

--- a/server/infra/resource/src/database/forms/question.rs
+++ b/server/infra/resource/src/database/forms/question.rs
@@ -46,8 +46,9 @@ impl FormQuestionDatabase for ConnectionPool {
                 let form_id_string = form_id.into_inner().to_string();
                 let existing_question_ids = fetch_question_ids(txn, &form_id_string).await?;
 
-                let (existing_questions, new_questions): (Vec<_>, Vec<_>) =
-                    questions.iter().partition(|question| question.id.is_some());
+                let (existing_questions, new_questions): (Vec<_>, Vec<_>) = questions
+                    .iter()
+                    .partition(|question| question.id().is_some());
 
                 temporarily_relocate_existing_questions(txn, &form_id_string).await?;
                 upsert_existing_questions(txn, &form_id_string, &existing_questions).await?;
@@ -55,7 +56,7 @@ impl FormQuestionDatabase for ConnectionPool {
 
                 let retained_question_ids = existing_questions
                     .iter()
-                    .filter_map(|question| question.id.map(|id| id.into_inner()))
+                    .filter_map(|question| question.id().map(|id| id.into_inner()))
                     .chain(
                         inserted_questions
                             .iter()
@@ -73,7 +74,7 @@ impl FormQuestionDatabase for ConnectionPool {
 
                 let assigned_questions = existing_questions
                     .into_iter()
-                    .filter_map(|question| question.id.map(|id| (id.into_inner(), question)))
+                    .filter_map(|question| question.id().map(|id| (id.into_inner(), question)))
                     .chain(inserted_questions)
                     .collect_vec();
 
@@ -280,19 +281,19 @@ async fn upsert_existing_questions(
         .iter()
         .fold(query(&sql), |query, question| {
             query
-                .bind(question.id.map(|id| id.into_inner()))
+                .bind(question.id().map(|id| id.into_inner()))
                 .bind(form_id)
-                .bind(question.template_key.to_owned().into_inner())
-                .bind(question.position)
-                .bind(question.title.to_owned().into_inner())
+                .bind(question.template_key().to_owned().into_inner())
+                .bind(question.position())
+                .bind(question.title().to_owned().into_inner())
                 .bind(
                     question
-                        .description
-                        .to_owned()
+                        .description()
+                        .cloned()
                         .map(|description| description.into_inner()),
                 )
-                .bind(question.question_type.to_string())
-                .bind(question.is_required)
+                .bind(question.question_type().to_string())
+                .bind(question.is_required())
         })
         .execute(&mut *txn)
         .await?;
@@ -318,17 +319,17 @@ async fn insert_new_questions<'a>(
         .fold(query(&sql), |query, question| {
             query
                 .bind(form_id.to_owned().into_inner().to_string())
-                .bind(question.template_key.to_owned().into_inner())
-                .bind(question.position)
-                .bind(question.title.to_owned().into_inner())
+                .bind(question.template_key().to_owned().into_inner())
+                .bind(question.position())
+                .bind(question.title().to_owned().into_inner())
                 .bind(
                     question
-                        .description
-                        .to_owned()
+                        .description()
+                        .cloned()
                         .map(|description| description.into_inner()),
                 )
-                .bind(question.question_type.to_string())
-                .bind(question.is_required)
+                .bind(question.question_type().to_string())
+                .bind(question.is_required())
         })
         .execute(&mut *txn)
         .await?;
@@ -379,7 +380,7 @@ async fn sync_choices_for_questions(
     let retained_choice_ids = assigned_questions
         .iter()
         .flat_map(|(_, question)| {
-            question.choices.iter().flat_map(|choices| {
+            question.choices().into_iter().flat_map(|choices| {
                 choices
                     .iter()
                     .filter_map(|choice| choice.id.map(|id| id.into_inner()))
@@ -400,7 +401,7 @@ async fn sync_choices_for_questions(
     let existing_choices = assigned_questions
         .iter()
         .flat_map(|(question_id, question)| {
-            question.choices.iter().flat_map(|choices| {
+            question.choices().into_iter().flat_map(|choices| {
                 choices.iter().filter_map(|choice| {
                     choice.id.map(|id| {
                         (
@@ -418,9 +419,9 @@ async fn sync_choices_for_questions(
 
     let new_choices = assigned_questions
         .iter()
-        .filter(|(_, question)| question.question_type != QuestionType::Text)
+        .filter(|(_, question)| question.question_type() != QuestionType::Text)
         .flat_map(|(question_id, question)| {
-            question.choices.iter().flat_map(|choices| {
+            question.choices().into_iter().flat_map(|choices| {
                 choices
                     .iter()
                     .filter(|choice| choice.id.is_none())

--- a/server/infra/resource/src/dto.rs
+++ b/server/infra/resource/src/dto.rs
@@ -68,6 +68,15 @@ impl TryFrom<QuestionDto> for domain::form::question::models::Question {
             is_required,
         }: QuestionDto,
     ) -> Result<Self, Self::Error> {
+        let choices = choices
+            .into_iter()
+            .map(TryInto::try_into)
+            .collect::<Result<Vec<_>, _>>()
+            .map(|choices| {
+                (!choices.is_empty())
+                    .then(|| NonEmptyVec::try_new(choices).expect("non-empty choices"))
+            })?;
+
         Question::from_raw_parts(
             id.map(Into::into),
             FormId::from(Uuid::from_str(&form_id).map_err(Into::<InfraError>::into)?),
@@ -76,14 +85,7 @@ impl TryFrom<QuestionDto> for domain::form::question::models::Question {
             title.try_into()?,
             description.map(TryInto::try_into).transpose()?,
             QuestionType::from_str(&question_type).map_err(Into::<InfraError>::into)?,
-            choices
-                .into_iter()
-                .map(TryInto::try_into)
-                .collect::<Result<Vec<_>, _>>()
-                .map(|choices| {
-                    (!choices.is_empty())
-                        .then(|| NonEmptyVec::try_new(choices).expect("non-empty choices"))
-                })?,
+            choices,
             is_required,
         )
         .map_err(Into::into)
@@ -221,6 +223,33 @@ impl TryFrom<CommentDto> for domain::form::comment::models::Comment {
             }
             .try_into()?,
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn question_dto_rejects_text_question_with_choices() {
+        let result: Result<domain::form::question::models::Question, _> = QuestionDto {
+            id: Some(1),
+            form_id: Uuid::nil().to_string(),
+            template_key: "template".to_string(),
+            position: 0,
+            title: "Question".to_string(),
+            description: None,
+            question_type: "Text".to_string(),
+            choices: vec![ChoiceDto {
+                id: Some(1),
+                position: 0,
+                label: "A".to_string(),
+            }],
+            is_required: true,
+        }
+        .try_into();
+
+        assert!(result.is_err());
     }
 }
 

--- a/server/presentation/src/handlers/form/form_handler.rs
+++ b/server/presentation/src/handlers/form/form_handler.rs
@@ -375,18 +375,57 @@ pub async fn update_form_handler(
                             )
                         })
                         .collect::<Result<Vec<_>, _>>()?;
-                    domain::form::question::models::Question::new(
-                        question.id,
-                        form_id,
-                        question.template_key,
-                        question.position,
-                        question.title,
-                        question.description,
-                        question.question_type,
-                        (!choices.is_empty())
-                            .then(|| NonEmptyVec::try_new(choices).expect("non-empty choices")),
-                        question.is_required,
-                    )
+                    let choices = (!choices.is_empty())
+                        .then(|| NonEmptyVec::try_new(choices).expect("non-empty choices"));
+                    match question.question_type {
+                        domain::form::question::models::QuestionType::Text => {
+                            domain::form::question::models::Question::from_raw_parts(
+                                question.id,
+                                form_id,
+                                question.template_key,
+                                question.position,
+                                question.title,
+                                question.description,
+                                question.question_type,
+                                choices,
+                                question.is_required,
+                            )
+                        }
+                        domain::form::question::models::QuestionType::SingleChoice => {
+                            domain::form::question::models::Question::new_single_choice(
+                                question.id,
+                                form_id,
+                                question.template_key,
+                                question.position,
+                                question.title,
+                                question.description,
+                                choices.ok_or_else(|| {
+                                    errors::domain::DomainError::InvalidEntity {
+                                        message: "choice question must have at least one choice"
+                                            .to_string(),
+                                    }
+                                })?,
+                                question.is_required,
+                            )
+                        }
+                        domain::form::question::models::QuestionType::MultipleChoice => {
+                            domain::form::question::models::Question::new_multiple_choice(
+                                question.id,
+                                form_id,
+                                question.template_key,
+                                question.position,
+                                question.title,
+                                question.description,
+                                choices.ok_or_else(|| {
+                                    errors::domain::DomainError::InvalidEntity {
+                                        message: "choice question must have at least one choice"
+                                            .to_string(),
+                                    }
+                                })?,
+                                question.is_required,
+                            )
+                        }
+                    }
                 })
                 .collect::<Result<Vec<_>, _>>()
                 .and_then(QuestionSet::try_new)

--- a/server/presentation/src/schemas/form/form_response_schemas.rs
+++ b/server/presentation/src/schemas/form/form_response_schemas.rs
@@ -128,21 +128,22 @@ pub struct QuestionResponseSchema {
 impl From<domain::form::question::models::Question> for QuestionResponseSchema {
     fn from(val: domain::form::question::models::Question) -> Self {
         QuestionResponseSchema {
-            id: val.id.map(|id| id.into_inner()),
-            form_id: val.form_id.into_inner().to_string(),
-            template_key: val.template_key.into_inner(),
-            position: val.position,
-            title: val.title.into_inner(),
-            description: val.description.map(NonEmptyString::into_inner),
-            question_type: val.question_type.to_string(),
+            id: val.id().map(|id| id.into_inner()),
+            form_id: val.form_id().into_inner().to_string(),
+            template_key: val.template_key().to_owned().into_inner(),
+            position: val.position(),
+            title: val.title().to_owned().into_inner(),
+            description: val.description().cloned().map(NonEmptyString::into_inner),
+            question_type: val.question_type().to_string(),
             choices: val
-                .choices
+                .choices()
+                .cloned()
                 .map(|choices| choices.into_inner())
                 .unwrap_or_default()
                 .into_iter()
                 .map(Into::into)
                 .collect(),
-            is_required: val.is_required,
+            is_required: val.is_required(),
         }
     }
 }
@@ -327,4 +328,41 @@ pub struct SenderSchema {
     pub uuid: String,
     pub name: String,
     pub role: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use domain::form::{
+        models::FormId,
+        question::models::{Choice, Question},
+    };
+    use types::non_empty_vec::NonEmptyVec;
+    use uuid::Uuid;
+
+    #[test]
+    fn question_response_schema_preserves_api_shape_for_choice_question() {
+        let question = Question::new_single_choice(
+            Some(1.into()),
+            FormId::from(Uuid::nil()),
+            "role".to_string().try_into().unwrap(),
+            0,
+            "Role".to_string().try_into().unwrap(),
+            Some("desc".to_string().try_into().unwrap()),
+            NonEmptyVec::try_new(vec![
+                Choice::new(Some(10.into()), 0, "Admin".to_string().try_into().unwrap()).unwrap(),
+                Choice::new(Some(11.into()), 1, "User".to_string().try_into().unwrap()).unwrap(),
+            ])
+            .unwrap(),
+            true,
+        )
+        .unwrap();
+
+        let schema = QuestionResponseSchema::from(question);
+
+        assert_eq!(schema.question_type, "SingleChoice");
+        assert_eq!(schema.choices.len(), 2);
+        assert_eq!(schema.choices[0].label, "Admin");
+        assert!(schema.is_required);
+    }
 }

--- a/server/usecase/src/forms/form.rs
+++ b/server/usecase/src/forms/form.rs
@@ -181,23 +181,23 @@ impl<
         if let Some(questions) = &questions {
             let existing_question_ids = current_questions
                 .iter()
-                .filter_map(|question| question.id.map(|id| id.into_inner()))
+                .filter_map(|question| question.id().map(|id| id.into_inner()))
                 .collect::<BTreeSet<_>>();
             if let Some(invalid_question) = questions
                 .iter()
-                .find(|question| question.form_id != form_id)
+                .find(|question| question.form_id() != &form_id)
             {
                 return Err(DomainError::InvalidEntity {
                     message: format!(
                         "question.form_id must match the target form: {}",
-                        invalid_question.template_key.as_str()
+                        invalid_question.template_key().as_str()
                     ),
                 }
                 .into());
             }
             if let Some(invalid_id) = questions
                 .iter()
-                .filter_map(|question| question.id.map(|id| id.into_inner()))
+                .filter_map(|question| question.id().map(|id| id.into_inner()))
                 .find(|id| !existing_question_ids.contains(id))
             {
                 return Err(DomainError::InvalidEntity {
@@ -305,18 +305,18 @@ fn validate_answered_form_question_update(
 ) -> Result<(), Error> {
     let current_by_id = current_questions
         .iter()
-        .filter_map(|question| question.id.map(|id| (id.into_inner(), question)))
+        .filter_map(|question| question.id().map(|id| (id.into_inner(), question)))
         .collect::<HashMap<_, _>>();
     let updated_by_id = updated_questions
         .iter()
-        .filter_map(|question| question.id.map(|id| (id.into_inner(), question)))
+        .filter_map(|question| question.id().map(|id| (id.into_inner(), question)))
         .collect::<HashMap<_, _>>();
 
     if let Some(error) = current_questions
         .iter()
         .filter_map(|current_question| {
             current_question
-                .id
+                .id()
                 .map(|id| (id.into_inner(), current_question))
         })
         .find_map(|(current_id, current_question)| {
@@ -326,35 +326,35 @@ fn validate_answered_form_question_update(
                     .ok_or_else(|| DomainError::InvalidEntity {
                         message: format!(
                             "cannot delete question {} from a form that already has answers",
-                            current_question.template_key.as_str()
+                            current_question.template_key().as_str()
                         ),
                     });
 
             updated_question
                 .and_then(|updated_question| {
-                    (current_question.template_key == updated_question.template_key)
+                    (current_question.template_key() == updated_question.template_key())
                         .then_some(updated_question)
                         .ok_or_else(|| DomainError::InvalidEntity {
                             message: format!(
                                 "cannot change template_key for answered question {}",
-                                current_question.template_key.as_str()
+                                current_question.template_key().as_str()
                             ),
                         })
                 })
                 .and_then(|updated_question| {
-                    (current_question.question_type == updated_question.question_type)
+                    (current_question.question_type() == updated_question.question_type())
                         .then_some((current_question, updated_question))
                         .ok_or_else(|| DomainError::InvalidEntity {
                             message: format!(
                                 "cannot change question_type for answered question {}",
-                                current_question.template_key.as_str()
+                                current_question.template_key().as_str()
                             ),
                         })
                 })
                 .and_then(|(current_question, updated_question)| {
                     let current_choice_ids = current_question
-                        .choices
-                        .iter()
+                        .choices()
+                        .into_iter()
                         .flat_map(|choices| {
                             choices
                                 .iter()
@@ -362,8 +362,8 @@ fn validate_answered_form_question_update(
                         })
                         .collect::<BTreeSet<_>>();
                     let updated_choice_ids = updated_question
-                        .choices
-                        .iter()
+                        .choices()
+                        .into_iter()
                         .flat_map(|choices| {
                             choices
                                 .iter()
@@ -378,7 +378,7 @@ fn validate_answered_form_question_update(
                             message: format!(
                                 "cannot delete choice {} from answered question {}",
                                 choice_id,
-                                current_question.template_key.as_str()
+                                current_question.template_key().as_str()
                             ),
                         })
                         .map_or(Ok(()), Err)
@@ -393,7 +393,7 @@ fn validate_answered_form_question_update(
         .iter()
         .filter_map(|updated_question| {
             updated_question
-                .id
+                .id()
                 .map(|id| (id.into_inner(), updated_question))
         })
         .find_map(|(updated_id, updated_question)| {
@@ -404,8 +404,8 @@ fn validate_answered_form_question_update(
                 })
                 .and_then(|current_question| {
                     let current_choice_ids = current_question
-                        .choices
-                        .iter()
+                        .choices()
+                        .into_iter()
                         .flat_map(|choices| {
                             choices
                                 .iter()
@@ -414,8 +414,8 @@ fn validate_answered_form_question_update(
                         .collect::<BTreeSet<_>>();
 
                     updated_question
-                        .choices
-                        .iter()
+                        .choices()
+                        .into_iter()
                         .flat_map(|choices| {
                             choices
                                 .iter()
@@ -426,7 +426,7 @@ fn validate_answered_form_question_update(
                             message: format!(
                                 "cannot regenerate choice id {} for answered question {}",
                                 choice_id,
-                                updated_question.template_key.as_str()
+                                updated_question.template_key().as_str()
                             ),
                         })
                         .map_or(Ok(()), Err)


### PR DESCRIPTION
question_type と choices の実行時整合性に依存しない形へ寄せ、質問種別ごとの責務を型に閉じ込めるため。\n\n内部表現を整理しつつ API shape と既存の保存形式は維持し、境界変換と回答検証を enum ベースへ揃えた。

Co-authored-by: Codex <noreply@openai.com>
