### PR TITLE
refactor: domain 層から serenity 依存を除去

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1020,7 +1020,6 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "serenity",
  "strum 0.28.0",
  "strum_macros 0.28.0",
  "test-case",

--- a/server/domain/Cargo.toml
+++ b/server/domain/Cargo.toml
@@ -17,7 +17,6 @@ strum_macros = { workspace = true }
 types = { path = "../types" }
 uuid = { workspace = true }
 regex = { workspace = true }
-serenity = { workspace = true }
 tracing = { workspace = true }
 common = { path = "../common" }
 

--- a/server/domain/src/notification/discord_sender.rs
+++ b/server/domain/src/notification/discord_sender.rs
@@ -1,9 +1,8 @@
 use async_trait::async_trait;
 use errors::Error;
 use mockall::automock;
-use serenity::all::ExecuteWebhook;
 
-use crate::{form::models::WebhookUrl, user::models::DiscordUserId};
+use crate::user::models::DiscordUserId;
 
 #[automock]
 #[async_trait]
@@ -12,10 +11,5 @@ pub trait DiscordSender: Send + Sync {
         &self,
         user_id: DiscordUserId,
         message: String,
-    ) -> Result<(), Error>;
-    async fn send_webhook_message(
-        &self,
-        webhook_url: WebhookUrl,
-        message: ExecuteWebhook,
     ) -> Result<(), Error>;
 }

--- a/server/infra/resource/src/outgoing/discord_sender_impl.rs
+++ b/server/infra/resource/src/outgoing/discord_sender_impl.rs
@@ -1,12 +1,6 @@
-use domain::{
-    form::models::WebhookUrl, notification::discord_sender::DiscordSender,
-    user::models::DiscordUserId,
-};
+use domain::{notification::discord_sender::DiscordSender, user::models::DiscordUserId};
 use errors::{Error, infra::InfraError};
-use serenity::{
-    all::{ExecuteWebhook, UserId},
-    async_trait,
-};
+use serenity::{all::UserId, async_trait};
 
 use crate::outgoing::connection::ConnectionPool;
 
@@ -36,30 +30,6 @@ impl DiscordSender for ConnectionPool {
             .say(&http, message)
             .await
             .map_err(Into::<InfraError>::into)?;
-
-        Ok(())
-    }
-
-    async fn send_webhook_message(
-        &self,
-        webhook_url: WebhookUrl,
-        message: ExecuteWebhook,
-    ) -> Result<(), Error> {
-        if let Some(webhook_url) = webhook_url.into_inner() {
-            let http = &self.pool.http;
-
-            let webhook = serenity::model::webhook::Webhook::from_url(
-                http,
-                webhook_url.into_inner().as_str(),
-            )
-            .await
-            .map_err(Into::<InfraError>::into)?;
-
-            webhook
-                .execute(http, false, message)
-                .await
-                .map_err(Into::<InfraError>::into)?;
-        }
 
         Ok(())
     }


### PR DESCRIPTION
## 概要
- `DiscordSender` trait の `send_webhook_message` メソッドは呼び出し箇所がなく、引数の `ExecuteWebhook` 型が domain 層に serenity への不要な依存を持ち込んでいた
- Discord Embed の構築はインフラの関心事であり、domain 層にドメイン型として持つべきではないため、未使用メソッドごと削除して serenity 依存を解消した
- `send_direct_message` は引き続き利用可能で、既存の DM 通知フローに影響なし

Closes #1005

## 確認事項
- `cargo build` でコンパイル成功を確認
- `makers pretty`（clippy, nextest, doc-tests, fmt）が全パスすることを確認
- `send_webhook_message` の呼び出し箇所がゼロであることを grep で確認済み

## 補足
- `DiscordSender` trait 自体が domain 層にあることの妥当性（Discord はインフラの関心事）は別途検討課題として残る

🤖 Generated with Claude Code