### PR TITLE
docs: server/ 配下に AI Agent 向けコーディング規約を追加

### DIFF
--- a/server/AGENTS.md
+++ b/server/AGENTS.md
@@ -2,12 +2,12 @@
 
 ## `use` 宣言 — 原則と例外
 
-**原則**: 型・トレイト・関数は `use` でインポートし、コード本文では短名で参照する。
+型・トレイト・関数は原則 `use` でインポートし、コード本文では短名で参照する。
+新しく型を追加・参照するときは、まずそのファイルの既存 `use` ブロックと実装の書き方に合わせる。
 
 NG 例（AI がやりがちなミス）:
 
 ```rust
-// NG: use せずフルパスで書く
 async fn handle(
     state: axum::extract::State<crate::server::AppState>,
 ) -> impl axum::response::IntoResponse {
@@ -29,18 +29,12 @@ async fn handle(state: State<AppState>) -> impl IntoResponse {
 }
 ```
 
-補足:
-
-- 同じモジュールから複数の型をインポートするときは `{}` でグループ化する
-- 外部クレートを先に並べ、1 行空けて内部クレート（`domain`, `crate::` など）を書く（既存ファイルの並び順に従う）
-
-### 例外 — 名前衝突時はフルパスが正しい
+### 例外
 
 `infra` 層の DTO ↔ ドメイン型変換では、DTO 型とドメイン型が同じ短名を持つことが多い。
-このときは `use` でどちらかを隠すより、フルパスで両者を区別するのが正しいスタイル（`dto.rs`、`messaging/schema.rs`、`messaging/connection.rs` が該当）。
+このときは `use` でどちらかを隠すより、フルパスで両者を区別する。
 
 ```rust
-// OK: 同名の型が衝突するので impl ヘッダーとボディをフルパスで書く
 impl TryFrom<CommentDto> for domain::form::comment::models::Comment {
     type Error = InfraError;
     fn try_from(dto: CommentDto) -> Result<Self, Self::Error> {
@@ -49,61 +43,25 @@ impl TryFrom<CommentDto> for domain::form::comment::models::Comment {
 }
 ```
 
-**判断基準**: 新しく型を追加・参照するとき、まずそのファイルの既存 `use` ブロックと既存の実装を見て、フルパスが使われているパターンかどうか確認する。
-
 ---
 
 ## 宣言的・関数型スタイルの優先
 
-**原則**: `let mut` / 命令的 `for` ループよりイテレータチェーンを使った宣言的スタイルを優先する。
+単純な値の変換・絞り込み・収集では、`let mut` / 命令的 `for` ループよりイテレータチェーンを優先する。
 
-NG 例:
-
-```rust
-// NG: mutable な Vec を for ループで組み立てる
-let mut result = vec![];
-for item in items {
-    if let Ok(read) = item.try_into_read(&actor) {
-        result.push(read);
-    }
-}
-```
-
-OK 例:
+特に、`Vec` を組み立てるだけの `let mut` + `for` + `push` は避け、`map` / `filter_map` / `flat_map` / `collect` を使う。
 
 ```rust
-// OK: flat_map で None/Err を除外しながら収集
 let result = items
     .into_iter()
     .flat_map(|item| item.try_into_read(&actor))
     .collect::<Vec<_>>();
 ```
 
-### 追加パターン
-
-構造体のフィールドを 1 つ変えた新しい値を返す → struct update syntax:
+構造体のフィールドを一部だけ変えた新しい値を返すときは、可能なら struct update syntax を使う。
 
 ```rust
-// NG
-let mut updated = self.clone();
-updated.title = new_title;
-updated
-
-// OK: self を consume して新しい値を返す
 pub fn change_title(self, title: Title) -> Self {
     Self { title, ..self }
 }
 ```
-
-`Result` のコレクション:
-
-```rust
-// OK
-items
-    .into_iter()
-    .map(|item| item.try_into_read(&actor))
-    .collect::<Result<Vec<_>, _>>()
-    .map_err(Into::into)
-```
-
-**判断基準**: `let mut` を書こうとしたら、まずイテレータチェーンで同等に書けないか検討する。「変更量を最小にする」という理由で `push` を追加するより、変換全体を宣言的に書き直すほうがこのプロジェクトでは正しい。

--- a/server/AGENTS.md
+++ b/server/AGENTS.md
@@ -1,0 +1,107 @@
+# server/ AI Agent 向けコーディング規約
+
+## `use` 宣言 — 原則と例外
+
+**原則**: 型・トレイト・関数は `use` でインポートし、コード本文では短名で参照する。
+
+NG 例（AI がやりがちなミス）:
+
+```rust
+// NG: use せずフルパスで書く
+async fn handle(
+    state: axum::extract::State<crate::server::AppState>,
+) -> impl axum::response::IntoResponse {
+    let id = domain::form::models::FormId::new(uuid::Uuid::new_v4());
+}
+```
+
+OK 例:
+
+```rust
+use axum::{extract::State, response::IntoResponse};
+use domain::form::models::FormId;
+use uuid::Uuid;
+
+async fn handle(state: State<AppState>) -> impl IntoResponse {
+    let id = FormId::new(Uuid::new_v4());
+}
+```
+
+補足:
+
+- 同じモジュールから複数の型をインポートするときは `{}` でグループ化する
+- 外部クレートを先に並べ、1 行空けて内部クレート（`domain`, `crate::` など）を書く（既存ファイルの並び順に従う）
+
+### 例外 — 名前衝突時はフルパスが正しい
+
+`infra` 層の DTO ↔ ドメイン型変換では、DTO 型とドメイン型が同じ短名を持つことが多い。
+このときは `use` でどちらかを隠すより、フルパスで両者を区別するのが正しいスタイル（`dto.rs`、`messaging/schema.rs`、`messaging/connection.rs` が該当）。
+
+```rust
+// OK: 同名の型が衝突するので impl ヘッダーとボディをフルパスで書く
+impl TryFrom<CommentDto> for domain::form::comment::models::Comment {
+    type Error = InfraError;
+    fn try_from(dto: CommentDto) -> Result<Self, Self::Error> {
+        Ok(domain::form::comment::models::Comment::from_raw_parts(...))
+    }
+}
+```
+
+**判断基準**: 新しく型を追加・参照するとき、まずそのファイルの既存 `use` ブロックと既存の実装を見て、フルパスが使われているパターンかどうか確認する。
+
+---
+
+## 宣言的・関数型スタイルの優先
+
+**原則**: `let mut` / 命令的 `for` ループよりイテレータチェーンを使った宣言的スタイルを優先する。
+
+NG 例:
+
+```rust
+// NG: mutable な Vec を for ループで組み立てる
+let mut result = vec![];
+for item in items {
+    if let Ok(read) = item.try_into_read(&actor) {
+        result.push(read);
+    }
+}
+```
+
+OK 例:
+
+```rust
+// OK: flat_map で None/Err を除外しながら収集
+let result = items
+    .into_iter()
+    .flat_map(|item| item.try_into_read(&actor))
+    .collect::<Vec<_>>();
+```
+
+### 追加パターン
+
+構造体のフィールドを 1 つ変えた新しい値を返す → struct update syntax:
+
+```rust
+// NG
+let mut updated = self.clone();
+updated.title = new_title;
+updated
+
+// OK: self を consume して新しい値を返す
+pub fn change_title(self, title: Title) -> Self {
+    Self { title, ..self }
+}
+```
+
+`Result` のコレクション:
+
+```rust
+// OK
+items
+    .into_iter()
+    .map(|guard| guard.try_into_read(actor))
+    .collect::<Result<Vec<_>, _>>()
+    .map_err(Into::into)
+```
+
+**判断基準**: `let mut` を書こうとしたら、まずイテレータチェーンで同等に書けないか検討する。「変更量を最小にする」という理由で `push` を追加するより、変換全体を宣言的に書き直すほうがこのプロジェクトでは正しい。

--- a/server/AGENTS.md
+++ b/server/AGENTS.md
@@ -19,8 +19,10 @@ OK 例:
 
 ```rust
 use axum::{extract::State, response::IntoResponse};
-use domain::form::models::FormId;
 use uuid::Uuid;
+
+use crate::server::AppState;
+use domain::form::models::FormId;
 
 async fn handle(state: State<AppState>) -> impl IntoResponse {
     let id = FormId::new(Uuid::new_v4());
@@ -99,7 +101,7 @@ pub fn change_title(self, title: Title) -> Self {
 // OK
 items
     .into_iter()
-    .map(|guard| guard.try_into_read(actor))
+    .map(|item| item.try_into_read(&actor))
     .collect::<Result<Vec<_>, _>>()
     .map_err(Into::into)
 ```

--- a/server/CLAUDE.md
+++ b/server/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## 概要

- `server/AGENTS.md` を新規作成し、AI Agent がコードを書く際に繰り返し起こす問題への対策をドキュメント化した
- `use` 宣言の原則（フルパス参照を避ける）と、infra 層 DTO 変換での意図的なフルパス使用の例外を整理
- `let mut` + 命令的 `for` ループより、イテレータチェーンを使った宣言的スタイルを優先するよう明記
- `server/CLAUDE.md` を `server/AGENTS.md` へのシンボリックリンクとして追加

## 確認事項

- `cargo build` が通ることを確認済み
- `server/CLAUDE.md -> AGENTS.md` のシンボリックリンクが正しく作成されていることを確認済み
- infra 層の `dto.rs`・`messaging/schema.rs`・`messaging/connection.rs` の実際のコードを参照し、フルパスが使われる理由（名前衝突）を確認した上で例外として明記

## 補足

- ドキュメントの対象は AI Agent（Claude Code 等）。AGENTS.md は Claude Code が自動的に読み込む規約ファイル
- CLAUDE.md は同内容のシンボリックリンクとして追加することで、ツール側の読み込みパスに依存しない構成にしている

🤖 Generated with Claude Code