### PR TITLE
makers pretty の format 対象を workspace 全体にする

### DIFF
--- a/server/Makefile.toml
+++ b/server/Makefile.toml
@@ -33,7 +33,7 @@ args = ["clippy", "--", "-D", "warnings"]
 
 [tasks.format]
 command = "cargo"
-args = ["fmt", "--", "--config-path=${REPOSITORY_ROOT}/.cargo-husky/hooks/rustfmt.toml", "--emit=files"]
+args = ["fmt", "--all", "--", "--config-path=${REPOSITORY_ROOT}/.cargo-husky/hooks/rustfmt.toml", "--emit=files"]
 
 [tasks.pretty]
 dependencies = ["fix", "test", "lint", "format"]


### PR DESCRIPTION
## 概要
- ルートから委譲された makers pretty が server 配下で cargo fmt を実行しても、root workspace の targets を解決できるようにしました。
- server/Makefile.toml の format task に --all を追加し、Failed to find targets で format step が失敗する問題を修正しました。

## 確認事項
- cargo fmt --all --check に rustfmt config を指定して実行し、workspace 全体を対象に rustfmt が実行できることを確認しました。
- makers pretty が clippy fix、nextest、doctest、lint、format まで完了することを確認しました。

🤖 Generated with Codex