### PR TITLE
ci: pre-commit フックに OpenAPI 差分チェックを追加

### DIFF
--- a/.cargo-husky/hooks/pre-commit
+++ b/.cargo-husky/hooks/pre-commit
@@ -1,4 +1,5 @@
 #!/bin/sh
 
 cargo fmt --all -- --config-path=.cargo-husky/hooks/rustfmt.toml --check &&
-  cargo clippy --all -- -D warnings
+  cargo clippy --all -- -D warnings &&
+  cargo make check-openapi


### PR DESCRIPTION
## 概要
- pre-commit フック（cargo-husky）に `cargo make check-openapi` を追加
- コミット時に OpenAPI spec (`docs/openapi.json`) の更新漏れを自動検出する
- 既存の `check-openapi` タスク（再生成 → git diff で差分検出）をそのまま利用

## 確認事項
- pre-commit フックが既存のチェック（fmt, clippy）に加えて正常に実行されることをコミット時に確認済み

🤖 Generated with Claude Code