### PR TITLE
fix: answers取得時のutf8mb4エラーを解消

### DIFF
--- a/server/infra/resource/src/database/forms/answer_label.rs
+++ b/server/infra/resource/src/database/forms/answer_label.rs
@@ -131,7 +131,7 @@ impl FormAnswerLabelDatabase for ConnectionPool {
         &self,
         answer_id: AnswerId,
     ) -> Result<Vec<AnswerLabelDto>, InfraError> {
-        let answer_id = answer_id.into_inner();
+        let answer_id = answer_id.into_inner().to_string();
 
         self.read_only_transaction(|txn| {
             Box::pin(async move {

--- a/server/infra/resource/src/database/forms/message.rs
+++ b/server/infra/resource/src/database/forms/message.rs
@@ -15,7 +15,7 @@ impl FormMessageDatabase for ConnectionPool {
     #[tracing::instrument]
     async fn post_message(&self, message: &Message) -> Result<(), InfraError> {
         let id = message.id().to_string().to_owned();
-        let related_answer_id = message.related_answer_id().into_inner().to_owned();
+        let related_answer_id = message.related_answer_id().to_string();
         let sender = message.sender().id.to_string().to_owned();
         let body = message.body().to_owned();
         let timestamp = message.timestamp().to_owned();
@@ -49,7 +49,7 @@ impl FormMessageDatabase for ConnectionPool {
                 sqlx::query!(
                     "UPDATE messages SET body = ? WHERE id = ?",
                     body,
-                    message_id.into_inner(),
+                    message_id.to_string(),
                 )
                 .execute(&mut **txn)
                 .await?;


### PR DESCRIPTION
## 概要
- answers 取得時にラベル読込クエリだけ `answer_id` を `Uuid` のまま bind していたため、MariaDB の `CHAR(36)` 列比較で `Invalid utf8mb4 character string` が発生していました。
- `label_settings_for_form_answers.answer_id` への bind を文字列 UUID に統一し、回答取得時のラベル検索を既存の他クエリと同じ型で実行するよう修正しました。

## 確認事項
- `cargo build` を実行し、修正後もワークスペース全体がビルドできることを確認しました。
- ローカル DB に対する実 API 再現までは未実施ですが、エラー原因だった bind 型の不一致は解消しています。

🤖 Generated with Codex
