### PR TITLE
refactor: 認証ミドルウェアのパスベース除外をルーター分割に置き換える

### DIFF
--- a/server/entrypoint/src/main.rs
+++ b/server/entrypoint/src/main.rs
@@ -95,9 +95,19 @@ async fn main() -> anyhow::Result<()> {
 
     use presentation::handlers::health_check_handler;
 
-    let (versioned_api_router, openapi) = openapi::versioned_api_router()
+    let openapi = openapi::versioned_api_router().into_openapi();
+
+    let (public_api, _) = openapi::public_api_router()
         .with_state(shared_repository.to_owned())
         .split_for_parts();
+
+    let (authenticated_api, _) = openapi::authenticated_api_router()
+        .with_state(shared_repository.to_owned())
+        .split_for_parts();
+    let authenticated_api = authenticated_api.route_layer(middleware::from_fn_with_state(
+        shared_repository.to_owned(),
+        auth,
+    ));
 
     // post_message_handler uses a different State type, so register it separately
     let message_post_router = Router::new()
@@ -105,6 +115,10 @@ async fn main() -> anyhow::Result<()> {
             "/forms/{form_id}/answers/{answer_id}/messages",
             post(post_message_handler),
         )
+        .route_layer(middleware::from_fn_with_state(
+            shared_repository.to_owned(),
+            auth,
+        ))
         .with_state(Arc::new(
             RealInfrastructureRepositoryWithNotificationAPI::new(
                 shared_repository.to_owned(),
@@ -115,14 +129,10 @@ async fn main() -> anyhow::Result<()> {
     let app = Router::new()
         .merge(SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", openapi))
         .route("/health", get(health_check_handler::health_check))
-        .merge(versioned_api_router)
+        .nest("/api/v1", public_api.merge(authenticated_api))
         .nest("/api/v1", message_post_router)
         .fallback(not_found_handler)
         .layer(layer)
-        .route_layer(middleware::from_fn_with_state(
-            shared_repository.to_owned(),
-            auth,
-        ))
         .layer(
             CorsLayer::new()
                 .allow_methods([

--- a/server/entrypoint/src/main.rs
+++ b/server/entrypoint/src/main.rs
@@ -129,8 +129,12 @@ async fn main() -> anyhow::Result<()> {
     let app = Router::new()
         .merge(SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", openapi))
         .route("/health", get(health_check_handler::health_check))
-        .nest("/api/v1", public_api.merge(authenticated_api))
-        .nest("/api/v1", message_post_router)
+        .nest(
+            "/api/v1",
+            public_api
+                .merge(authenticated_api)
+                .merge(message_post_router),
+        )
         .fallback(not_found_handler)
         .layer(layer)
         .layer(

--- a/server/entrypoint/src/openapi.rs
+++ b/server/entrypoint/src/openapi.rs
@@ -82,13 +82,25 @@ impl Modify for SecurityAddon {
     }
 }
 
-pub fn api_router() -> OpenApiRouter<RealInfrastructureRepository> {
+pub fn public_api_router() -> OpenApiRouter<RealInfrastructureRepository> {
+    use presentation::handlers::form::{answer_handler, form_handler};
+
+    OpenApiRouter::new()
+        .routes(routes!(form_handler::get_temporary_answer_form_handler))
+        .routes(routes!(answer_handler::post_temporary_answer_handler))
+        .routes(routes!(
+            user_handler::start_session,
+            user_handler::end_session
+        ))
+}
+
+pub fn authenticated_api_router() -> OpenApiRouter<RealInfrastructureRepository> {
     use presentation::handlers::form::{
         answer_handler, answer_label_handler, comment_handler, form_handler, form_label_handler,
         message_handler,
     };
 
-    OpenApiRouter::with_openapi(ManuallyRegisteredApiDoc::openapi())
+    OpenApiRouter::new()
         .routes(routes!(
             form_handler::create_form_handler,
             form_handler::form_list_handler
@@ -97,7 +109,6 @@ pub fn api_router() -> OpenApiRouter<RealInfrastructureRepository> {
             form_handler::get_form_handler,
             form_handler::update_form_handler
         ))
-        .routes(routes!(form_handler::get_temporary_answer_form_handler))
         .routes(routes!(form_handler::archive_form_handler))
         .routes(routes!(form_handler::archived_form_list_handler))
         .routes(routes!(form_handler::get_archived_form_handler))
@@ -106,7 +117,6 @@ pub fn api_router() -> OpenApiRouter<RealInfrastructureRepository> {
             answer_handler::get_answer_by_form_id_handler,
             answer_handler::post_answer_handler
         ))
-        .routes(routes!(answer_handler::post_temporary_answer_handler))
         .routes(routes!(answer_handler::get_all_answers))
         .routes(routes!(
             answer_label_handler::get_labels_for_answers,
@@ -155,17 +165,16 @@ pub fn api_router() -> OpenApiRouter<RealInfrastructureRepository> {
             notification_handler::update_notification_settings
         ))
         .routes(routes!(
-            user_handler::start_session,
-            user_handler::end_session
-        ))
-        .routes(routes!(
             user_handler::link_discord,
             user_handler::unlink_discord
         ))
 }
 
 pub fn versioned_api_router() -> OpenApiRouter<RealInfrastructureRepository> {
-    OpenApiRouter::with_openapi(ApiMetadata::openapi()).nest("/api/v1", api_router())
+    let combined = OpenApiRouter::with_openapi(ManuallyRegisteredApiDoc::openapi())
+        .merge(public_api_router())
+        .merge(authenticated_api_router());
+    OpenApiRouter::with_openapi(ApiMetadata::openapi()).nest("/api/v1", combined)
 }
 
 pub fn openapi() -> utoipa::openapi::OpenApi {

--- a/server/presentation/src/auth.rs
+++ b/server/presentation/src/auth.rs
@@ -16,37 +16,11 @@ use resource::repository::RealInfrastructureRepository;
 use serde_json::json;
 use usecase::user::UserUseCase;
 
-fn is_temporary_answer_path(path: &str) -> bool {
-    let segments = path.trim_start_matches('/').split('/').collect::<Vec<_>>();
-    matches!(
-        segments.as_slice(),
-        [
-            "api",
-            "v1",
-            "forms",
-            _,
-            "temporary-answers" | "temporary-answer-form"
-        ]
-    )
-}
-
 pub async fn auth(
     State(repository): State<RealInfrastructureRepository>,
     mut request: Request<Body>,
     next: Next,
 ) -> Result<Response, Response> {
-    let ignore_auth_paths = ["/api/v1/session", "/health"];
-    let ignore_auth_path_prefixes = ["/swagger-ui", "/api-docs"];
-    let path = request.uri().path();
-    if ignore_auth_paths.contains(&request.uri().path())
-        || ignore_auth_path_prefixes
-            .iter()
-            .any(|prefix| path.starts_with(prefix))
-        || is_temporary_answer_path(path)
-    {
-        return Ok(next.run(request).await);
-    }
-
     let user_use_case = UserUseCase {
         repository: repository.user_repository(),
     };


### PR DESCRIPTION
## 概要
- 認証不要ルートの判定が `auth.rs` 内の `is_temporary_answer_path` や `ignore_auth_paths` による文字列マッチに依存しており、ルート追加時にミドルウェア側の更新漏れが起きやすかった
- `openapi.rs` の `api_router()` を `public_api_router()` と `authenticated_api_router()` に分割し、`main.rs` で auth ミドルウェアを authenticated 側にのみ `route_layer` で適用するようにした
- `auth.rs` からパスベースの除外ロジック（`is_temporary_answer_path`, `ignore_auth_paths`, `ignore_auth_path_prefixes`）をすべて削除し、ミドルウェアは適用されたルートを無条件に認証する形にした

## 確認事項
- `cargo build` でコンパイル確認済み
- `makers pretty` で clippy, テスト全56件, フォーマットすべてパス
- OpenAPI スペック生成は `versioned_api_router()` で public/authenticated 両方をマージして行うため、API ドキュメントに影響なし

🤖 Generated with Claude Code