### PR TITLE
フォームアーカイブを ArchivedForm 作成として扱う

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5046,6 +5046,7 @@ name = "usecase"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "chrono",
  "common",
  "domain",
  "errors",

--- a/server/domain/src/repository/form/archived_form_repository.rs
+++ b/server/domain/src/repository/form/archived_form_repository.rs
@@ -3,10 +3,10 @@ use errors::Error;
 use mockall::automock;
 
 use crate::{
-    form::models::{ActiveForm, ArchivedForm, FormId},
+    form::models::{ArchivedForm, FormId},
     types::{
         authorization_guard::AuthorizationGuard,
-        authorization_guard_with_context::{Read, Update},
+        authorization_guard_with_context::{Create, Read, Update},
     },
     user::models::User,
 };
@@ -27,7 +27,7 @@ pub trait ArchivedFormRepository: Send + Sync + 'static {
     async fn archive(
         &self,
         actor: &User,
-        form: AuthorizationGuard<ActiveForm, Update>,
+        form: AuthorizationGuard<ArchivedForm, Create>,
     ) -> Result<AuthorizationGuard<ArchivedForm, Read>, Error>;
     async fn restore(
         &self,

--- a/server/infra/resource/src/database/components.rs
+++ b/server/infra/resource/src/database/components.rs
@@ -66,7 +66,7 @@ pub trait FormDatabase: Send + Sync {
         query: Option<String>,
     ) -> Result<Vec<ArchivedFormDto>, InfraError>;
     async fn get_archived(&self, form_id: FormId) -> Result<Option<ArchivedFormDto>, InfraError>;
-    async fn archive(&self, form_id: FormId, actor: &User) -> Result<ArchivedForm, InfraError>;
+    async fn archive(&self, form: &ArchivedForm) -> Result<ArchivedForm, InfraError>;
     async fn restore(&self, form_id: FormId) -> Result<(), InfraError>;
     async fn update(&self, form: &ActiveForm, updated_by: &User) -> Result<(), InfraError>;
     async fn size(&self) -> Result<u32, InfraError>;

--- a/server/infra/resource/src/database/forms/form.rs
+++ b/server/infra/resource/src/database/forms/form.rs
@@ -400,20 +400,21 @@ async fn update_form_root(
 
 async fn copy_active_form_to_archive(
     txn: &mut DatabaseTransaction,
-    form_id: FormId,
-    actor: &User,
+    form: &ArchivedForm,
 ) -> Result<(), InfraError> {
-    let form_id = form_id.into_inner().to_string();
-    let actor_id = actor.id.to_string();
+    let form_id = form.form().id().into_inner().to_string();
+    let archived_at = *form.archived_at();
+    let archived_by = form.archived_by().to_string();
 
     sqlx::query(
         r"INSERT INTO archived_form_meta_data
         (id, title, description, visibility, answer_visibility, created_at, created_by, updated_at, updated_by, archived_at, archived_by)
-        SELECT id, title, description, visibility, answer_visibility, created_at, created_by, updated_at, updated_by, CURRENT_TIMESTAMP, ?
+        SELECT id, title, description, visibility, answer_visibility, created_at, created_by, updated_at, updated_by, ?, ?
         FROM form_meta_data
         WHERE id = ?",
     )
-    .bind(actor_id)
+    .bind(archived_at)
+    .bind(archived_by)
     .bind(&form_id)
     .execute(&mut **txn)
     .await?;
@@ -801,17 +802,18 @@ impl FormDatabase for ConnectionPool {
     }
 
     #[tracing::instrument]
-    async fn archive(&self, form_id: FormId, actor: &User) -> Result<ArchivedForm, InfraError> {
-        let actor = actor.clone();
+    async fn archive(&self, form: &ArchivedForm) -> Result<ArchivedForm, InfraError> {
+        let form = form.clone();
         self.read_write_transaction(move |txn| {
             Box::pin(async move {
+                let form_id = *form.form().id();
                 if fetch_form_row(txn, form_id).await?.is_none() {
                     return Err(InfraError::FormNotFound {
                         id: form_id.into_inner(),
                     });
                 }
 
-                copy_active_form_to_archive(txn, form_id, &actor).await?;
+                copy_active_form_to_archive(txn, &form).await?;
 
                 let row = fetch_archived_form_row(txn, form_id)
                     .await?

--- a/server/infra/resource/src/repository/form_repository_impls/form_repository_impl.rs
+++ b/server/infra/resource/src/repository/form_repository_impls/form_repository_impl.rs
@@ -1,5 +1,4 @@
 use async_trait::async_trait;
-use chrono::Utc;
 use domain::{
     form::models::{ActiveForm, ArchivedForm, FormId},
     repository::form::{
@@ -130,12 +129,10 @@ where
     async fn archive(
         &self,
         actor: &User,
-        form: AuthorizationGuard<ActiveForm, Update>,
+        form: AuthorizationGuard<ArchivedForm, Create>,
     ) -> Result<AuthorizationGuard<ArchivedForm, Read>, Error> {
-        let form = form.try_into_update(actor, |form| form)?;
-        let form_id = *form.id();
-        let _ = form.archive(Utc::now(), actor.id);
-        let archived_form = self.client.form().archive(form_id, actor).await?;
+        let form = form.try_into_create(actor, |form| form)?;
+        let archived_form = self.client.form().archive(&form).await?;
         Ok(AuthorizationGuard::<ArchivedForm, Create>::from(archived_form).into_read())
     }
 

--- a/server/usecase/Cargo.toml
+++ b/server/usecase/Cargo.toml
@@ -14,3 +14,4 @@ tokio = { workspace = true }
 common = { path = "../common" }
 async-trait = { workspace = true }
 serde_json = { workspace = true }
+chrono = { workspace = true }

--- a/server/usecase/src/forms/form.rs
+++ b/server/usecase/src/forms/form.rs
@@ -219,9 +219,7 @@ impl<
             .get(form_id)
             .await?
             .ok_or(Error::from(FormNotFound))?;
-        let form = form
-            .into_update()
-            .try_into_update(actor, |form| form.archive(Utc::now(), actor.id))?;
+        let form = form.try_into_read(actor)?.archive(Utc::now(), actor.id);
         let archived_form = self
             .archived_form_repository
             .archive(actor, form.into())

--- a/server/usecase/src/forms/form.rs
+++ b/server/usecase/src/forms/form.rs
@@ -1,3 +1,4 @@
+use chrono::Utc;
 use domain::{
     form::{
         answer::settings::models::{AnswerVisibility, DefaultAnswerTitle, ResponsePeriod},
@@ -218,9 +219,12 @@ impl<
             .get(form_id)
             .await?
             .ok_or(Error::from(FormNotFound))?;
+        let form = form
+            .into_update()
+            .try_into_update(actor, |form| form.archive(Utc::now(), actor.id))?;
         let archived_form = self
             .archived_form_repository
-            .archive(actor, form.into_update())
+            .archive(actor, form.into())
             .await?;
         archived_form.try_into_read(actor).map_err(Into::into)
     }


### PR DESCRIPTION
## 概要
- `ArchivedFormRepository::archive` が `ActiveForm` の更新ではなく `ArchivedForm` の作成を受け取るようにし、操作の責務を型で表現しました。
- usecase 側で `ActiveForm::archive` により `ArchivedForm` を構築し、infra repository では `try_into_create` による作成権限チェックへ変更しました。
- DB 層では `CURRENT_TIMESTAMP` と actor への暗黙依存をやめ、渡された `ArchivedForm` の `archived_at` / `archived_by` を保存するようにしました。

## 確認事項
- `cargo fmt --check` でフォーマット差分がないことを確認しました。
- `cargo check` で workspace のコンパイルが通ることを確認しました。
- `cargo test -p usecase -p resource -p domain` で関連 crate の unit test / doctest が通ることを確認しました。
- コミット hook の `cargo check` も通過しています。

🤖 Generated with Codex