### PR TITLE
feat: optional_auth ミドルウェアを導入し認証任意エンドポイントを統合

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -365,6 +365,7 @@
           }
         },
         "security": [
+          {},
           {
             "bearer": []
           }
@@ -1784,6 +1785,7 @@
           }
         },
         "security": [
+          {},
           {
             "bearer": []
           }
@@ -2172,78 +2174,6 @@
             "bearer": []
           }
         ]
-      }
-    },
-    "/api/v1/forms/{id}/temporary-answer-form": {
-      "get": {
-        "tags": [
-          "Answers"
-        ],
-        "summary": "未ログイン回答用フォームの取得",
-        "operationId": "get_temporary_answer_form_handler",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "description": "Form ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "The request has succeeded.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TemporaryAnswerFormSchema"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "The server could not understand the request due to invalid syntax.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Access is forbidden.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "The server cannot find the requested resource.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Server error",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        }
       }
     },
     "/api/v1/forms/{id}/temporary-answers": {
@@ -5094,41 +5024,6 @@
           },
           "temporary_user": {
             "$ref": "#/components/schemas/TemporaryUserCreateSchema"
-          }
-        }
-      },
-      "TemporaryAnswerFormSchema": {
-        "type": "object",
-        "required": [
-          "id",
-          "title",
-          "description",
-          "metadata",
-          "answer_settings",
-          "questions"
-        ],
-        "properties": {
-          "answer_settings": {
-            "$ref": "#/components/schemas/AnswerSettingsSchema"
-          },
-          "description": {
-            "type": "string"
-          },
-          "id": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "metadata": {
-            "$ref": "#/components/schemas/FormMetaSchema"
-          },
-          "questions": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/QuestionResponseSchema"
-            }
-          },
-          "title": {
-            "type": "string"
           }
         }
       },

--- a/server/entrypoint/src/main.rs
+++ b/server/entrypoint/src/main.rs
@@ -16,7 +16,7 @@ use entrypoint::openapi;
 use futures::join;
 use hyper::header::SET_COOKIE;
 use presentation::api::notification_api_impl::NotificationAPIImpl;
-use presentation::auth::auth;
+use presentation::auth::{auth, optional_auth};
 use presentation::handlers::form::message_handler::{
     RealInfrastructureRepositoryWithNotificationAPI, post_message_handler,
 };
@@ -101,6 +101,14 @@ async fn main() -> anyhow::Result<()> {
         .with_state(shared_repository.to_owned())
         .split_for_parts();
 
+    let (optional_auth_api, _) = openapi::optional_auth_api_router()
+        .with_state(shared_repository.to_owned())
+        .split_for_parts();
+    let optional_auth_api = optional_auth_api.route_layer(middleware::from_fn_with_state(
+        shared_repository.to_owned(),
+        optional_auth,
+    ));
+
     let (authenticated_api, _) = openapi::authenticated_api_router()
         .with_state(shared_repository.to_owned())
         .split_for_parts();
@@ -132,6 +140,7 @@ async fn main() -> anyhow::Result<()> {
         .nest(
             "/api/v1",
             public_api
+                .merge(optional_auth_api)
                 .merge(authenticated_api)
                 .merge(message_post_router),
         )

--- a/server/entrypoint/src/openapi.rs
+++ b/server/entrypoint/src/openapi.rs
@@ -25,7 +25,6 @@ use utoipa_axum::routes;
         presentation::schemas::form::form_response_schemas::FormMetaSchema,
         presentation::schemas::form::form_response_schemas::FormSchema,
         presentation::schemas::form::form_response_schemas::FormSettingsSchema,
-        presentation::schemas::form::form_response_schemas::TemporaryAnswerFormSchema,
         presentation::schemas::form::form_response_schemas::TemporaryUser,
         presentation::schemas::form::form_response_schemas::MessageContentSchema,
         presentation::schemas::form::form_response_schemas::ChoiceResponseSchema,
@@ -83,15 +82,22 @@ impl Modify for SecurityAddon {
 }
 
 pub fn public_api_router() -> OpenApiRouter<RealInfrastructureRepository> {
-    use presentation::handlers::form::{answer_handler, form_handler};
+    use presentation::handlers::form::answer_handler;
 
     OpenApiRouter::new()
-        .routes(routes!(form_handler::get_temporary_answer_form_handler))
         .routes(routes!(answer_handler::post_temporary_answer_handler))
         .routes(routes!(
             user_handler::start_session,
             user_handler::end_session
         ))
+}
+
+pub fn optional_auth_api_router() -> OpenApiRouter<RealInfrastructureRepository> {
+    use presentation::handlers::form::form_handler;
+
+    OpenApiRouter::new()
+        .routes(routes!(form_handler::form_list_handler))
+        .routes(routes!(form_handler::get_form_handler))
 }
 
 pub fn authenticated_api_router() -> OpenApiRouter<RealInfrastructureRepository> {
@@ -101,14 +107,8 @@ pub fn authenticated_api_router() -> OpenApiRouter<RealInfrastructureRepository>
     };
 
     OpenApiRouter::new()
-        .routes(routes!(
-            form_handler::create_form_handler,
-            form_handler::form_list_handler
-        ))
-        .routes(routes!(
-            form_handler::get_form_handler,
-            form_handler::update_form_handler
-        ))
+        .routes(routes!(form_handler::create_form_handler))
+        .routes(routes!(form_handler::update_form_handler))
         .routes(routes!(form_handler::archive_form_handler))
         .routes(routes!(form_handler::archived_form_list_handler))
         .routes(routes!(form_handler::get_archived_form_handler))
@@ -173,6 +173,7 @@ pub fn authenticated_api_router() -> OpenApiRouter<RealInfrastructureRepository>
 pub fn versioned_api_router() -> OpenApiRouter<RealInfrastructureRepository> {
     let combined = OpenApiRouter::with_openapi(ManuallyRegisteredApiDoc::openapi())
         .merge(public_api_router())
+        .merge(optional_auth_api_router())
         .merge(authenticated_api_router());
     OpenApiRouter::with_openapi(ApiMetadata::openapi()).nest("/api/v1", combined)
 }

--- a/server/presentation/src/auth.rs
+++ b/server/presentation/src/auth.rs
@@ -12,96 +12,87 @@ use axum_extra::{
     headers::{Authorization, authorization::Bearer},
 };
 use domain::repository::Repositories;
+use domain::user::models::{ActiveUser, User};
 use resource::repository::RealInfrastructureRepository;
 use serde_json::json;
 use usecase::user::UserUseCase;
+
+fn unauthorized_response(detail: &str) -> Response {
+    (
+        StatusCode::UNAUTHORIZED,
+        [(header::CONTENT_TYPE, "application/problem+json")],
+        Json(json!({
+            "type": "about:blank",
+            "title": "Unauthorized",
+            "status": 401,
+            "detail": detail,
+            "errorCode": "UNAUTHORIZED"
+        })),
+    )
+        .into_response()
+}
+
+async fn resolve_user(
+    repository: &RealInfrastructureRepository,
+    session_id: &str,
+) -> Result<ActiveUser, Response> {
+    let user_use_case = UserUseCase {
+        repository: repository.user_repository(),
+    };
+
+    let session_user = user_use_case
+        .fetch_user_by_session_id(session_id.to_string())
+        .await
+        .map_err(|_| unauthorized_response("Failed to retrieve user by session id."))?
+        .ok_or_else(|| unauthorized_response("Invalid session id."))?;
+
+    user_use_case
+        .find_by(&session_user, session_user.id().into_inner())
+        .await
+        .map_err(|_| unauthorized_response("Failed to retrieve user from database."))
+}
 
 pub async fn auth(
     State(repository): State<RealInfrastructureRepository>,
     mut request: Request<Body>,
     next: Next,
 ) -> Result<Response, Response> {
-    let user_use_case = UserUseCase {
-        repository: repository.user_repository(),
-    };
-
     let auth = request
         .extract_parts::<TypedHeader<Authorization<Bearer>>>()
         .await
-        .map_err(|_| {
-            (
-                StatusCode::UNAUTHORIZED,
-                [(header::CONTENT_TYPE, "application/problem+json")],
-                Json(json!({
-                    "type": "about:blank",
-                    "title": "Unauthorized",
-                    "status": 401,
-                    "detail": "Authorization header is missing.",
-                    "errorCode": "UNAUTHORIZED"
-                })),
-            )
-                .into_response()
-        })?;
+        .map_err(|_| unauthorized_response("Authorization header is missing."))?;
 
-    let session_id = auth.token();
-
-    let session_user = match user_use_case
-        .fetch_user_by_session_id(session_id.to_string())
-        .await
-        .map_err(|_| {
-            (
-                StatusCode::UNAUTHORIZED,
-                [(header::CONTENT_TYPE, "application/problem+json")],
-                Json(json!({
-                    "type": "about:blank",
-                    "title": "Unauthorized",
-                    "status": 401,
-                    "detail": "Failed to retrieve user by session id.",
-                    "errorCode": "UNAUTHORIZED"
-                })),
-            )
-                .into_response()
-        })? {
-        Some(user) => user,
-        None => {
-            return Err((
-                StatusCode::UNAUTHORIZED,
-                [(header::CONTENT_TYPE, "application/problem+json")],
-                Json(json!({
-                    "type": "about:blank",
-                    "title": "Unauthorized",
-                    "status": 401,
-                    "detail": "Invalid session id.",
-                    "errorCode": "UNAUTHORIZED"
-                })),
-            )
-                .into_response());
-        }
-    };
-
-    let user = user_use_case
-        .find_by(&session_user, session_user.id().into_inner())
-        .await
-        .map_err(|_| {
-            (
-                StatusCode::UNAUTHORIZED,
-                [(header::CONTENT_TYPE, "application/problem+json")],
-                Json(json!({
-                    "type": "about:blank",
-                    "title": "Unauthorized",
-                    "status": 401,
-                    "detail": "Failed to retrieve user from database.",
-                    "errorCode": "UNAUTHORIZED"
-                })),
-            )
-                .into_response()
-        })?;
+    let user = resolve_user(&repository, auth.token()).await?;
 
     request
         .extensions_mut()
-        .insert(domain::user::models::User::ActiveUser(user.clone()));
+        .insert(User::ActiveUser(user.clone()));
     request.extensions_mut().insert(user);
 
-    let response = next.run(request).await;
-    Ok(response)
+    Ok(next.run(request).await)
+}
+
+pub async fn optional_auth(
+    State(repository): State<RealInfrastructureRepository>,
+    mut request: Request<Body>,
+    next: Next,
+) -> Result<Response, Response> {
+    let auth = request
+        .extract_parts::<TypedHeader<Authorization<Bearer>>>()
+        .await;
+
+    match auth {
+        Ok(auth) => {
+            let user = resolve_user(&repository, auth.token()).await?;
+            request
+                .extensions_mut()
+                .insert(User::ActiveUser(user.clone()));
+            request.extensions_mut().insert(user);
+        }
+        Err(_) => {
+            request.extensions_mut().insert(User::Anonymous);
+        }
+    }
+
+    Ok(next.run(request).await)
 }

--- a/server/presentation/src/auth.rs
+++ b/server/presentation/src/auth.rs
@@ -81,10 +81,7 @@ pub async fn optional_auth(
     match auth {
         Ok(auth) => {
             let user = resolve_user(&repository, auth.token()).await?;
-            request
-                .extensions_mut()
-                .insert(User::ActiveUser(user.clone()));
-            request.extensions_mut().insert(user);
+            request.extensions_mut().insert(User::ActiveUser(user));
         }
         Err(_) => {
             request.extensions_mut().insert(User::Anonymous);

--- a/server/presentation/src/auth.rs
+++ b/server/presentation/src/auth.rs
@@ -64,9 +64,6 @@ pub async fn auth(
 
     let user = resolve_user(&repository, auth.token()).await?;
 
-    request
-        .extensions_mut()
-        .insert(User::ActiveUser(user.clone()));
     request.extensions_mut().insert(user);
 
     Ok(next.run(request).await)

--- a/server/presentation/src/handlers/form/form_handler.rs
+++ b/server/presentation/src/handlers/form/form_handler.rs
@@ -194,6 +194,7 @@ fn archived_form_schema_from_parts(
 )]
 pub async fn create_form_handler(
     Extension(user): Extension<ActiveUser>,
+    Extension(actor): Extension<User>,
     State(repository): State<RealInfrastructureRepository>,
     json: Result<Json<FormCreateSchema>, JsonRejection>,
 ) -> Result<CreateFormResponse, Response> {
@@ -227,7 +228,7 @@ pub async fn create_form_handler(
         id: form.id().to_owned(),
         title: form.title().to_owned(),
         description: form.description().to_owned(),
-        settings: FormSettingsSchema::from_settings_ref(&User::from(user.clone()), form.settings()),
+        settings: FormSettingsSchema::from_settings_ref(&actor, form.settings()),
         metadata: FormMetaSchema::from_meta_ref(form.metadata()),
         questions: form
             .questions()
@@ -358,6 +359,7 @@ pub async fn get_form_handler(
 )]
 pub async fn archive_form_handler(
     Extension(user): Extension<ActiveUser>,
+    Extension(actor): Extension<User>,
     State(repository): State<RealInfrastructureRepository>,
     path: Result<Path<FormId>, PathRejection>,
 ) -> Result<impl IntoResponse, Response> {
@@ -373,7 +375,7 @@ pub async fn archive_form_handler(
     Ok((
         StatusCode::OK,
         Json(archived_form_schema_from_parts(
-            &User::from(user.clone()),
+            &actor,
             archived_form,
             user,
             vec![],
@@ -405,6 +407,7 @@ pub async fn archive_form_handler(
 )]
 pub async fn update_form_handler(
     Extension(user): Extension<ActiveUser>,
+    Extension(actor): Extension<User>,
     State(repository): State<RealInfrastructureRepository>,
     path: Result<Path<FormId>, PathRejection>,
     json: Result<Json<FormUpdateSchema>, JsonRejection>,
@@ -473,10 +476,7 @@ pub async fn update_form_handler(
         id: updated_form.id().to_owned(),
         title: updated_form.title().to_owned(),
         description: updated_form.description().to_owned(),
-        settings: FormSettingsSchema::from_settings_ref(
-            &User::from(user.clone()),
-            updated_form.settings(),
-        ),
+        settings: FormSettingsSchema::from_settings_ref(&actor, updated_form.settings()),
         metadata: FormMetaSchema::from_meta_ref(updated_form.metadata()),
         questions: updated_form
             .questions()
@@ -509,6 +509,7 @@ pub async fn update_form_handler(
 )]
 pub async fn archived_form_list_handler(
     Extension(user): Extension<ActiveUser>,
+    Extension(actor): Extension<User>,
     State(repository): State<RealInfrastructureRepository>,
     Query(offset_and_limit): Query<OffsetAndLimit>,
     query: Result<
@@ -538,7 +539,7 @@ pub async fn archived_form_list_handler(
             .into_iter()
             .map(|details| {
                 archived_form_schema_from_parts(
-                    &User::from(user.clone()),
+                    &actor,
                     details.form,
                     details.archived_by,
                     details.labels,
@@ -568,6 +569,7 @@ pub async fn archived_form_list_handler(
 )]
 pub async fn get_archived_form_handler(
     Extension(user): Extension<ActiveUser>,
+    Extension(actor): Extension<User>,
     State(repository): State<RealInfrastructureRepository>,
     path: Result<Path<FormId>, PathRejection>,
 ) -> Result<ArchivedFormResponse, Response> {
@@ -584,7 +586,7 @@ pub async fn get_archived_form_handler(
         .map_err(handle_error)?;
 
     Ok(ArchivedFormResponse::Ok(archived_form_schema_from_parts(
-        &User::from(user.clone()),
+        &actor,
         form,
         archived_by,
         labels,

--- a/server/presentation/src/handlers/form/form_handler.rs
+++ b/server/presentation/src/handlers/form/form_handler.rs
@@ -8,7 +8,7 @@ use axum::{
 };
 use domain::{
     form::{models::FormId, question::models::QuestionSet},
-    repository::{Repositories, form::active_form_repository::ActiveFormRepository},
+    repository::Repositories,
     user::models::{ActiveUser, User},
 };
 use itertools::Itertools;
@@ -25,7 +25,6 @@ use crate::schemas::form::{
     form_request_schemas::{FormCreateSchema, FormUpdateSchema, OffsetAndLimit, QuestionSchema},
     form_response_schemas::{
         ArchivedFormSchema, FormMetaSchema, FormSchema, FormSettingsSchema, QuestionResponseSchema,
-        TemporaryAnswerFormSchema,
     },
 };
 use axum::extract::rejection::PathRejection;
@@ -83,20 +82,6 @@ impl IntoResponse for GetFormResponse {
     fn into_response(self) -> Response {
         match self {
             Self::Ok(body) => (StatusCode::OK, Json(json!(body))).into_response(),
-        }
-    }
-}
-
-#[derive(utoipa::IntoResponses)]
-pub enum GetTemporaryAnswerFormResponse {
-    #[response(status = 200, description = "The request has succeeded.")]
-    Ok(TemporaryAnswerFormSchema),
-}
-
-impl IntoResponse for GetTemporaryAnswerFormResponse {
-    fn into_response(self) -> Response {
-        match self {
-            Self::Ok(body) => (StatusCode::OK, Json(body)).into_response(),
         }
     }
 }
@@ -167,7 +152,7 @@ fn build_form_use_case(repository: &RealInfrastructureRepository) -> ResourceFor
 }
 
 fn archived_form_schema_from_parts(
-    user: &ActiveUser,
+    user: &User,
     form: domain::form::models::ArchivedForm,
     archived_by: ActiveUser,
     labels: Vec<domain::form::models::FormLabel>,
@@ -242,7 +227,7 @@ pub async fn create_form_handler(
         id: form.id().to_owned(),
         title: form.title().to_owned(),
         description: form.description().to_owned(),
-        settings: FormSettingsSchema::from_settings_ref(&user, form.settings()),
+        settings: FormSettingsSchema::from_settings_ref(&User::from(user.clone()), form.settings()),
         metadata: FormMetaSchema::from_meta_ref(form.metadata()),
         questions: form
             .questions()
@@ -269,11 +254,11 @@ pub async fn create_form_handler(
         Forbidden,
         InternalServerError,
     ),
-    security(("bearer" = [])),
+    security((), ("bearer" = [])),
     tag = "Forms"
 )]
 pub async fn form_list_handler(
-    Extension(user): Extension<ActiveUser>,
+    Extension(user): Extension<User>,
     State(repository): State<RealInfrastructureRepository>,
     Query(offset_and_limit): Query<OffsetAndLimit>,
 ) -> Result<FormListResponse, Response> {
@@ -320,11 +305,11 @@ pub async fn form_list_handler(
         NotFound,
         InternalServerError,
     ),
-    security(("bearer" = [])),
+    security((), ("bearer" = [])),
     tag = "Forms"
 )]
 pub async fn get_form_handler(
-    Extension(user): Extension<ActiveUser>,
+    Extension(user): Extension<User>,
     State(repository): State<RealInfrastructureRepository>,
     path: Result<Path<FormId>, PathRejection>,
 ) -> Result<GetFormResponse, Response> {
@@ -350,61 +335,6 @@ pub async fn get_form_handler(
             .map(QuestionResponseSchema::from)
             .collect(),
         labels,
-    }))
-}
-
-#[utoipa::path(
-    get,
-    path = "/forms/{id}/temporary-answer-form",
-    summary = "未ログイン回答用フォームの取得",
-    params(
-        ("id" = String, Path, description = "Form ID"),
-    ),
-    responses(
-        GetTemporaryAnswerFormResponse,
-        BadRequest,
-        Forbidden,
-        NotFound,
-        InternalServerError,
-    ),
-    tag = "Answers"
-)]
-pub async fn get_temporary_answer_form_handler(
-    State(repository): State<RealInfrastructureRepository>,
-    path: Result<Path<FormId>, PathRejection>,
-) -> Result<GetTemporaryAnswerFormResponse, Response> {
-    let Path(form_id) = path.map_err_to_error().map_err(handle_error)?;
-    let form_guard = repository
-        .active_form_repository()
-        .get(form_id)
-        .await
-        .map_err(handle_error)?
-        .ok_or(errors::Error::from(
-            errors::usecase::UseCaseError::FormNotFound,
-        ))
-        .map_err(handle_error)?;
-    let form = form_guard
-        .try_into_read(&User::Anonymous)
-        .map_err(|e| handle_error(e.into()))?;
-
-    if !form.settings().allow_temporary_answers() {
-        return Err(handle_error(errors::domain::DomainError::Forbidden.into()));
-    }
-
-    Ok(GetTemporaryAnswerFormResponse::Ok(TemporaryAnswerFormSchema {
-        id: form.id().to_owned(),
-        title: form.title().to_owned(),
-        description: form.description().to_owned(),
-        metadata: FormMetaSchema::from_meta_ref(form.metadata()),
-        answer_settings: crate::schemas::form::form_response_schemas::AnswerSettingsSchema::from_answer_settings_ref(
-            form.settings().answer_settings(),
-        ),
-        questions: form
-            .questions()
-            .iter()
-            .cloned()
-            .map(QuestionResponseSchema::from)
-            .collect(),
     }))
 }
 
@@ -443,7 +373,7 @@ pub async fn archive_form_handler(
     Ok((
         StatusCode::OK,
         Json(archived_form_schema_from_parts(
-            &user.clone(),
+            &User::from(user.clone()),
             archived_form,
             user,
             vec![],
@@ -543,7 +473,10 @@ pub async fn update_form_handler(
         id: updated_form.id().to_owned(),
         title: updated_form.title().to_owned(),
         description: updated_form.description().to_owned(),
-        settings: FormSettingsSchema::from_settings_ref(&user, updated_form.settings()),
+        settings: FormSettingsSchema::from_settings_ref(
+            &User::from(user.clone()),
+            updated_form.settings(),
+        ),
         metadata: FormMetaSchema::from_meta_ref(updated_form.metadata()),
         questions: updated_form
             .questions()
@@ -605,7 +538,7 @@ pub async fn archived_form_list_handler(
             .into_iter()
             .map(|details| {
                 archived_form_schema_from_parts(
-                    &user,
+                    &User::from(user.clone()),
                     details.form,
                     details.archived_by,
                     details.labels,
@@ -651,7 +584,7 @@ pub async fn get_archived_form_handler(
         .map_err(handle_error)?;
 
     Ok(ArchivedFormResponse::Ok(archived_form_schema_from_parts(
-        &user,
+        &User::from(user.clone()),
         form,
         archived_by,
         labels,

--- a/server/presentation/src/handlers/form/form_handler.rs
+++ b/server/presentation/src/handlers/form/form_handler.rs
@@ -194,7 +194,6 @@ fn archived_form_schema_from_parts(
 )]
 pub async fn create_form_handler(
     Extension(user): Extension<ActiveUser>,
-    Extension(actor): Extension<User>,
     State(repository): State<RealInfrastructureRepository>,
     json: Result<Json<FormCreateSchema>, JsonRejection>,
 ) -> Result<CreateFormResponse, Response> {
@@ -228,7 +227,7 @@ pub async fn create_form_handler(
         id: form.id().to_owned(),
         title: form.title().to_owned(),
         description: form.description().to_owned(),
-        settings: FormSettingsSchema::from_settings_ref(&actor, form.settings()),
+        settings: FormSettingsSchema::from_settings_ref(&User::from(user.clone()), form.settings()),
         metadata: FormMetaSchema::from_meta_ref(form.metadata()),
         questions: form
             .questions()
@@ -359,7 +358,6 @@ pub async fn get_form_handler(
 )]
 pub async fn archive_form_handler(
     Extension(user): Extension<ActiveUser>,
-    Extension(actor): Extension<User>,
     State(repository): State<RealInfrastructureRepository>,
     path: Result<Path<FormId>, PathRejection>,
 ) -> Result<impl IntoResponse, Response> {
@@ -375,7 +373,7 @@ pub async fn archive_form_handler(
     Ok((
         StatusCode::OK,
         Json(archived_form_schema_from_parts(
-            &actor,
+            &User::from(user.clone()),
             archived_form,
             user,
             vec![],
@@ -407,7 +405,6 @@ pub async fn archive_form_handler(
 )]
 pub async fn update_form_handler(
     Extension(user): Extension<ActiveUser>,
-    Extension(actor): Extension<User>,
     State(repository): State<RealInfrastructureRepository>,
     path: Result<Path<FormId>, PathRejection>,
     json: Result<Json<FormUpdateSchema>, JsonRejection>,
@@ -476,7 +473,10 @@ pub async fn update_form_handler(
         id: updated_form.id().to_owned(),
         title: updated_form.title().to_owned(),
         description: updated_form.description().to_owned(),
-        settings: FormSettingsSchema::from_settings_ref(&actor, updated_form.settings()),
+        settings: FormSettingsSchema::from_settings_ref(
+            &User::from(user.clone()),
+            updated_form.settings(),
+        ),
         metadata: FormMetaSchema::from_meta_ref(updated_form.metadata()),
         questions: updated_form
             .questions()
@@ -509,7 +509,6 @@ pub async fn update_form_handler(
 )]
 pub async fn archived_form_list_handler(
     Extension(user): Extension<ActiveUser>,
-    Extension(actor): Extension<User>,
     State(repository): State<RealInfrastructureRepository>,
     Query(offset_and_limit): Query<OffsetAndLimit>,
     query: Result<
@@ -534,6 +533,7 @@ pub async fn archived_form_list_handler(
         .await
         .map_err(handle_error)?;
 
+    let actor = User::from(user);
     Ok(ArchivedFormListResponse::Ok(
         forms
             .into_iter()
@@ -569,7 +569,6 @@ pub async fn archived_form_list_handler(
 )]
 pub async fn get_archived_form_handler(
     Extension(user): Extension<ActiveUser>,
-    Extension(actor): Extension<User>,
     State(repository): State<RealInfrastructureRepository>,
     path: Result<Path<FormId>, PathRejection>,
 ) -> Result<ArchivedFormResponse, Response> {
@@ -586,7 +585,7 @@ pub async fn get_archived_form_handler(
         .map_err(handle_error)?;
 
     Ok(ArchivedFormResponse::Ok(archived_form_schema_from_parts(
-        &actor,
+        &User::from(user.clone()),
         form,
         archived_by,
         labels,

--- a/server/presentation/src/schemas/form/form_response_schemas.rs
+++ b/server/presentation/src/schemas/form/form_response_schemas.rs
@@ -69,14 +69,10 @@ pub struct FormSettingsSchema {
 }
 
 impl FormSettingsSchema {
-    pub fn from_settings_ref(
-        actor: &domain::user::models::ActiveUser,
-        settings: &FormSettings,
-    ) -> Self {
-        let actor_user = domain::user::models::User::from(actor.clone());
+    pub fn from_settings_ref(actor: &domain::user::models::User, settings: &FormSettings) -> Self {
         FormSettingsSchema {
             webhook_url: settings
-                .webhook_url(&actor_user)
+                .webhook_url(actor)
                 .ok()
                 .map(|url| url.to_owned().into_inner().map(NonEmptyString::into_inner)),
             visibility: settings.visibility().to_owned(),
@@ -116,19 +112,6 @@ pub struct FormSchema {
     pub questions: Vec<QuestionResponseSchema>,
     #[schema(value_type = Vec<FormLabelResponseSchema>)]
     pub labels: Vec<FormLabel>,
-}
-
-#[derive(Serialize, Debug, utoipa::ToSchema)]
-pub struct TemporaryAnswerFormSchema {
-    #[schema(value_type = String, format = "uuid")]
-    pub id: FormId,
-    #[schema(value_type = String)]
-    pub title: FormTitle,
-    #[schema(value_type = String)]
-    pub description: FormDescription,
-    pub metadata: FormMetaSchema,
-    pub answer_settings: AnswerSettingsSchema,
-    pub questions: Vec<QuestionResponseSchema>,
 }
 
 #[derive(Serialize, Debug, utoipa::ToSchema)]

--- a/server/usecase/src/forms/form.rs
+++ b/server/usecase/src/forms/form.rs
@@ -92,17 +92,16 @@ impl<
     /// `actor` が参照可能なフォームのリストを取得する
     pub async fn form_list(
         &self,
-        actor: &ActiveUser,
+        actor: &User,
         offset: Option<u32>,
         limit: Option<u32>,
     ) -> Result<Vec<(ActiveForm, Vec<FormLabel>)>, Error> {
-        let actor_user = User::from(actor.clone());
         let forms = self
             .active_form_repository
             .list(offset, limit)
             .await?
             .into_iter()
-            .flat_map(|form| form.try_into_read(&actor_user))
+            .flat_map(|form| form.try_into_read(actor))
             .collect::<Vec<_>>();
 
         let form_labels = futures::future::try_join_all(forms.iter().map(|form| {
@@ -118,7 +117,7 @@ impl<
                     form,
                     labels
                         .into_iter()
-                        .map(|guard| guard.try_into_read(&actor_user))
+                        .map(|guard| guard.try_into_read(actor))
                         .collect::<Result<Vec<_>, _>>()?,
                 ))
             })
@@ -129,22 +128,21 @@ impl<
 
     pub async fn get_form(
         &self,
-        actor: &ActiveUser,
+        actor: &User,
         form_id: FormId,
     ) -> Result<ActiveFormWithLabels, Error> {
-        let actor_user = User::from(actor.clone());
         let form = self
             .active_form_repository
             .get(form_id)
             .await?
             .ok_or(Error::from(FormNotFound))?
-            .try_into_read(&actor_user)?;
+            .try_into_read(actor)?;
         let labels = self
             .form_label_repository
             .fetch_labels_by_form_id(form_id)
             .await?
             .into_iter()
-            .map(|label| label.try_into_read(&actor_user))
+            .map(|label| label.try_into_read(actor))
             .collect::<Result<Vec<_>, _>>()?;
 
         Ok(ActiveFormWithLabels { form, labels })


### PR DESCRIPTION
## 概要
- 認証済み/未認証ユーザーが同じリソース（フォーム）にアクセスする際、ルーター層の二分構造（public vs authenticated）により別パスが必要だった問題を解消
- Bearer ヘッダーの有無で `User::ActiveUser` / `User::Anonymous` を切り替える `optional_auth` ミドルウェアを導入し、`GET /forms` と `GET /forms/{id}` を認証任意エンドポイントに移行
- これにより `GET /forms/{id}/temporary-answer-form` エンドポイントと `TemporaryAnswerFormSchema` を削除（**破壊的変更**）

### 変更ファイル
- `auth.rs`: 共通ロジックを `resolve_user` に抽出、`optional_auth` を新規追加
- `form_response_schemas.rs`: `FormSettingsSchema::from_settings_ref` が `&User` を受け取るように変更
- `form.rs` (usecase): `get_form` / `form_list` が `&User` を受け取るように変更
- `form_handler.rs`: `get_form_handler` / `form_list_handler` が `Extension<User>` を使用、`get_temporary_answer_form_handler` を削除
- `openapi.rs`: ルーターを public / optional_auth / authenticated の3グループに再構成
- `main.rs`: `optional_auth` ミドルウェアの適用を追加

## 確認事項
- `cargo build` でコンパイル通過を確認
- `makers pretty`（clippy + nextest 56テスト + doctest 15テスト + format）すべて通過
- `cargo test` で全テスト通過を確認
- `optional_auth` の挙動: Bearer なし → `User::Anonymous` 挿入、Bearer あり有効 → `User::ActiveUser` 挿入、Bearer あり無効 → 401 返却
- Anonymous ユーザーのフォーム閲覧は、ドメイン層の `ActiveForm::can_read` が `Visibility::PUBLIC` のフォームのみ許可する既存ロジックで制御される

## 補足
- `POST /forms/{id}/temporary-answers`（一時回答投稿）はリクエストスキーマが根本的に異なるため統合対象外とし、従来通り public_api_router に残している
- `GET /forms/{id}/temporary-answer-form` の削除は破壊的変更。フロントエンド側の対応が必要

🤖 Generated with Claude Code