### PR TITLE
feat: makers db タスクを追加

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -27,6 +27,10 @@ dependencies = ["generate-openapi", "check-openapi-tracked"]
 command = "git"
 args = ["diff", "--exit-code", "--", "docs/openapi.json"]
 
+[tasks.db]
+command = "docker"
+args = ["exec", "-it", "mariadb", "mariadb", "-uuser", "-ppassword", "seichi_portal"]
+
 [tasks.up]
 dependencies = ["up-db", "run-server"]
 


### PR DESCRIPTION
## 概要

- `makers db` で MariaDB の対話シェルに直接接続できるショートカットタスクを追加
- 実行内容は `docker exec -it mariadb mariadb -uuser -ppassword seichi_portal`
- ローカル開発時に毎回長いコマンドを打つ手間を省く

## 確認事項

- `Makefile.toml` への追記のみで、既存タスクへの影響なし
- 接続情報は `compose.yaml` の `db` サービス定義と一致していることを確認済み

🤖 Generated with Claude Code