### PR TITLE
usecase の境界モデル命名を整理

### DIFF
--- a/server/infra/resource/src/database/components.rs
+++ b/server/infra/resource/src/database/components.rs
@@ -1,7 +1,7 @@
 use crate::{
     dto::{
-        ActiveFormDto, AnswerLabelDto, ArchivedFormDto, CommentDto, DiscordUserDto, FormAnswerDto,
-        FormLabelDto, MessageDto, NotificationSettingsDto,
+        ActiveFormRecord, AnswerLabelDto, ArchivedFormRecord, CommentDto, DiscordUserDto,
+        FormAnswerDto, FormLabelDto, MessageDto, NotificationSettingsDto,
     },
     external::discord_api::DiscordAPI,
 };
@@ -57,15 +57,16 @@ pub trait FormDatabase: Send + Sync {
         &self,
         offset: Option<u32>,
         limit: Option<u32>,
-    ) -> Result<Vec<ActiveFormDto>, InfraError>;
-    async fn get(&self, form_id: FormId) -> Result<Option<ActiveFormDto>, InfraError>;
+    ) -> Result<Vec<ActiveFormRecord>, InfraError>;
+    async fn get(&self, form_id: FormId) -> Result<Option<ActiveFormRecord>, InfraError>;
     async fn list_archived(
         &self,
         offset: Option<u32>,
         limit: Option<u32>,
         query: Option<String>,
-    ) -> Result<Vec<ArchivedFormDto>, InfraError>;
-    async fn get_archived(&self, form_id: FormId) -> Result<Option<ArchivedFormDto>, InfraError>;
+    ) -> Result<Vec<ArchivedFormRecord>, InfraError>;
+    async fn get_archived(&self, form_id: FormId)
+    -> Result<Option<ArchivedFormRecord>, InfraError>;
     async fn archive(&self, form: &ArchivedForm) -> Result<ArchivedForm, InfraError>;
     async fn restore(&self, form_id: FormId) -> Result<(), InfraError>;
     async fn update(&self, form: &ActiveForm, updated_by: &User) -> Result<(), InfraError>;

--- a/server/infra/resource/src/database/components.rs
+++ b/server/infra/resource/src/database/components.rs
@@ -1,9 +1,9 @@
 use crate::{
-    dto::{
-        ActiveFormRecord, AnswerLabelDto, ArchivedFormRecord, CommentDto, DiscordUserDto,
-        FormAnswerDto, FormLabelDto, MessageDto, NotificationSettingsDto,
-    },
     external::discord_api::DiscordAPI,
+    records::{
+        ActiveFormRecord, AnswerLabelRecord, ArchivedFormRecord, CommentRecord, DiscordUserRecord,
+        FormAnswerRecord, FormLabelRecord, MessageRecord, NotificationSettingsRecord,
+    },
 };
 use async_trait::async_trait;
 use domain::search::models::{NumberOfRecordsPerAggregate, RealAnswers};
@@ -77,16 +77,19 @@ pub trait FormDatabase: Send + Sync {
 #[async_trait]
 pub trait FormAnswerDatabase: Send + Sync {
     async fn post_answer(&self, answer: &AnswerEntry) -> Result<(), InfraError>;
-    async fn get_answers(&self, answer_id: AnswerId) -> Result<Option<FormAnswerDto>, InfraError>;
+    async fn get_answers(
+        &self,
+        answer_id: AnswerId,
+    ) -> Result<Option<FormAnswerRecord>, InfraError>;
     async fn get_answers_by_form_id(
         &self,
         form_id: FormId,
-    ) -> Result<Vec<FormAnswerDto>, InfraError>;
-    async fn get_all_answers(&self) -> Result<Vec<FormAnswerDto>, InfraError>;
+    ) -> Result<Vec<FormAnswerRecord>, InfraError>;
+    async fn get_all_answers(&self) -> Result<Vec<FormAnswerRecord>, InfraError>;
     async fn get_answers_by_answer_ids(
         &self,
         answer_ids: Vec<AnswerId>,
-    ) -> Result<Vec<FormAnswerDto>, InfraError>;
+    ) -> Result<Vec<FormAnswerRecord>, InfraError>;
     async fn update_answer_entry(&self, answer_entry: &AnswerEntry) -> Result<(), InfraError>;
     async fn size(&self) -> Result<u32, InfraError>;
 }
@@ -95,19 +98,19 @@ pub trait FormAnswerDatabase: Send + Sync {
 #[async_trait]
 pub trait FormAnswerLabelDatabase: Send + Sync {
     async fn create_label_for_answers(&self, label: &AnswerLabel) -> Result<(), InfraError>;
-    async fn get_labels_for_answers(&self) -> Result<Vec<AnswerLabelDto>, InfraError>;
+    async fn get_labels_for_answers(&self) -> Result<Vec<AnswerLabelRecord>, InfraError>;
     async fn get_label_for_answers(
         &self,
         label_id: AnswerLabelId,
-    ) -> Result<Option<AnswerLabelDto>, InfraError>;
+    ) -> Result<Option<AnswerLabelRecord>, InfraError>;
     async fn get_labels_for_answers_by_label_ids(
         &self,
         label_ids: Vec<AnswerLabelId>,
-    ) -> Result<Vec<AnswerLabelDto>, InfraError>;
+    ) -> Result<Vec<AnswerLabelRecord>, InfraError>;
     async fn get_labels_for_answers_by_answer_id(
         &self,
         answer_id: AnswerId,
-    ) -> Result<Vec<AnswerLabelDto>, InfraError>;
+    ) -> Result<Vec<AnswerLabelRecord>, InfraError>;
     async fn delete_label_for_answers(&self, label_id: AnswerLabelId) -> Result<(), InfraError>;
     async fn edit_label_for_answers(&self, label: &AnswerLabel) -> Result<(), InfraError>;
     async fn replace_answer_labels(
@@ -129,18 +132,21 @@ pub trait FormMessageDatabase: Send + Sync {
     async fn fetch_messages_by_form_answer(
         &self,
         answers: &AnswerEntry,
-    ) -> Result<Vec<MessageDto>, InfraError>;
-    async fn fetch_message(&self, message_id: &MessageId)
-    -> Result<Option<MessageDto>, InfraError>;
+    ) -> Result<Vec<MessageRecord>, InfraError>;
+    async fn fetch_message(
+        &self,
+        message_id: &MessageId,
+    ) -> Result<Option<MessageRecord>, InfraError>;
     async fn delete_message(&self, message_id: MessageId) -> Result<(), InfraError>;
 }
 
 #[automock]
 #[async_trait]
 pub trait FormCommentDatabase: Send + Sync {
-    async fn get_comment(&self, comment_id: CommentId) -> Result<Option<CommentDto>, InfraError>;
-    async fn get_comments(&self, answer_id: AnswerId) -> Result<Vec<CommentDto>, InfraError>;
-    async fn get_all_comments(&self) -> Result<Vec<CommentDto>, InfraError>;
+    async fn get_comment(&self, comment_id: CommentId)
+    -> Result<Option<CommentRecord>, InfraError>;
+    async fn get_comments(&self, answer_id: AnswerId) -> Result<Vec<CommentRecord>, InfraError>;
+    async fn get_all_comments(&self) -> Result<Vec<CommentRecord>, InfraError>;
     async fn upsert_comment(
         &self,
         answer_id: AnswerId,
@@ -154,13 +160,13 @@ pub trait FormCommentDatabase: Send + Sync {
 #[async_trait]
 pub trait FormLabelDatabase: Send + Sync {
     async fn create_label_for_forms(&self, label: &FormLabel) -> Result<(), InfraError>;
-    async fn fetch_labels(&self) -> Result<Vec<FormLabelDto>, InfraError>;
+    async fn fetch_labels(&self) -> Result<Vec<FormLabelRecord>, InfraError>;
     async fn fetch_labels_by_ids(
         &self,
         ids: Vec<FormLabelId>,
-    ) -> Result<Vec<FormLabelDto>, InfraError>;
+    ) -> Result<Vec<FormLabelRecord>, InfraError>;
     async fn delete_label_for_forms(&self, label_id: FormLabelId) -> Result<(), InfraError>;
-    async fn fetch_label(&self, id: FormLabelId) -> Result<Option<FormLabelDto>, InfraError>;
+    async fn fetch_label(&self, id: FormLabelId) -> Result<Option<FormLabelRecord>, InfraError>;
     async fn edit_label_for_forms(
         &self,
         id: FormLabelId,
@@ -169,7 +175,7 @@ pub trait FormLabelDatabase: Send + Sync {
     async fn fetch_labels_by_form_id(
         &self,
         form_id: FormId,
-    ) -> Result<Vec<FormLabelDto>, InfraError>;
+    ) -> Result<Vec<FormLabelRecord>, InfraError>;
     async fn size(&self) -> Result<u32, InfraError>;
 }
 
@@ -198,7 +204,10 @@ pub trait UserDatabase: Send + Sync {
         user: &User,
     ) -> Result<(), InfraError>;
     async fn unlink_discord_user(&self, user: &User) -> Result<(), InfraError>;
-    async fn fetch_discord_user(&self, user: &User) -> Result<Option<DiscordUserDto>, InfraError>;
+    async fn fetch_discord_user(
+        &self,
+        user: &User,
+    ) -> Result<Option<DiscordUserRecord>, InfraError>;
     async fn fetch_size(&self) -> Result<u32, InfraError>;
 }
 
@@ -229,5 +238,5 @@ pub trait NotificationDatabase: Send + Sync {
     async fn fetch_notification_settings(
         &self,
         recipient_id: Uuid,
-    ) -> Result<Option<NotificationSettingsDto>, InfraError>;
+    ) -> Result<Option<NotificationSettingsRecord>, InfraError>;
 }

--- a/server/infra/resource/src/database/forms/answer_label.rs
+++ b/server/infra/resource/src/database/forms/answer_label.rs
@@ -8,7 +8,7 @@ use crate::{
     database::{
         components::FormAnswerLabelDatabase, connection::ConnectionPool, count::count_as_u32,
     },
-    dto::AnswerLabelDto,
+    records::AnswerLabelRecord,
 };
 
 #[async_trait]
@@ -35,7 +35,7 @@ impl FormAnswerLabelDatabase for ConnectionPool {
     }
 
     #[tracing::instrument]
-    async fn get_labels_for_answers(&self) -> Result<Vec<AnswerLabelDto>, InfraError> {
+    async fn get_labels_for_answers(&self) -> Result<Vec<AnswerLabelRecord>, InfraError> {
         self.read_only_transaction(|txn| {
             Box::pin(async move {
                 let labels_rs = sqlx::query("SELECT id, name FROM label_for_form_answers")
@@ -45,7 +45,7 @@ impl FormAnswerLabelDatabase for ConnectionPool {
                 labels_rs
                     .into_iter()
                     .map(|rs| {
-                        Ok::<_, InfraError>(AnswerLabelDto {
+                        Ok::<_, InfraError>(AnswerLabelRecord {
                             id: rs.try_get("id")?,
                             name: rs.try_get("name")?,
                         })
@@ -60,7 +60,7 @@ impl FormAnswerLabelDatabase for ConnectionPool {
     async fn get_label_for_answers(
         &self,
         label_id: AnswerLabelId,
-    ) -> Result<Option<AnswerLabelDto>, InfraError> {
+    ) -> Result<Option<AnswerLabelRecord>, InfraError> {
         let label_id = label_id.into_inner();
 
         self.read_only_transaction(|txn| {
@@ -74,7 +74,7 @@ impl FormAnswerLabelDatabase for ConnectionPool {
                 label_rs
                     .into_iter()
                     .map(|rs| {
-                        Ok::<_, InfraError>(AnswerLabelDto {
+                        Ok::<_, InfraError>(AnswerLabelRecord {
                             id: rs.try_get("id")?,
                             name: rs.try_get("name")?,
                         })
@@ -90,7 +90,7 @@ impl FormAnswerLabelDatabase for ConnectionPool {
     async fn get_labels_for_answers_by_label_ids(
         &self,
         label_ids: Vec<AnswerLabelId>,
-    ) -> Result<Vec<AnswerLabelDto>, InfraError> {
+    ) -> Result<Vec<AnswerLabelRecord>, InfraError> {
         if label_ids.is_empty() {
             return Ok(Vec::new());
         }
@@ -115,12 +115,12 @@ impl FormAnswerLabelDatabase for ConnectionPool {
                 labels_rs
                     .into_iter()
                     .map(|rs| {
-                        Ok::<_, InfraError>(AnswerLabelDto {
+                        Ok::<_, InfraError>(AnswerLabelRecord {
                             id: rs.try_get("id")?,
                             name: rs.try_get("name")?,
                         })
                     })
-                    .collect::<Result<Vec<AnswerLabelDto>, _>>()
+                    .collect::<Result<Vec<AnswerLabelRecord>, _>>()
             })
         })
         .await
@@ -130,7 +130,7 @@ impl FormAnswerLabelDatabase for ConnectionPool {
     async fn get_labels_for_answers_by_answer_id(
         &self,
         answer_id: AnswerId,
-    ) -> Result<Vec<AnswerLabelDto>, InfraError> {
+    ) -> Result<Vec<AnswerLabelRecord>, InfraError> {
         let answer_id = answer_id.into_inner().to_string();
 
         self.read_only_transaction(|txn| {
@@ -147,12 +147,12 @@ impl FormAnswerLabelDatabase for ConnectionPool {
                 labels_rs
                     .into_iter()
                     .map(|rs| {
-                        Ok::<_, InfraError>(AnswerLabelDto {
+                        Ok::<_, InfraError>(AnswerLabelRecord {
                             id: rs.try_get("label_id")?,
                             name: rs.try_get("name")?,
                         })
                     })
-                    .collect::<Result<Vec<AnswerLabelDto>, _>>()
+                    .collect::<Result<Vec<AnswerLabelRecord>, _>>()
             })
         })
             .await

--- a/server/infra/resource/src/database/forms/answers.rs
+++ b/server/infra/resource/src/database/forms/answers.rs
@@ -20,13 +20,13 @@ use crate::{
         connection::{ConnectionPool, DatabaseTransaction},
         count::count_as_u32,
     },
-    dto::{FormAnswerContentDto, FormAnswerDto},
+    records::{FormAnswerContentRecord, FormAnswerRecord},
 };
 
 async fn fetch_real_answers_by_answer_ids<T>(
     txn: &mut DatabaseTransaction,
     answer_ids: &[T],
-) -> Result<Vec<(Uuid, FormAnswerContentDto)>, InfraError>
+) -> Result<Vec<(Uuid, FormAnswerContentRecord)>, InfraError>
 where
     T: AsRef<str>,
 {
@@ -50,7 +50,7 @@ where
         .map(|row| {
             Ok::<_, InfraError>((
                 Uuid::from_str(&row.try_get::<String, _>("answer_id")?)?,
-                FormAnswerContentDto {
+                FormAnswerContentRecord {
                     id: row.try_get("id")?,
                     question_id: row.try_get("question_id")?,
                     answer: row.try_get("answer")?,
@@ -61,28 +61,28 @@ where
 }
 
 fn attach_contents(
-    form_answer_dtos: Vec<FormAnswerDto>,
-    answer_id_with_content_dto: Vec<(Uuid, FormAnswerContentDto)>,
-) -> Result<Vec<FormAnswerDto>, InfraError> {
-    let grouped_answer_contents = answer_id_with_content_dto
+    form_answer_records: Vec<FormAnswerRecord>,
+    answer_id_with_content_record: Vec<(Uuid, FormAnswerContentRecord)>,
+) -> Result<Vec<FormAnswerRecord>, InfraError> {
+    let grouped_answer_contents = answer_id_with_content_record
         .into_iter()
         .into_group_map_by(|(answer_id, _)| *answer_id);
 
-    form_answer_dtos
+    form_answer_records
         .into_iter()
-        .map(|dto| {
-            Ok::<_, InfraError>(FormAnswerDto {
+        .map(|record| {
+            Ok::<_, InfraError>(FormAnswerRecord {
                 contents: grouped_answer_contents
-                    .get(&Uuid::from_str(&dto.id)?)
+                    .get(&Uuid::from_str(&record.id)?)
                     .cloned()
                     .map(|contents| {
                         contents
                             .into_iter()
-                            .map(|(_, content_dto)| content_dto)
+                            .map(|(_, content_record)| content_record)
                             .collect_vec()
                     })
                     .unwrap_or_default(),
-                ..dto
+                ..record
             })
         })
         .collect()
@@ -146,7 +146,10 @@ impl FormAnswerDatabase for ConnectionPool {
     }
 
     #[tracing::instrument]
-    async fn get_answers(&self, answer_id: AnswerId) -> Result<Option<FormAnswerDto>, InfraError> {
+    async fn get_answers(
+        &self,
+        answer_id: AnswerId,
+    ) -> Result<Option<FormAnswerRecord>, InfraError> {
         self.read_only_transaction(|txn| {
             Box::pin(async move {
                 let answer_query_result_opt = sqlx::query(
@@ -168,7 +171,7 @@ impl FormAnswerDatabase for ConnectionPool {
                 let contents = contents
                     .into_iter()
                     .map(|rs| {
-                        Ok::<_, InfraError>(FormAnswerContentDto {
+                        Ok::<_, InfraError>(FormAnswerContentRecord {
                             id: rs.try_get("id")?,
                             question_id: rs.try_get("question_id")?,
                             answer: rs.try_get("answer")?,
@@ -178,7 +181,7 @@ impl FormAnswerDatabase for ConnectionPool {
 
                 answer_query_result_opt
                     .map(|rs| {
-                        Ok::<_, InfraError>(FormAnswerDto {
+                        Ok::<_, InfraError>(FormAnswerRecord {
                             id: rs.try_get("answer_id")?,
                             uuid: rs.try_get("user")?,
                             user_name: rs.try_get("name")?,
@@ -199,7 +202,7 @@ impl FormAnswerDatabase for ConnectionPool {
     async fn get_answers_by_form_id(
         &self,
         form_id: FormId,
-    ) -> Result<Vec<FormAnswerDto>, InfraError> {
+    ) -> Result<Vec<FormAnswerRecord>, InfraError> {
         self.read_only_transaction(|txn| {
             Box::pin(async move {
                 let answers = sqlx::query(
@@ -212,12 +215,12 @@ impl FormAnswerDatabase for ConnectionPool {
                 .fetch_all(&mut **txn)
                 .await?;
 
-                let form_answer_dtos = answers
+                let form_answer_records = answers
                     .into_iter()
                     .map(|rs| {
                         let answer_id = Uuid::from_str(&rs.try_get::<String, _>("answer_id")?)?;
 
-                        Ok::<_, InfraError>(FormAnswerDto {
+                        Ok::<_, InfraError>(FormAnswerRecord {
                             id: answer_id.to_string(),
                             uuid: rs.try_get("user")?,
                             user_name: rs.try_get("name")?,
@@ -229,16 +232,16 @@ impl FormAnswerDatabase for ConnectionPool {
                         })
                     }).collect::<Result<Vec<_>, _>>()?;
 
-                let answer_ids = form_answer_dtos.iter().map(|dto| dto.id.to_owned()).collect_vec();
+                let answer_ids = form_answer_records.iter().map(|record| record.id.to_owned()).collect_vec();
 
                 let contents = fetch_real_answers_by_answer_ids(txn, &answer_ids).await?;
-                attach_contents(form_answer_dtos, contents)
+                attach_contents(form_answer_records, contents)
             })
         }).await
     }
 
     #[tracing::instrument]
-    async fn get_all_answers(&self) -> Result<Vec<FormAnswerDto>, InfraError> {
+    async fn get_all_answers(&self) -> Result<Vec<FormAnswerRecord>, InfraError> {
         self.read_only_transaction(|txn| {
             Box::pin(async move {
                 let answers = sqlx::query(
@@ -249,12 +252,12 @@ impl FormAnswerDatabase for ConnectionPool {
                 .fetch_all(&mut **txn)
                 .await?;
 
-                let form_answer_dtos = answers
+                let form_answer_records = answers
                     .into_iter()
                     .map(|rs| {
                         let answer_id = Uuid::from_str(&rs.try_get::<String, _>("answer_id")?)?;
 
-                        Ok::<_, InfraError>(FormAnswerDto {
+                        Ok::<_, InfraError>(FormAnswerRecord {
                             id: answer_id.to_string(),
                             uuid: rs.try_get("user")?,
                             user_name: rs.try_get("name")?,
@@ -266,9 +269,9 @@ impl FormAnswerDatabase for ConnectionPool {
                         })
                     }).collect::<Result<Vec<_>, _>>()?;
 
-                let answer_ids = form_answer_dtos.iter().map(|dto| dto.id.to_owned()).collect_vec();
+                let answer_ids = form_answer_records.iter().map(|record| record.id.to_owned()).collect_vec();
                 let contents = fetch_real_answers_by_answer_ids(txn, &answer_ids).await?;
-                attach_contents(form_answer_dtos, contents)
+                attach_contents(form_answer_records, contents)
             })
         })
             .await
@@ -278,7 +281,7 @@ impl FormAnswerDatabase for ConnectionPool {
     async fn get_answers_by_answer_ids(
         &self,
         answer_ids: Vec<AnswerId>,
-    ) -> Result<Vec<FormAnswerDto>, InfraError> {
+    ) -> Result<Vec<FormAnswerRecord>, InfraError> {
         if answer_ids.is_empty() {
             return Ok(Vec::new());
         }
@@ -303,12 +306,12 @@ impl FormAnswerDatabase for ConnectionPool {
                     .fetch_all(&mut **txn)
                     .await?;
 
-                let form_answer_dtos = answers
+                let form_answer_records = answers
                     .into_iter()
                     .map(|rs| {
                         let answer_id = Uuid::from_str(&rs.try_get::<String, _>("answer_id")?)?;
 
-                        Ok::<_, InfraError>(FormAnswerDto {
+                        Ok::<_, InfraError>(FormAnswerRecord {
                             id: answer_id.to_string(),
                             uuid: rs.try_get("user")?,
                             user_name: rs.try_get("name")?,
@@ -320,10 +323,10 @@ impl FormAnswerDatabase for ConnectionPool {
                         })
                     }).collect::<Result<Vec<_>, _>>()?;
 
-                let answer_ids = form_answer_dtos.iter().map(|dto| dto.id.to_owned()).collect_vec();
+                let answer_ids = form_answer_records.iter().map(|record| record.id.to_owned()).collect_vec();
 
                 let contents = fetch_real_answers_by_answer_ids(txn, &answer_ids).await?;
-                attach_contents(form_answer_dtos, contents)
+                attach_contents(form_answer_records, contents)
             })
         }).await
     }

--- a/server/infra/resource/src/database/forms/comment.rs
+++ b/server/infra/resource/src/database/forms/comment.rs
@@ -1,6 +1,6 @@
 use crate::{
     database::{components::FormCommentDatabase, connection::ConnectionPool, count::count_as_u32},
-    dto::CommentDto,
+    records::CommentRecord,
 };
 use async_trait::async_trait;
 use domain::form::{
@@ -12,11 +12,14 @@ use errors::infra::InfraError;
 #[async_trait]
 impl FormCommentDatabase for ConnectionPool {
     #[tracing::instrument]
-    async fn get_comment(&self, comment_id: CommentId) -> Result<Option<CommentDto>, InfraError> {
+    async fn get_comment(
+        &self,
+        comment_id: CommentId,
+    ) -> Result<Option<CommentRecord>, InfraError> {
         self.read_only_transaction(|txn| {
             Box::pin(async move {
                 let comment = sqlx::query_as!(
-                    CommentDto,
+                    CommentRecord,
                     r"SELECT form_answer_comments.id AS comment_id, answer_id, commented_by AS commented_by_id, name AS commented_by_name, role AS commented_by_role, content, timestamp AS `timestamp!: chrono::DateTime<chrono::Utc>`
                     FROM form_answer_comments
                     INNER JOIN users ON form_answer_comments.commented_by = users.id
@@ -33,11 +36,11 @@ impl FormCommentDatabase for ConnectionPool {
     }
 
     #[tracing::instrument]
-    async fn get_comments(&self, answer_id: AnswerId) -> Result<Vec<CommentDto>, InfraError> {
+    async fn get_comments(&self, answer_id: AnswerId) -> Result<Vec<CommentRecord>, InfraError> {
         self.read_only_transaction(|txn| {
             Box::pin(async move {
                 let comments = sqlx::query_as!(
-                    CommentDto,
+                    CommentRecord,
                     r"SELECT form_answer_comments.id AS comment_id, answer_id, commented_by AS commented_by_id, name AS commented_by_name, role AS commented_by_role, content, timestamp AS `timestamp!: chrono::DateTime<chrono::Utc>`
                     FROM form_answer_comments
                     INNER JOIN users ON form_answer_comments.commented_by = users.id
@@ -54,11 +57,11 @@ impl FormCommentDatabase for ConnectionPool {
     }
 
     #[tracing::instrument]
-    async fn get_all_comments(&self) -> Result<Vec<CommentDto>, InfraError> {
+    async fn get_all_comments(&self) -> Result<Vec<CommentRecord>, InfraError> {
         self.read_only_transaction(|txn| {
             Box::pin(async move {
                 let comments = sqlx::query_as!(
-                    CommentDto,
+                    CommentRecord,
                     r"SELECT form_answer_comments.id AS comment_id, answer_id, commented_by AS commented_by_id, name AS commented_by_name, role AS commented_by_role, content, timestamp AS `timestamp!: chrono::DateTime<chrono::Utc>`
                     FROM form_answer_comments
                     INNER JOIN users ON form_answer_comments.commented_by = users.id"

--- a/server/infra/resource/src/database/forms/form.rs
+++ b/server/infra/resource/src/database/forms/form.rs
@@ -22,7 +22,7 @@ use crate::{
         connection::{ConnectionPool, DatabaseTransaction},
         count::count_as_u32,
     },
-    dto::{ActiveFormRecord, ArchivedFormRecord, ChoiceDto, QuestionDto},
+    records::{ActiveFormRecord, ArchivedFormRecord, ChoiceRecord, QuestionRecord},
 };
 
 struct FormRow {
@@ -52,7 +52,7 @@ async fn get_questions_txn_with_tables(
     form_id: FormId,
     questions_table: &str,
     choices_table: &str,
-) -> Result<Vec<QuestionDto>, InfraError> {
+) -> Result<Vec<QuestionRecord>, InfraError> {
     let form_id = form_id.into_inner().to_string();
     let questions_sql = format!(
         "SELECT question_id, form_id, template_key, position, title, description, question_type, is_required
@@ -82,7 +82,7 @@ async fn get_questions_txn_with_tables(
             let question_id = Uuid::parse_str(&choice_rs.try_get::<String, _>("question_id")?)?;
             Ok::<_, InfraError>((
                 question_id,
-                ChoiceDto {
+                ChoiceRecord {
                     id: Some(choice_rs.try_get("id")?),
                     position: choice_rs.try_get::<u16, _>("position")?,
                     label: choice_rs.try_get("label")?,
@@ -98,7 +98,7 @@ async fn get_questions_txn_with_tables(
         .map(|question_rs| {
             let question_id = Uuid::parse_str(&question_rs.try_get::<String, _>("question_id")?)?;
 
-            Ok::<_, InfraError>(QuestionDto {
+            Ok::<_, InfraError>(QuestionRecord {
                 id: question_id.to_string(),
                 form_id: question_rs.try_get("form_id")?,
                 template_key: question_rs.try_get("template_key")?,
@@ -115,7 +115,7 @@ async fn get_questions_txn_with_tables(
                     .unwrap_or(false),
             })
         })
-        .collect::<Result<Vec<QuestionDto>, _>>()
+        .collect::<Result<Vec<QuestionRecord>, _>>()
 }
 
 async fn active_form_record_from_row(

--- a/server/infra/resource/src/database/forms/form.rs
+++ b/server/infra/resource/src/database/forms/form.rs
@@ -22,10 +22,10 @@ use crate::{
         connection::{ConnectionPool, DatabaseTransaction},
         count::count_as_u32,
     },
-    dto::{ArchivedFormDto, ChoiceDto, FormDto, QuestionDto},
+    dto::{ActiveFormRecord, ArchivedFormRecord, ChoiceDto, QuestionDto},
 };
 
-struct FormRowDto {
+struct FormRow {
     id: String,
     title: String,
     description: String,
@@ -39,8 +39,8 @@ struct FormRowDto {
     answer_visibility: String,
 }
 
-struct ArchivedFormRowDto {
-    form: FormRowDto,
+struct ArchivedFormRow {
+    form: FormRow,
     archived_at: DateTime<Utc>,
     archived_by_name: String,
     archived_by_id: String,
@@ -118,10 +118,10 @@ async fn get_questions_txn_with_tables(
         .collect::<Result<Vec<QuestionDto>, _>>()
 }
 
-async fn active_form_dto_from_row(
+async fn active_form_record_from_row(
     txn: &mut DatabaseTransaction,
-    row: FormRowDto,
-) -> Result<FormDto, InfraError> {
+    row: FormRow,
+) -> Result<ActiveFormRecord, InfraError> {
     let form_id = FormId::from(Uuid::parse_str(&row.id)?);
     let form_id_string = form_id.into_inner().to_string();
     let label_ids = sqlx::query!(
@@ -134,7 +134,7 @@ async fn active_form_dto_from_row(
     .map(|row| Ok::<_, InfraError>(FormLabelId::from(Uuid::parse_str(&row.label_id)?)))
     .collect::<Result<Vec<_>, _>>()?;
 
-    Ok(FormDto {
+    Ok(ActiveFormRecord {
         id: row.id,
         title: row.title,
         description: row.description,
@@ -152,10 +152,10 @@ async fn active_form_dto_from_row(
     })
 }
 
-async fn archived_form_dto_from_row(
+async fn archived_form_record_from_row(
     txn: &mut DatabaseTransaction,
-    row: ArchivedFormRowDto,
-) -> Result<ArchivedFormDto, InfraError> {
+    row: ArchivedFormRow,
+) -> Result<ArchivedFormRecord, InfraError> {
     let form_id = FormId::from(Uuid::parse_str(&row.form.id)?);
     let form_id_string = form_id.into_inner().to_string();
     let label_ids = sqlx::query!(
@@ -168,8 +168,8 @@ async fn archived_form_dto_from_row(
     .map(|row| Ok::<_, InfraError>(FormLabelId::from(Uuid::parse_str(&row.label_id)?)))
     .collect::<Result<Vec<_>, _>>()?;
 
-    Ok(ArchivedFormDto {
-        form: FormDto {
+    Ok(ArchivedFormRecord {
+        form: ActiveFormRecord {
             id: row.form.id,
             title: row.form.title,
             description: row.form.description,
@@ -197,8 +197,8 @@ async fn archived_form_dto_from_row(
     })
 }
 
-fn form_row_from_db_row(row: sqlx::mysql::MySqlRow) -> Result<FormRowDto, InfraError> {
-    Ok(FormRowDto {
+fn form_row_from_db_row(row: sqlx::mysql::MySqlRow) -> Result<FormRow, InfraError> {
+    Ok(FormRow {
         id: row.try_get("id")?,
         title: row.try_get("title")?,
         description: row.try_get("description")?,
@@ -215,9 +215,9 @@ fn form_row_from_db_row(row: sqlx::mysql::MySqlRow) -> Result<FormRowDto, InfraE
 
 fn archived_form_row_from_db_row(
     row: sqlx::mysql::MySqlRow,
-) -> Result<ArchivedFormRowDto, InfraError> {
-    Ok(ArchivedFormRowDto {
-        form: FormRowDto {
+) -> Result<ArchivedFormRow, InfraError> {
+    Ok(ArchivedFormRow {
+        form: FormRow {
             id: row.try_get("id")?,
             title: row.try_get("title")?,
             description: row.try_get("description")?,
@@ -240,7 +240,7 @@ fn archived_form_row_from_db_row(
 async fn fetch_form_row(
     txn: &mut DatabaseTransaction,
     form_id: FormId,
-) -> Result<Option<FormRowDto>, InfraError> {
+) -> Result<Option<FormRow>, InfraError> {
     let row = sqlx::query(
         r"SELECT f.id, f.title, f.description, f.visibility, f.answer_visibility,
             f.created_at, f.updated_at, w.url AS webhook_url, p.start_at, p.end_at,
@@ -261,7 +261,7 @@ async fn fetch_form_row(
 async fn fetch_archived_form_row(
     txn: &mut DatabaseTransaction,
     form_id: FormId,
-) -> Result<Option<ArchivedFormRowDto>, InfraError> {
+) -> Result<Option<ArchivedFormRow>, InfraError> {
     let row = sqlx::query(
         r"SELECT f.id, f.title, f.description, f.visibility, f.answer_visibility,
             f.created_at, f.updated_at, w.url AS webhook_url, p.start_at, p.end_at,
@@ -682,7 +682,7 @@ impl FormDatabase for ConnectionPool {
         &self,
         offset: Option<u32>,
         limit: Option<u32>,
-    ) -> Result<Vec<FormDto>, InfraError> {
+    ) -> Result<Vec<ActiveFormRecord>, InfraError> {
         self.read_only_transaction(|txn| {
             Box::pin(async move {
                 let rows = sqlx::query(
@@ -703,7 +703,7 @@ impl FormDatabase for ConnectionPool {
 
                 let mut forms = Vec::with_capacity(rows.len());
                 for row in rows {
-                    forms.push(active_form_dto_from_row(txn, form_row_from_db_row(row)?).await?);
+                    forms.push(active_form_record_from_row(txn, form_row_from_db_row(row)?).await?);
                 }
                 Ok::<_, InfraError>(forms)
             })
@@ -712,11 +712,11 @@ impl FormDatabase for ConnectionPool {
     }
 
     #[tracing::instrument]
-    async fn get(&self, form_id: FormId) -> Result<Option<FormDto>, InfraError> {
+    async fn get(&self, form_id: FormId) -> Result<Option<ActiveFormRecord>, InfraError> {
         self.read_only_transaction(|txn| {
             Box::pin(async move {
                 match fetch_form_row(txn, form_id).await? {
-                    Some(row) => active_form_dto_from_row(txn, row).await.map(Some),
+                    Some(row) => active_form_record_from_row(txn, row).await.map(Some),
                     None => Ok(None),
                 }
             })
@@ -730,7 +730,7 @@ impl FormDatabase for ConnectionPool {
         offset: Option<u32>,
         limit: Option<u32>,
         query_text: Option<String>,
-    ) -> Result<Vec<ArchivedFormDto>, InfraError> {
+    ) -> Result<Vec<ArchivedFormRecord>, InfraError> {
         self.read_only_transaction(|txn| {
             Box::pin(async move {
                 let rows = if let Some(query_text) = query_text {
@@ -778,7 +778,7 @@ impl FormDatabase for ConnectionPool {
                 let mut forms = Vec::with_capacity(rows.len());
                 for row in rows {
                     forms.push(
-                        archived_form_dto_from_row(txn, archived_form_row_from_db_row(row)?)
+                        archived_form_record_from_row(txn, archived_form_row_from_db_row(row)?)
                             .await?,
                     );
                 }
@@ -789,11 +789,14 @@ impl FormDatabase for ConnectionPool {
     }
 
     #[tracing::instrument]
-    async fn get_archived(&self, form_id: FormId) -> Result<Option<ArchivedFormDto>, InfraError> {
+    async fn get_archived(
+        &self,
+        form_id: FormId,
+    ) -> Result<Option<ArchivedFormRecord>, InfraError> {
         self.read_only_transaction(|txn| {
             Box::pin(async move {
                 match fetch_archived_form_row(txn, form_id).await? {
-                    Some(row) => archived_form_dto_from_row(txn, row).await.map(Some),
+                    Some(row) => archived_form_record_from_row(txn, row).await.map(Some),
                     None => Ok(None),
                 }
             })
@@ -821,7 +824,7 @@ impl FormDatabase for ConnectionPool {
                         id: form_id.into_inner(),
                     })?;
 
-                archived_form_dto_from_row(txn, row)
+                archived_form_record_from_row(txn, row)
                     .await?
                     .try_into()
                     .map_err(|error: errors::Error| InfraError::Unexpected {

--- a/server/infra/resource/src/database/forms/form_label.rs
+++ b/server/infra/resource/src/database/forms/form_label.rs
@@ -6,7 +6,7 @@ use sqlx::{Row, query};
 
 use crate::{
     database::{components::FormLabelDatabase, connection::ConnectionPool, count::count_as_u32},
-    dto::FormLabelDto,
+    records::FormLabelRecord,
 };
 
 #[async_trait]
@@ -33,7 +33,7 @@ impl FormLabelDatabase for ConnectionPool {
     }
 
     #[tracing::instrument]
-    async fn fetch_labels(&self) -> Result<Vec<FormLabelDto>, InfraError> {
+    async fn fetch_labels(&self) -> Result<Vec<FormLabelRecord>, InfraError> {
         self.read_only_transaction(|txn| {
             Box::pin(async move {
                 let labels_rs = sqlx::query("SELECT id, name FROM label_for_forms")
@@ -43,12 +43,12 @@ impl FormLabelDatabase for ConnectionPool {
                 labels_rs
                     .into_iter()
                     .map(|rs| {
-                        Ok::<_, InfraError>(FormLabelDto {
+                        Ok::<_, InfraError>(FormLabelRecord {
                             id: rs.try_get("id")?,
                             name: rs.try_get("name")?,
                         })
                     })
-                    .collect::<Result<Vec<FormLabelDto>, _>>()
+                    .collect::<Result<Vec<FormLabelRecord>, _>>()
             })
         })
         .await
@@ -58,7 +58,7 @@ impl FormLabelDatabase for ConnectionPool {
     async fn fetch_labels_by_ids(
         &self,
         ids: Vec<FormLabelId>,
-    ) -> Result<Vec<FormLabelDto>, InfraError> {
+    ) -> Result<Vec<FormLabelRecord>, InfraError> {
         if ids.is_empty() {
             return Ok(Vec::new());
         }
@@ -83,12 +83,12 @@ impl FormLabelDatabase for ConnectionPool {
                 labels_rs
                     .into_iter()
                     .map(|rs| {
-                        Ok::<_, InfraError>(FormLabelDto {
+                        Ok::<_, InfraError>(FormLabelRecord {
                             id: rs.try_get("id")?,
                             name: rs.try_get("name")?,
                         })
                     })
-                    .collect::<Result<Vec<FormLabelDto>, _>>()
+                    .collect::<Result<Vec<FormLabelRecord>, _>>()
             })
         })
         .await
@@ -112,7 +112,7 @@ impl FormLabelDatabase for ConnectionPool {
     }
 
     #[tracing::instrument]
-    async fn fetch_label(&self, id: FormLabelId) -> Result<Option<FormLabelDto>, InfraError> {
+    async fn fetch_label(&self, id: FormLabelId) -> Result<Option<FormLabelRecord>, InfraError> {
         self.read_only_transaction(|txn| {
             Box::pin(async move {
                 let label_rs = sqlx::query("SELECT id, name FROM label_for_forms WHERE id = ?")
@@ -122,7 +122,7 @@ impl FormLabelDatabase for ConnectionPool {
 
                 label_rs
                     .map(|rs| {
-                        Ok::<_, InfraError>(FormLabelDto {
+                        Ok::<_, InfraError>(FormLabelRecord {
                             id: rs.try_get("id")?,
                             name: rs.try_get("name")?,
                         })
@@ -159,7 +159,7 @@ impl FormLabelDatabase for ConnectionPool {
     async fn fetch_labels_by_form_id(
         &self,
         form_id: FormId,
-    ) -> Result<Vec<FormLabelDto>, InfraError> {
+    ) -> Result<Vec<FormLabelRecord>, InfraError> {
         let form_id = form_id.into_inner().to_string();
         self.read_only_transaction(|txn| {
             Box::pin(async move {
@@ -178,12 +178,12 @@ impl FormLabelDatabase for ConnectionPool {
                 labels_rs
                     .into_iter()
                     .map(|rs| {
-                        Ok::<_, InfraError>(FormLabelDto {
+                        Ok::<_, InfraError>(FormLabelRecord {
                             id: rs.try_get("id")?,
                             name: rs.try_get("name")?,
                         })
                     })
-                    .collect::<Result<Vec<FormLabelDto>, _>>()
+                    .collect::<Result<Vec<FormLabelRecord>, _>>()
             })
         })
         .await

--- a/server/infra/resource/src/database/forms/message.rs
+++ b/server/infra/resource/src/database/forms/message.rs
@@ -7,7 +7,7 @@ use errors::infra::InfraError;
 
 use crate::{
     database::{components::FormMessageDatabase, connection::ConnectionPool},
-    dto::MessageDto,
+    records::MessageRecord,
 };
 
 #[async_trait]
@@ -64,13 +64,13 @@ impl FormMessageDatabase for ConnectionPool {
     async fn fetch_messages_by_form_answer(
         &self,
         answers: &AnswerEntry,
-    ) -> Result<Vec<MessageDto>, InfraError> {
+    ) -> Result<Vec<MessageRecord>, InfraError> {
         let answer_id = answers.id().into_inner().to_owned();
 
         self.read_only_transaction(|txn| {
             Box::pin(async move {
                 let rows = sqlx::query_as!(
-                    MessageDto,
+                    MessageRecord,
                     r"SELECT messages.id AS id, related_answer_id AS related_answer, sender AS sender_id, users.name AS sender_name, users.role AS sender_role, body, timestamp AS `timestamp!: chrono::DateTime<chrono::Utc>`
                     FROM messages
                     INNER JOIN users ON users.id = messages.sender
@@ -90,13 +90,13 @@ impl FormMessageDatabase for ConnectionPool {
     async fn fetch_message(
         &self,
         message_id: &MessageId,
-    ) -> Result<Option<MessageDto>, InfraError> {
+    ) -> Result<Option<MessageRecord>, InfraError> {
         let message_id = message_id.into_inner().to_string();
 
         self.read_only_transaction(|txn| {
             Box::pin(async move {
                 let row = sqlx::query_as!(
-                    MessageDto,
+                    MessageRecord,
                     r"SELECT messages.id AS id, related_answer_id AS related_answer, sender AS sender_id, users.name AS sender_name, users.role AS sender_role, body, timestamp AS `timestamp!: chrono::DateTime<chrono::Utc>`
                     FROM messages
                     INNER JOIN users ON users.id = messages.sender

--- a/server/infra/resource/src/database/notification.rs
+++ b/server/infra/resource/src/database/notification.rs
@@ -7,7 +7,7 @@ use uuid::Uuid;
 
 use crate::{
     database::{components::NotificationDatabase, connection::ConnectionPool},
-    dto::{NotificationSettingsDto, UserDto},
+    records::{NotificationSettingsRecord, UserRecord},
 };
 
 #[async_trait]
@@ -44,7 +44,7 @@ impl NotificationDatabase for ConnectionPool {
     async fn fetch_notification_settings(
         &self,
         recipient_id: Uuid,
-    ) -> Result<Option<NotificationSettingsDto>, InfraError> {
+    ) -> Result<Option<NotificationSettingsRecord>, InfraError> {
         self.read_only_transaction(|txn| {
             Box::pin(async move {
                 let rs = sqlx::query!(
@@ -59,8 +59,8 @@ impl NotificationDatabase for ConnectionPool {
                 .await?;
 
                 rs.map(|row| {
-                    Ok::<_, InfraError>(NotificationSettingsDto {
-                        recipient: UserDto {
+                    Ok::<_, InfraError>(NotificationSettingsRecord {
+                        recipient: UserRecord {
                             name: row.name,
                             id: recipient_id.to_string(),
                             role: Role::from_str(&row.role)?,

--- a/server/infra/resource/src/database/user.rs
+++ b/server/infra/resource/src/database/user.rs
@@ -16,7 +16,7 @@ use crate::{
         connection::{ConnectionPool, redis_connection},
         count::count_as_u32,
     },
-    dto::DiscordUserDto,
+    records::DiscordUserRecord,
 };
 
 #[async_trait]
@@ -236,7 +236,10 @@ impl UserDatabase for ConnectionPool {
         .await
     }
 
-    async fn fetch_discord_user(&self, user: &User) -> Result<Option<DiscordUserDto>, InfraError> {
+    async fn fetch_discord_user(
+        &self,
+        user: &User,
+    ) -> Result<Option<DiscordUserRecord>, InfraError> {
         let user_id = user.id.to_string();
 
         Ok(self
@@ -252,7 +255,7 @@ impl UserDatabase for ConnectionPool {
 
                     query
                         .map(|row| {
-                            Ok::<_, InfraError>(DiscordUserDto {
+                            Ok::<_, InfraError>(DiscordUserRecord {
                                 user_id: row.discord_id,
                                 username: row.discord_username,
                             })

--- a/server/infra/resource/src/dto.rs
+++ b/server/infra/resource/src/dto.rs
@@ -97,7 +97,7 @@ impl TryFrom<QuestionDto> for Question {
     }
 }
 
-pub struct ActiveFormDto {
+pub struct ActiveFormRecord {
     pub id: String,
     pub title: String,
     pub description: String,
@@ -113,13 +113,11 @@ pub struct ActiveFormDto {
     pub label_ids: Vec<FormLabelId>,
 }
 
-pub type FormDto = ActiveFormDto;
-
-impl TryFrom<ActiveFormDto> for ActiveForm {
+impl TryFrom<ActiveFormRecord> for ActiveForm {
     type Error = errors::Error;
 
     fn try_from(
-        ActiveFormDto {
+        ActiveFormRecord {
             id,
             title,
             description,
@@ -133,7 +131,7 @@ impl TryFrom<ActiveFormDto> for ActiveForm {
             answer_visibility,
             questions,
             label_ids,
-        }: ActiveFormDto,
+        }: ActiveFormRecord,
     ) -> Result<Self, Self::Error> {
         let questions = questions
             .into_iter()
@@ -163,18 +161,18 @@ impl TryFrom<ActiveFormDto> for ActiveForm {
     }
 }
 
-pub struct ArchivedFormDto {
-    pub form: ActiveFormDto,
+pub struct ArchivedFormRecord {
+    pub form: ActiveFormRecord,
     pub archived_at: DateTime<Utc>,
     pub archived_by_name: String,
     pub archived_by_id: String,
     pub archived_by_role: Role,
 }
 
-impl TryFrom<ArchivedFormDto> for ArchivedForm {
+impl TryFrom<ArchivedFormRecord> for ArchivedForm {
     type Error = errors::Error;
 
-    fn try_from(value: ArchivedFormDto) -> Result<Self, Self::Error> {
+    fn try_from(value: ArchivedFormRecord) -> Result<Self, Self::Error> {
         Ok(ArchivedForm::from_persisted(
             value.form.try_into()?,
             value.archived_at,

--- a/server/infra/resource/src/lib.rs
+++ b/server/infra/resource/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod database;
-pub mod dto;
 pub mod external;
 pub mod health_check;
 pub mod messaging;
 pub mod outgoing;
+pub mod records;
 pub mod repository;

--- a/server/infra/resource/src/records.rs
+++ b/server/infra/resource/src/records.rs
@@ -23,28 +23,28 @@ use types::non_empty_vec::NonEmptyVec;
 use uuid::Uuid;
 
 #[derive(Clone)]
-pub struct ChoiceDto {
+pub struct ChoiceRecord {
     pub id: Option<i32>,
     pub position: u16,
     pub label: String,
 }
 
-impl TryFrom<ChoiceDto> for Choice {
+impl TryFrom<ChoiceRecord> for Choice {
     type Error = errors::Error;
 
     fn try_from(
-        ChoiceDto {
+        ChoiceRecord {
             id,
             position,
             label,
-        }: ChoiceDto,
+        }: ChoiceRecord,
     ) -> Result<Self, Self::Error> {
         Choice::from_raw_parts(id.map(Into::into), position, label.try_into()?).map_err(Into::into)
     }
 }
 
 #[derive(Clone)]
-pub struct QuestionDto {
+pub struct QuestionRecord {
     pub id: String,
     pub form_id: String,
     pub template_key: String,
@@ -52,15 +52,15 @@ pub struct QuestionDto {
     pub title: String,
     pub description: Option<String>,
     pub question_type: String,
-    pub choices: Vec<ChoiceDto>,
+    pub choices: Vec<ChoiceRecord>,
     pub is_required: bool,
 }
 
-impl TryFrom<QuestionDto> for Question {
+impl TryFrom<QuestionRecord> for Question {
     type Error = errors::Error;
 
     fn try_from(
-        QuestionDto {
+        QuestionRecord {
             id,
             form_id: _,
             template_key,
@@ -70,7 +70,7 @@ impl TryFrom<QuestionDto> for Question {
             question_type,
             choices,
             is_required,
-        }: QuestionDto,
+        }: QuestionRecord,
     ) -> Result<Self, Self::Error> {
         let choices = choices
             .into_iter()
@@ -109,7 +109,7 @@ pub struct ActiveFormRecord {
     pub default_answer_title: Option<String>,
     pub visibility: String,
     pub answer_visibility: String,
-    pub questions: Vec<QuestionDto>,
+    pub questions: Vec<QuestionRecord>,
     pub label_ids: Vec<FormLabelId>,
 }
 
@@ -184,21 +184,21 @@ impl TryFrom<ArchivedFormRecord> for ArchivedForm {
 }
 
 #[derive(Clone)]
-pub struct FormAnswerContentDto {
+pub struct FormAnswerContentRecord {
     pub id: String,
     pub question_id: String,
     pub answer: String,
 }
 
-impl TryFrom<FormAnswerContentDto> for FormAnswerContent {
+impl TryFrom<FormAnswerContentRecord> for FormAnswerContent {
     type Error = InfraError;
 
     fn try_from(
-        FormAnswerContentDto {
+        FormAnswerContentRecord {
             id,
             question_id,
             answer,
-        }: FormAnswerContentDto,
+        }: FormAnswerContentRecord,
     ) -> Result<Self, Self::Error> {
         Ok(FormAnswerContent {
             id: Uuid::parse_str(&id)?.into(),
@@ -208,16 +208,16 @@ impl TryFrom<FormAnswerContentDto> for FormAnswerContent {
     }
 }
 
-pub struct UserDto {
+pub struct UserRecord {
     pub name: String,
     pub id: String,
     pub role: Role,
 }
 
-impl TryFrom<UserDto> for User {
+impl TryFrom<UserRecord> for User {
     type Error = errors::infra::InfraError;
 
-    fn try_from(UserDto { name, id, role }: UserDto) -> Result<Self, Self::Error> {
+    fn try_from(UserRecord { name, id, role }: UserRecord) -> Result<Self, Self::Error> {
         Ok(User {
             name,
             id: Uuid::from_str(&id)?.into(),
@@ -226,7 +226,7 @@ impl TryFrom<UserDto> for User {
     }
 }
 
-pub struct CommentDto {
+pub struct CommentRecord {
     pub answer_id: String,
     pub comment_id: String,
     pub content: String,
@@ -236,11 +236,11 @@ pub struct CommentDto {
     pub commented_by_role: String,
 }
 
-impl TryFrom<CommentDto> for domain::form::comment::models::Comment {
+impl TryFrom<CommentRecord> for domain::form::comment::models::Comment {
     type Error = errors::Error;
 
     fn try_from(
-        CommentDto {
+        CommentRecord {
             answer_id,
             comment_id,
             content,
@@ -248,7 +248,7 @@ impl TryFrom<CommentDto> for domain::form::comment::models::Comment {
             commented_by_name: _,
             commented_by_id,
             commented_by_role: _,
-        }: CommentDto,
+        }: CommentRecord,
     ) -> Result<Self, Self::Error> {
         Ok(domain::form::comment::models::Comment::from_raw_parts(
             Uuid::from_str(&answer_id)
@@ -271,8 +271,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn question_dto_rejects_text_question_with_choices() {
-        let result: Result<Question, _> = QuestionDto {
+    fn question_record_rejects_text_question_with_choices() {
+        let result: Result<Question, _> = QuestionRecord {
             id: Uuid::nil().to_string(),
             form_id: Uuid::nil().to_string(),
             template_key: "template".to_string(),
@@ -280,7 +280,7 @@ mod tests {
             title: "Question".to_string(),
             description: None,
             question_type: "Text".to_string(),
-            choices: vec![ChoiceDto {
+            choices: vec![ChoiceRecord {
                 id: Some(1),
                 position: 0,
                 label: "A".to_string(),
@@ -293,7 +293,7 @@ mod tests {
     }
 }
 
-pub struct FormAnswerDto {
+pub struct FormAnswerRecord {
     pub id: String,
     pub user_name: String,
     pub uuid: String,
@@ -301,14 +301,14 @@ pub struct FormAnswerDto {
     pub timestamp: DateTime<Utc>,
     pub form_id: String,
     pub title: Option<String>,
-    pub contents: Vec<FormAnswerContentDto>,
+    pub contents: Vec<FormAnswerContentRecord>,
 }
 
-impl TryFrom<FormAnswerDto> for AnswerEntry {
+impl TryFrom<FormAnswerRecord> for AnswerEntry {
     type Error = errors::Error;
 
     fn try_from(
-        FormAnswerDto {
+        FormAnswerRecord {
             id,
             user_name: _,
             uuid,
@@ -317,7 +317,7 @@ impl TryFrom<FormAnswerDto> for AnswerEntry {
             form_id,
             title,
             contents,
-        }: FormAnswerDto,
+        }: FormAnswerRecord,
     ) -> Result<Self, Self::Error> {
         unsafe {
             Ok(AnswerEntry::from_raw_parts(
@@ -339,15 +339,15 @@ impl TryFrom<FormAnswerDto> for AnswerEntry {
     }
 }
 
-pub struct AnswerLabelDto {
+pub struct AnswerLabelRecord {
     pub id: String,
     pub name: String,
 }
 
-impl TryFrom<AnswerLabelDto> for AnswerLabel {
+impl TryFrom<AnswerLabelRecord> for AnswerLabel {
     type Error = errors::Error;
 
-    fn try_from(AnswerLabelDto { id, name }: AnswerLabelDto) -> Result<Self, Self::Error> {
+    fn try_from(AnswerLabelRecord { id, name }: AnswerLabelRecord) -> Result<Self, Self::Error> {
         Ok(AnswerLabel::from_raw_parts(
             Uuid::from_str(&id)
                 .map_err(Into::<InfraError>::into)?
@@ -357,15 +357,15 @@ impl TryFrom<AnswerLabelDto> for AnswerLabel {
     }
 }
 
-pub struct FormLabelDto {
+pub struct FormLabelRecord {
     pub id: String,
     pub name: String,
 }
 
-impl TryFrom<FormLabelDto> for FormLabel {
+impl TryFrom<FormLabelRecord> for FormLabel {
     type Error = errors::Error;
 
-    fn try_from(FormLabelDto { id, name }: FormLabelDto) -> Result<Self, Self::Error> {
+    fn try_from(FormLabelRecord { id, name }: FormLabelRecord) -> Result<Self, Self::Error> {
         Ok(FormLabel::from_raw_parts(
             Uuid::from_str(&id)
                 .map_err(Into::<InfraError>::into)?
@@ -375,7 +375,7 @@ impl TryFrom<FormLabelDto> for FormLabel {
     }
 }
 
-pub struct MessageDto {
+pub struct MessageRecord {
     pub id: String,
     pub related_answer: String,
     pub sender_name: String,
@@ -385,11 +385,11 @@ pub struct MessageDto {
     pub timestamp: DateTime<Utc>,
 }
 
-impl TryFrom<MessageDto> for domain::form::message::models::Message {
+impl TryFrom<MessageRecord> for domain::form::message::models::Message {
     type Error = errors::Error;
 
     fn try_from(
-        MessageDto {
+        MessageRecord {
             id,
             related_answer,
             sender_name: _,
@@ -397,7 +397,7 @@ impl TryFrom<MessageDto> for domain::form::message::models::Message {
             sender_role: _,
             body,
             timestamp,
-        }: MessageDto,
+        }: MessageRecord,
     ) -> Result<Self, Self::Error> {
         unsafe {
             Ok(domain::form::message::models::Message::from_raw_parts(
@@ -417,19 +417,19 @@ impl TryFrom<MessageDto> for domain::form::message::models::Message {
     }
 }
 
-pub struct NotificationSettingsDto {
-    pub recipient: UserDto,
+pub struct NotificationSettingsRecord {
+    pub recipient: UserRecord,
     pub is_send_message_notification: bool,
 }
 
-impl TryFrom<NotificationSettingsDto> for domain::notification::models::NotificationPreference {
+impl TryFrom<NotificationSettingsRecord> for domain::notification::models::NotificationPreference {
     type Error = errors::Error;
 
     fn try_from(
-        NotificationSettingsDto {
+        NotificationSettingsRecord {
             recipient,
             is_send_message_notification,
-        }: NotificationSettingsDto,
+        }: NotificationSettingsRecord,
     ) -> Result<Self, Self::Error> {
         Ok(
             domain::notification::models::NotificationPreference::from_raw_parts(
@@ -442,13 +442,13 @@ impl TryFrom<NotificationSettingsDto> for domain::notification::models::Notifica
     }
 }
 
-pub struct DiscordUserDto {
+pub struct DiscordUserRecord {
     pub user_id: String,
     pub username: String,
 }
 
-impl From<DiscordUserDto> for domain::user::models::DiscordUser {
-    fn from(DiscordUserDto { user_id, username }: DiscordUserDto) -> Self {
+impl From<DiscordUserRecord> for domain::user::models::DiscordUser {
+    fn from(DiscordUserRecord { user_id, username }: DiscordUserRecord) -> Self {
         domain::user::models::DiscordUser::new(
             domain::user::models::DiscordUserId::new(user_id),
             domain::user::models::DiscordUserName::new(username),

--- a/server/infra/resource/src/repository/form_repository_impls/answer_repository_impl.rs
+++ b/server/infra/resource/src/repository/form_repository_impls/answer_repository_impl.rs
@@ -74,7 +74,7 @@ impl<Client: DatabaseComponents + 'static> AnswerRepository for Repository<Clien
             .map(|answers| {
                 answers
                     .into_iter()
-                    .map(|posted_answers_dto| posted_answers_dto.try_into())
+                    .map(|posted_answers_record| posted_answers_record.try_into())
                     .collect::<Result<Vec<AnswerEntry>, _>>()
             })??
             .into_iter()

--- a/server/infra/resource/src/repository/form_repository_impls/message_repository_impl.rs
+++ b/server/infra/resource/src/repository/form_repository_impls/message_repository_impl.rs
@@ -49,8 +49,8 @@ impl<Client: DatabaseComponents + 'static> MessageRepository for Repository<Clie
             .fetch_messages_by_form_answer(answers)
             .await?
             .into_iter()
-            .map(|dto| {
-                Ok::<Message, Error>(dto.try_into()?).map(|message| {
+            .map(|record| {
+                Ok::<Message, Error>(record.try_into()?).map(|message| {
                     let guard = AuthorizationGuardWithContext::new(message);
 
                     guard.into_read()
@@ -95,8 +95,8 @@ impl<Client: DatabaseComponents + 'static> MessageRepository for Repository<Clie
             .form_message()
             .fetch_message(message_id)
             .await?
-            .map(|dto| {
-                Ok::<Message, Error>(dto.try_into()?).map(|message| {
+            .map(|record| {
+                Ok::<Message, Error>(record.try_into()?).map(|message| {
                     let guard = AuthorizationGuardWithContext::new(message);
 
                     guard.into_read()

--- a/server/presentation/src/handlers/form/answer_handler.rs
+++ b/server/presentation/src/handlers/form/answer_handler.rs
@@ -117,12 +117,12 @@ pub async fn get_all_answers(
     Ok(GetAllAnswersResponse::Ok(
         answers
             .into_iter()
-            .map(|answer_dto| {
+            .map(|answer_details| {
                 FormAnswer::new(
-                    answer_dto.form_answer,
-                    answer_dto.user,
-                    answer_dto.comments,
-                    answer_dto.labels,
+                    answer_details.form_answer,
+                    answer_details.user,
+                    answer_details.comments,
+                    answer_details.labels,
                 )
             })
             .collect_vec(),
@@ -164,16 +164,16 @@ pub async fn get_answer_handler(
 
     let Path((form_id, answer_id)) = path.map_err_to_error().map_err(handle_error)?;
 
-    let answer_dto = form_answer_use_case
+    let answer_details = form_answer_use_case
         .get_answers(form_id, answer_id, &user)
         .await
         .map_err(handle_error)?;
 
     Ok(GetAnswerResponse::Ok(FormAnswer::new(
-        answer_dto.form_answer,
-        answer_dto.user,
-        answer_dto.comments,
-        answer_dto.labels,
+        answer_details.form_answer,
+        answer_details.user,
+        answer_details.comments,
+        answer_details.labels,
     )))
 }
 
@@ -219,12 +219,12 @@ pub async fn get_answer_by_form_id_handler(
     Ok(GetAnswersByFormResponse::Ok(
         answers
             .into_iter()
-            .map(|answer_dto| {
+            .map(|answer_details| {
                 FormAnswer::new(
-                    answer_dto.form_answer,
-                    answer_dto.user,
-                    answer_dto.comments,
-                    answer_dto.labels,
+                    answer_details.form_answer,
+                    answer_details.user,
+                    answer_details.comments,
+                    answer_details.labels,
                 )
             })
             .collect_vec(),
@@ -324,15 +324,15 @@ pub async fn update_answer_handler(
     let Path((form_id, answer_id)) = path.map_err_to_error().map_err(handle_error)?;
     let Json(schema) = json.map_err_to_error().map_err(handle_error)?;
 
-    let answer_dto = form_answer_use_case
+    let answer_details = form_answer_use_case
         .update_answer_meta(form_id, answer_id, &user, schema.title)
         .await
         .map_err(handle_error)?;
 
     Ok(UpdateAnswerResponse::Ok(FormAnswer::new(
-        answer_dto.form_answer,
-        answer_dto.user,
-        answer_dto.comments,
-        answer_dto.labels,
+        answer_details.form_answer,
+        answer_details.user,
+        answer_details.comments,
+        answer_details.labels,
     )))
 }

--- a/server/presentation/src/handlers/form/form_handler.rs
+++ b/server/presentation/src/handlers/form/form_handler.rs
@@ -15,8 +15,8 @@ use itertools::Itertools;
 use resource::repository::RealInfrastructureRepository;
 use serde_json::json;
 use usecase::{
-    dto::{ActiveFormDto, ArchivedFormDto, UpsertQuestionDto},
     forms::form::FormUseCase,
+    models::{ActiveFormWithLabels, ArchivedFormDetails, UpsertQuestionInput},
 };
 
 use crate::handlers::error_handler::handle_error;
@@ -310,7 +310,7 @@ pub async fn get_form_handler(
 
     let Path(form_id) = path.map_err_to_error().map_err(handle_error)?;
 
-    let ActiveFormDto { form, labels } = form_use_case
+    let ActiveFormWithLabels { form, labels } = form_use_case
         .get_form(&user, form_id)
         .await
         .map_err(handle_error)?;
@@ -432,7 +432,7 @@ pub async fn update_form_handler(
         };
     let questions = targets
         .questions
-        .map(into_upsert_question_dtos)
+        .map(into_upsert_question_inputs)
         .transpose()
         .map_err(handle_error)?;
     let labels = targets.labels;
@@ -518,8 +518,13 @@ pub async fn archived_form_list_handler(
     Ok(ArchivedFormListResponse::Ok(
         forms
             .into_iter()
-            .map(|dto| {
-                archived_form_schema_from_parts(&user, dto.form, dto.archived_by, dto.labels)
+            .map(|details| {
+                archived_form_schema_from_parts(
+                    &user,
+                    details.form,
+                    details.archived_by,
+                    details.labels,
+                )
             })
             .collect(),
     ))
@@ -551,7 +556,7 @@ pub async fn get_archived_form_handler(
     let form_use_case = build_form_use_case(&repository);
     let Path(form_id) = path.map_err_to_error().map_err(handle_error)?;
 
-    let ArchivedFormDto {
+    let ArchivedFormDetails {
         form,
         archived_by,
         labels,
@@ -602,12 +607,12 @@ pub async fn restore_archived_form_handler(
     Ok(StatusCode::NO_CONTENT.into_response())
 }
 
-fn into_upsert_question_dtos(
+fn into_upsert_question_inputs(
     questions: Vec<QuestionSchema>,
-) -> Result<Vec<UpsertQuestionDto>, errors::Error> {
+) -> Result<Vec<UpsertQuestionInput>, errors::Error> {
     let questions = questions
         .into_iter()
-        .map(into_upsert_question_dto)
+        .map(into_upsert_question_input)
         .collect::<Result<Vec<_>, _>>()?;
 
     if questions.is_empty() {
@@ -677,9 +682,9 @@ fn into_create_question(
     }
 }
 
-fn into_upsert_question_dto(
+fn into_upsert_question_input(
     question: QuestionSchema,
-) -> Result<UpsertQuestionDto, errors::domain::DomainError> {
+) -> Result<UpsertQuestionInput, errors::domain::DomainError> {
     let (question_type, definition, choices) = question.into_parts();
     let original_id = definition.id;
     let choices = into_domain_choices(choices);
@@ -727,7 +732,7 @@ fn into_upsert_question_dto(
         },
     };
 
-    Ok(UpsertQuestionDto {
+    Ok(UpsertQuestionInput {
         original_id,
         question,
     })
@@ -782,7 +787,7 @@ mod tests {
         }))
         .unwrap();
 
-        let result = into_upsert_question_dto(question);
+        let result = into_upsert_question_input(question);
 
         assert!(matches!(
             result,
@@ -864,7 +869,7 @@ mod tests {
         ]))
         .unwrap();
 
-        let result = into_upsert_question_dtos(questions);
+        let result = into_upsert_question_inputs(questions);
 
         assert!(matches!(
             result,

--- a/server/presentation/src/handlers/form/message_handler.rs
+++ b/server/presentation/src/handlers/form/message_handler.rs
@@ -199,15 +199,15 @@ pub async fn get_messages_handler(
     Ok(GetMessagesResponse::Ok(
         messages
             .into_iter()
-            .map(|message_dto| MessageContentSchema {
-                id: message_dto.message.id().into_inner(),
-                body: message_dto.message.body().to_owned(),
+            .map(|message_with_sender| MessageContentSchema {
+                id: message_with_sender.message.id().into_inner(),
+                body: message_with_sender.message.body().to_owned(),
                 sender: SenderSchema {
-                    uuid: message_dto.sender.id.to_string(),
-                    name: message_dto.sender.name,
-                    role: message_dto.sender.role.to_string(),
+                    uuid: message_with_sender.sender.id.to_string(),
+                    name: message_with_sender.sender.name,
+                    role: message_with_sender.sender.role.to_string(),
                 },
-                timestamp: message_dto.message.timestamp().to_owned(),
+                timestamp: message_with_sender.message.timestamp().to_owned(),
             })
             .collect_vec(),
     ))

--- a/server/presentation/src/handlers/user_handler.rs
+++ b/server/presentation/src/handlers/user_handler.rs
@@ -90,20 +90,20 @@ pub async fn get_my_user_info(
         repository: repository.user_repository(),
     };
 
-    let user_dto = user_use_case
+    let user_profile = user_use_case
         .fetch_user_information(&user, user.id.into_inner())
         .await
         .map_err(handle_error)?;
-    let discord_user_id_with_name = user_dto.discord_user.map(|user| {
+    let discord_user_id_with_name = user_profile.discord_user.map(|user| {
         (
             user.id().to_owned().into_inner(),
             user.name().to_owned().into_inner(),
         )
     });
     Ok(GetUserInfoResponse::Ok(UserInfoResponse {
-        id: user_dto.user.id.to_string(),
-        name: user_dto.user.name,
-        role: user_dto.user.role.to_string(),
+        id: user_profile.user.id.to_string(),
+        name: user_profile.user.name,
+        role: user_profile.user.role.to_string(),
         discord_user_id: discord_user_id_with_name.to_owned().map(|(id, _)| id),
         discord_username: discord_user_id_with_name.map(|(_, name)| name),
     }))
@@ -138,20 +138,20 @@ pub async fn get_user_info(
 
     let Path(uuid) = path.map_err_to_error().map_err(handle_error)?;
 
-    let user_dto = user_use_case
+    let user_profile = user_use_case
         .fetch_user_information(&actor, uuid)
         .await
         .map_err(handle_error)?;
-    let discord_user_id_with_name = user_dto.discord_user.map(|user| {
+    let discord_user_id_with_name = user_profile.discord_user.map(|user| {
         (
             user.id().to_owned().into_inner(),
             user.name().to_owned().into_inner(),
         )
     });
     Ok(GetUserInfoResponse::Ok(UserInfoResponse {
-        id: user_dto.user.id.to_string(),
-        name: user_dto.user.name,
-        role: user_dto.user.role.to_string(),
+        id: user_profile.user.id.to_string(),
+        name: user_profile.user.name,
+        role: user_profile.user.role.to_string(),
         discord_user_id: discord_user_id_with_name.to_owned().map(|(id, _)| id),
         discord_username: discord_user_id_with_name.map(|(_, name)| name),
     }))

--- a/server/presentation/src/schemas/form/form_response_schemas.rs
+++ b/server/presentation/src/schemas/form/form_response_schemas.rs
@@ -313,8 +313,8 @@ pub struct AnswerComment {
     commented_by: User,
 }
 
-impl From<usecase::dto::CommentDto> for AnswerComment {
-    fn from(val: usecase::dto::CommentDto) -> Self {
+impl From<usecase::models::CommentWithAuthor> for AnswerComment {
+    fn from(val: usecase::models::CommentWithAuthor) -> Self {
         AnswerComment {
             content: val.comment.content().to_string(),
             timestamp: val.comment.timestamp().to_owned(),
@@ -354,7 +354,7 @@ impl FormAnswer {
     pub fn new(
         answer: domain::form::answer::models::AnswerEntry,
         user: domain::user::models::User,
-        comments: Vec<usecase::dto::CommentDto>,
+        comments: Vec<usecase::models::CommentWithAuthor>,
         labels: Vec<domain::form::answer::models::AnswerLabel>,
     ) -> Self {
         FormAnswer {

--- a/server/presentation/src/schemas/search_schemas.rs
+++ b/server/presentation/src/schemas/search_schemas.rs
@@ -10,7 +10,7 @@ use domain::{
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use types::non_empty_string::NonEmptyString;
-use usecase::dto::CrossSearchDto;
+use usecase::models::CrossSearchOutput;
 use uuid::Uuid;
 
 #[derive(Deserialize, Debug, PartialEq, utoipa::ToSchema)]
@@ -55,15 +55,15 @@ pub struct CrossSearchResult {
     pub comments: Vec<CommentSchema>,
 }
 
-impl From<CrossSearchDto> for CrossSearchResult {
-    fn from(dto: CrossSearchDto) -> Self {
+impl From<CrossSearchOutput> for CrossSearchResult {
+    fn from(output: CrossSearchOutput) -> Self {
         Self {
-            forms: dto.forms,
-            users: dto.users,
-            answers: dto.answers,
-            label_for_forms: dto.label_for_forms,
-            label_for_answers: dto.label_for_answers,
-            comments: dto.comments.into_iter().map(Into::into).collect_vec(),
+            forms: output.forms,
+            users: output.users,
+            answers: output.answers,
+            label_for_forms: output.label_for_forms,
+            label_for_answers: output.label_for_answers,
+            comments: output.comments.into_iter().map(Into::into).collect_vec(),
         }
     }
 }

--- a/server/usecase/src/forms/answer.rs
+++ b/server/usecase/src/forms/answer.rs
@@ -24,7 +24,7 @@ use errors::{
 use futures::{StreamExt, stream, try_join};
 
 use crate::{
-    dto::{AnswerDto, CommentDto},
+    models::{AnswerDetails, CommentWithAuthor},
     user_reference_resolver::resolve_user_references,
 };
 
@@ -51,13 +51,13 @@ impl<
     R5: UserRepository,
 > AnswerUseCase<'_, R1, R2, R3, R4, R5>
 {
-    async fn build_answer_dto(
+    async fn build_answer_details(
         &self,
         actor: &User,
         form_answer: AnswerEntry,
         labels: Vec<domain::form::answer::models::AnswerLabel>,
         comments: Vec<domain::form::comment::models::Comment>,
-    ) -> Result<AnswerDto, Error> {
+    ) -> Result<AnswerDetails, Error> {
         let user_ids = std::iter::once(*form_answer.user_id())
             .chain(comments.iter().map(|comment| *comment.commented_by()))
             .collect();
@@ -76,14 +76,14 @@ impl<
                     .get(comment.commented_by())
                     .cloned()
                     .ok_or(Error::from(UserNotFound))?;
-                Ok::<_, Error>(CommentDto {
+                Ok::<_, Error>(CommentWithAuthor {
                     comment,
                     commented_by,
                 })
             })
             .collect::<Result<Vec<_>, _>>()?;
 
-        Ok(AnswerDto {
+        Ok(AnswerDetails {
             form_answer,
             user,
             labels,
@@ -135,7 +135,7 @@ impl<
         form_id: FormId,
         answer_id: AnswerId,
         user: &User,
-    ) -> Result<AnswerDto, Error> {
+    ) -> Result<AnswerDetails, Error> {
         if let Some(form_answer_guard) = self.answer_repository.get_answer(answer_id).await? {
             let form_guard = self
                 .active_form_repository
@@ -181,7 +181,7 @@ impl<
                 .map(|label| label.try_into_read(user))
                 .collect::<Result<Vec<_>, _>>()?;
 
-            self.build_answer_dto(user, form_answer, labels, comments)
+            self.build_answer_details(user, form_answer, labels, comments)
                 .await
         } else {
             Err(Error::from(AnswerNotFound))
@@ -192,7 +192,7 @@ impl<
         &self,
         form_id: FormId,
         actor: &User,
-    ) -> Result<Vec<AnswerDto>, Error> {
+    ) -> Result<Vec<AnswerDetails>, Error> {
         let form = self
             .active_form_repository
             .get(form_id)
@@ -248,16 +248,16 @@ impl<
                 .map(|label| label.try_into_read(actor))
                 .collect::<Result<Vec<_>, _>>()?;
 
-            self.build_answer_dto(actor, form_answer, labels, comments)
+            self.build_answer_details(actor, form_answer, labels, comments)
                 .await
         })
-        .collect::<Vec<Result<AnswerDto, Error>>>()
+        .collect::<Vec<Result<AnswerDetails, Error>>>()
         .await
         .into_iter()
         .collect::<Result<Vec<_>, _>>()
     }
 
-    pub async fn get_all_answers(&self, user: &User) -> Result<Vec<AnswerDto>, Error> {
+    pub async fn get_all_answers(&self, user: &User) -> Result<Vec<AnswerDetails>, Error> {
         stream::iter(self.answer_repository.get_all_answers().await?)
             .then(|form_answer_guard| async move {
                 let context = form_answer_guard
@@ -319,10 +319,10 @@ impl<
                     .map(|label| label.try_into_read(user))
                     .collect::<Result<Vec<_>, _>>()?;
 
-                self.build_answer_dto(user, form_answer, labels, comments)
+                self.build_answer_details(user, form_answer, labels, comments)
                     .await
             })
-            .collect::<Vec<Result<AnswerDto, Error>>>()
+            .collect::<Vec<Result<AnswerDetails, Error>>>()
             .await
             .into_iter()
             .collect::<Result<Vec<_>, _>>()
@@ -334,7 +334,7 @@ impl<
         answer_id: AnswerId,
         actor: &User,
         title: Option<AnswerTitle>,
-    ) -> Result<AnswerDto, Error> {
+    ) -> Result<AnswerDetails, Error> {
         let form_guard = self
             .active_form_repository
             .get(form_id)
@@ -399,7 +399,7 @@ impl<
                 &comment_authorization_context.related_answer_entry_guard_context,
             )?;
 
-        self.build_answer_dto(actor, form_answer, labels, comments)
+        self.build_answer_details(actor, form_answer, labels, comments)
             .await
     }
 }

--- a/server/usecase/src/forms/comment.rs
+++ b/server/usecase/src/forms/comment.rs
@@ -21,7 +21,7 @@ use errors::{
     usecase::UseCaseError::{AnswerNotFound, CommentNotFound, FormNotFound, UserNotFound},
 };
 
-use crate::{dto::CommentDto, user_reference_resolver::resolve_user_references};
+use crate::{models::CommentWithAuthor, user_reference_resolver::resolve_user_references};
 
 pub struct CommentUseCase<
     'a,
@@ -39,11 +39,11 @@ pub struct CommentUseCase<
 impl<R1: CommentRepository, R2: AnswerRepository, R3: ActiveFormRepository, R4: UserRepository>
     CommentUseCase<'_, R1, R2, R3, R4>
 {
-    async fn build_comment_dtos(
+    async fn build_comments_with_authors(
         &self,
         actor: &User,
         comments: Vec<Comment>,
-    ) -> Result<Vec<CommentDto>, Error> {
+    ) -> Result<Vec<CommentWithAuthor>, Error> {
         let user_ids = comments.iter().map(|c| *c.commented_by()).collect();
         let users = resolve_user_references(self.user_repository, actor, user_ids).await?;
 
@@ -54,7 +54,7 @@ impl<R1: CommentRepository, R2: AnswerRepository, R3: ActiveFormRepository, R4: 
                     .get(comment.commented_by())
                     .cloned()
                     .ok_or(Error::from(UserNotFound))?;
-                Ok(CommentDto {
+                Ok(CommentWithAuthor {
                     comment,
                     commented_by,
                 })
@@ -67,7 +67,7 @@ impl<R1: CommentRepository, R2: AnswerRepository, R3: ActiveFormRepository, R4: 
         actor: &User,
         form_id: FormId,
         answer_id: AnswerId,
-    ) -> Result<Vec<CommentDto>, Error> {
+    ) -> Result<Vec<CommentWithAuthor>, Error> {
         let answer_guard = self
             .answer_repository
             .get_answer(answer_id)
@@ -102,7 +102,7 @@ impl<R1: CommentRepository, R2: AnswerRepository, R3: ActiveFormRepository, R4: 
             .collect::<Result<Vec<_>, _>>()
             .map_err(Error::from)?;
 
-        self.build_comment_dtos(actor, comments).await
+        self.build_comments_with_authors(actor, comments).await
     }
 
     pub async fn post_comment(

--- a/server/usecase/src/forms/form.rs
+++ b/server/usecase/src/forms/form.rs
@@ -26,7 +26,7 @@ use errors::{
 use std::collections::{BTreeSet, HashMap};
 use types::non_empty_vec::NonEmptyVec;
 
-use crate::dto::{ActiveFormDto, ArchivedFormDto, UpsertQuestionDto};
+use crate::models::{ActiveFormWithLabels, ArchivedFormDetails, UpsertQuestionInput};
 
 pub struct FormUseCase<
     'a,
@@ -117,7 +117,11 @@ impl<
         Ok(forms_with_labels)
     }
 
-    pub async fn get_form(&self, actor: &User, form_id: FormId) -> Result<ActiveFormDto, Error> {
+    pub async fn get_form(
+        &self,
+        actor: &User,
+        form_id: FormId,
+    ) -> Result<ActiveFormWithLabels, Error> {
         let form = self
             .active_form_repository
             .get(form_id)
@@ -132,7 +136,7 @@ impl<
             .map(|label| label.try_into_read(actor))
             .collect::<Result<Vec<_>, _>>()?;
 
-        Ok(ActiveFormDto { form, labels })
+        Ok(ActiveFormWithLabels { form, labels })
     }
 
     pub async fn archived_form_list(
@@ -141,7 +145,7 @@ impl<
         offset: Option<u32>,
         limit: Option<u32>,
         query: Option<String>,
-    ) -> Result<Vec<ArchivedFormDto>, Error> {
+    ) -> Result<Vec<ArchivedFormDetails>, Error> {
         let forms = self
             .archived_form_repository
             .list(offset, limit, query)
@@ -166,7 +170,7 @@ impl<
                     .await?
                     .ok_or(Error::from(UserNotFound))?
                     .try_into_read(actor)?;
-                Ok::<_, Error>(ArchivedFormDto {
+                Ok::<_, Error>(ArchivedFormDetails {
                     archived_by,
                     form,
                     labels: labels
@@ -184,7 +188,7 @@ impl<
         &self,
         actor: &User,
         form_id: FormId,
-    ) -> Result<ArchivedFormDto, Error> {
+    ) -> Result<ArchivedFormDetails, Error> {
         let form = self
             .archived_form_repository
             .get(form_id)
@@ -206,7 +210,7 @@ impl<
             .ok_or(Error::from(UserNotFound))?
             .try_into_read(actor)?;
 
-        Ok(ArchivedFormDto {
+        Ok(ArchivedFormDetails {
             form,
             archived_by,
             labels,
@@ -251,7 +255,7 @@ impl<
         default_answer_title: Option<DefaultAnswerTitle>,
         visibility: Option<Visibility>,
         answer_visibility: Option<AnswerVisibility>,
-        questions: Option<Vec<UpsertQuestionDto>>,
+        questions: Option<Vec<UpsertQuestionInput>>,
         label_ids: Option<Vec<FormLabelId>>,
     ) -> Result<(ActiveForm, Vec<FormLabel>), Error> {
         let current_form = self
@@ -399,7 +403,7 @@ impl<
 
 fn validate_answered_form_question_update(
     current_questions: &[Question],
-    updated_questions: &[UpsertQuestionDto],
+    updated_questions: &[UpsertQuestionInput],
 ) -> Result<(), Error> {
     let current_by_id = current_questions
         .iter()

--- a/server/usecase/src/forms/message.rs
+++ b/server/usecase/src/forms/message.rs
@@ -32,7 +32,7 @@ use errors::{
     usecase::UseCaseError::{AnswerNotFound, FormNotFound, MessageNotFound, UserNotFound},
 };
 
-use crate::{dto::MessageDto, user_reference_resolver::resolve_user_references};
+use crate::{models::MessageWithSender, user_reference_resolver::resolve_user_references};
 
 pub struct MessageUseCase<
     'a,
@@ -176,7 +176,7 @@ impl<
         actor: &User,
         form_id: FormId,
         answer_id: AnswerId,
-    ) -> Result<Vec<MessageDto>, Error> {
+    ) -> Result<Vec<MessageWithSender>, Error> {
         let form_guard = self
             .active_form_repository
             .get(form_id)
@@ -221,7 +221,7 @@ impl<
                     .get(message.sender_id())
                     .cloned()
                     .ok_or(Error::from(UserNotFound))?;
-                Ok(MessageDto { message, sender })
+                Ok(MessageWithSender { message, sender })
             })
             .collect()
     }

--- a/server/usecase/src/lib.rs
+++ b/server/usecase/src/lib.rs
@@ -1,6 +1,6 @@
-pub mod dto;
 pub mod forms;
 pub mod health_check;
+pub mod models;
 pub mod notification;
 pub mod search;
 pub mod user;

--- a/server/usecase/src/models.rs
+++ b/server/usecase/src/models.rs
@@ -8,47 +8,45 @@ use domain::{
     user::models::{DiscordUser, User},
 };
 
-pub struct AnswerDto {
+pub struct AnswerDetails {
     pub form_answer: AnswerEntry,
     pub user: User,
     pub labels: Vec<AnswerLabel>,
-    pub comments: Vec<CommentDto>,
+    pub comments: Vec<CommentWithAuthor>,
 }
 
-pub struct ActiveFormDto {
+pub struct ActiveFormWithLabels {
     pub form: ActiveForm,
     pub labels: Vec<FormLabel>,
 }
 
-pub type FormDto = ActiveFormDto;
-
-pub struct ArchivedFormDto {
+pub struct ArchivedFormDetails {
     pub form: ArchivedForm,
     pub archived_by: User,
     pub labels: Vec<FormLabel>,
 }
 
-pub struct CommentDto {
+pub struct CommentWithAuthor {
     pub comment: Comment,
     pub commented_by: User,
 }
 
-pub struct MessageDto {
+pub struct MessageWithSender {
     pub message: domain::form::message::models::Message,
     pub sender: User,
 }
 
-pub struct UpsertQuestionDto {
+pub struct UpsertQuestionInput {
     pub original_id: Option<QuestionId>,
     pub question: Question,
 }
 
-pub struct UserDto {
+pub struct UserProfile {
     pub user: User,
     pub discord_user: Option<DiscordUser>,
 }
 
-pub struct CrossSearchDto {
+pub struct CrossSearchOutput {
     pub forms: Vec<ActiveForm>,
     pub users: Vec<User>,
     pub answers: Vec<AnswerEntry>,

--- a/server/usecase/src/search.rs
+++ b/server/usecase/src/search.rs
@@ -1,4 +1,4 @@
-use crate::dto::CrossSearchDto;
+use crate::models::CrossSearchOutput;
 use domain::repository::form::answer_label_repository::AnswerLabelRepository;
 use domain::repository::form::comment_repository::CommentRepository;
 use domain::repository::form::form_label_repository::FormLabelRepository;
@@ -56,7 +56,11 @@ impl<
     R7: UserRepository,
 > SearchUseCase<'_, R1, R2, R3, R4, R5, R6, R7>
 {
-    pub async fn cross_search(&self, actor: &User, query: String) -> Result<CrossSearchDto, Error> {
+    pub async fn cross_search(
+        &self,
+        actor: &User,
+        query: String,
+    ) -> Result<CrossSearchOutput, Error> {
         let (forms, users, label_for_forms, label_for_answers, answers, comments) = try_join!(
             self.search_repository.search_forms(&query),
             self.search_repository.search_users(&query),
@@ -185,7 +189,7 @@ impl<
 
         let comments = try_join_all(comment_futs).await?;
 
-        Ok(CrossSearchDto {
+        Ok(CrossSearchOutput {
             forms,
             users,
             label_for_forms,

--- a/server/usecase/src/user.rs
+++ b/server/usecase/src/user.rs
@@ -5,7 +5,7 @@ use domain::{
 use errors::{Error, usecase::UseCaseError};
 use uuid::Uuid;
 
-use crate::dto::UserDto;
+use crate::models::UserProfile;
 
 pub struct UserUseCase<'a, UserRepo: UserRepository> {
     pub repository: &'a UserRepo,
@@ -136,7 +136,7 @@ impl<R: UserRepository> UserUseCase<'_, R> {
         &self,
         actor: &User,
         target_user_id: Uuid,
-    ) -> Result<UserDto, Error> {
+    ) -> Result<UserProfile, Error> {
         let guard = self
             .repository
             .find_by(target_user_id)
@@ -147,6 +147,6 @@ impl<R: UserRepository> UserUseCase<'_, R> {
 
         let user = guard.try_into_read(actor)?;
 
-        Ok(UserDto { user, discord_user })
+        Ok(UserProfile { user, discord_user })
     }
 }


### PR DESCRIPTION
## 概要
- usecase の戻り値・入力値を `dto` module から `models` module に移し、`ActiveFormWithLabels` や `AnswerDetails` など用途が分かる名前に整理しました。
- 局所的な `FormDto` alias を削除し、infra 側のフォーム永続化型は `ActiveFormRecord` / `ArchivedFormRecord` として DB 由来であることを明確にしました。
- presentation 側の参照名もあわせて更新し、DB DTO・usecase 出力・API schema の語彙が混ざりにくい形にしています。

## 確認事項
- `cargo build` で workspace がコンパイルできることを確認しました。
- `makers pretty` を実行し、clippy fix、nextest 53 件、doctest 15 件、clippy `-D warnings`、fmt が通ることを確認しました。

🤖 Generated with Codex