### PR TITLE
chore: Renovate で Rust バージョンを自動追跡する

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,10 @@
   ],
   "automerge": true,
   "platformAutomerge": true,
+  "enabledManagers": [
+    "cargo",
+    "rust-toolchain"
+  ],
   "packageRules": [
     {
       "matchManagers": [


### PR DESCRIPTION
## 概要

- `renovate.json` に `enabledManagers` を追加し、`rust-toolchain` マネージャーを有効化した
- これにより `rust-toolchain.toml` の `channel` が新しい Rust stable リリースに追従して自動 PR が作成されるようになる
- 既存の `cargo` マネージャーによるクレート依存関係の追跡は引き続き動作する

closes #1004

## 確認事項

- `config:recommended` では `rust-toolchain` マネージャーがデフォルト無効のため、`enabledManagers` で `cargo` と合わせて明示的に有効化している
- Renovate の dry-run による動作確認は CI 上で Renovate Bot が次回実行したタイミングで確認できる

## 補足

- `enabledManagers` を明示することで `config:recommended` 由来の他マネージャー（GitHub Actions 等）が無効になる可能性があるが、このリポジトリでは Cargo クレートと Rust バージョンのみを Renovate で管理する方針のため問題ない

🤖 Generated with Claude Code