### PR TITLE
fix: フォーム回答送信時の real_answers 主キー欠落を修正

### DIFF
--- a/server/infra/resource/src/database/forms/answers.rs
+++ b/server/infra/resource/src/database/forms/answers.rs
@@ -104,6 +104,7 @@ impl FormAnswerDatabase for ConnectionPool {
             .iter()
             .map(|content| {
                 (
+                    content.id.to_owned().into_inner().to_string(),
                     answer_id.clone(),
                     content.question_id.to_owned().into_inner().to_string(),
                     content.answer.to_owned(),
@@ -126,13 +127,13 @@ impl FormAnswerDatabase for ConnectionPool {
 
                 if !contents.is_empty() {
                     let sql = format!(
-                        "INSERT INTO real_answers (answer_id, question_id, answer) VALUES {}",
-                        std::iter::repeat_n("(?, ?, ?)", contents.len()).join(", ")
+                        "INSERT INTO real_answers (id, answer_id, question_id, answer) VALUES {}",
+                        std::iter::repeat_n("(?, ?, ?, ?)", contents.len()).join(", ")
                     );
                     contents
                         .into_iter()
-                        .flat_map(|(answer_id, question_id, answer)| {
-                            [answer_id, question_id, answer]
+                        .flat_map(|(id, answer_id, question_id, answer)| {
+                            [id, answer_id, question_id, answer]
                         })
                         .fold(query(&sql), |query, value| query.bind(value))
                         .execute(&mut **txn)


### PR DESCRIPTION
## 概要
- フォーム回答送信時に `real_answers.id` を INSERT していなかったため、MySQL で `Field 'id' doesn't have a default value` が発生して 500 になっていた不具合を修正
- 回答内容ごとに生成済みの `FormAnswerContent.id` を `real_answers.id` として保存するように変更
- 影響範囲はフォーム回答作成時の永続化処理のみ

## 確認事項
- `cargo build` を実行し、修正後もバックエンド全体がコンパイルできることを確認
- 実機のフォーム送信までは未確認。レビューでは、回答送信時に 500 が解消し `real_answers` に各行の `id` が入ることを見てもらいたい

🤖 Generated with Codex