### PR TITLE
refactor: Actor 型を導入し認可チェックから unsafe を除去

### DIFF
--- a/server/domain/src/form/answer/models.rs
+++ b/server/domain/src/form/answer/models.rs
@@ -14,7 +14,7 @@ use crate::{
         question::models::{Question, QuestionId},
     },
     types::authorization_guard::AuthorizationGuardDefinitions,
-    user::models::{Role, TemporaryUser, User, UserId},
+    user::models::{Actor, Role, TemporaryUser, User, UserId},
 };
 
 pub type AnswerId = types::Id<AnswerEntry>;
@@ -241,20 +241,20 @@ impl AnswerLabel {
 }
 
 impl AuthorizationGuardDefinitions for AnswerLabel {
-    fn can_create(&self, actor: &User) -> bool {
-        matches!(actor, User::ActiveUser(actor) if actor.role() == &Role::Administrator)
+    fn can_create(&self, actor: &Actor) -> bool {
+        matches!(actor, Actor::User(User::ActiveUser(actor)) if actor.role() == &Role::Administrator)
     }
 
-    fn can_read(&self, _actor: &User) -> bool {
+    fn can_read(&self, _actor: &Actor) -> bool {
         true
     }
 
-    fn can_update(&self, actor: &User) -> bool {
-        matches!(actor, User::ActiveUser(actor) if actor.role() == &Role::Administrator)
+    fn can_update(&self, actor: &Actor) -> bool {
+        matches!(actor, Actor::User(User::ActiveUser(actor)) if actor.role() == &Role::Administrator)
     }
 
-    fn can_delete(&self, actor: &User) -> bool {
-        matches!(actor, User::ActiveUser(actor) if actor.role() == &Role::Administrator)
+    fn can_delete(&self, actor: &Actor) -> bool {
+        matches!(actor, Actor::User(User::ActiveUser(actor)) if actor.role() == &Role::Administrator)
     }
 }
 

--- a/server/domain/src/form/answer/service.rs
+++ b/server/domain/src/form/answer/service.rs
@@ -9,7 +9,7 @@ use crate::{
         models::Visibility,
     },
     types::authorization_guard_with_context::AuthorizationGuardWithContextDefinitions,
-    user::models::{Role, User},
+    user::models::{Actor, Role, User},
 };
 
 #[derive(Debug)]
@@ -21,16 +21,16 @@ pub struct AnswerEntryAuthorizationContext {
 }
 
 impl AuthorizationGuardWithContextDefinitions<AnswerEntryAuthorizationContext> for AnswerEntry {
-    fn can_create(&self, actor: &User, context: &AnswerEntryAuthorizationContext) -> bool {
+    fn can_create(&self, actor: &Actor, context: &AnswerEntryAuthorizationContext) -> bool {
         let is_within_period = context.response_period.is_within_period(Utc::now());
 
         match (self.author(), actor) {
-            (AnswerAuthor::AuthenticatedUser(user_id), User::ActiveUser(user)) => {
+            (AnswerAuthor::AuthenticatedUser(user_id), Actor::User(User::ActiveUser(user))) => {
                 let is_public_form = context.form_visibility == Visibility::PUBLIC;
                 *user_id == *user.id()
                     && ((is_public_form && is_within_period) || user.role() == &Role::Administrator)
             }
-            (AnswerAuthor::TemporaryUser(_), User::TemporaryUser(_)) => {
+            (AnswerAuthor::TemporaryUser(_), Actor::User(User::TemporaryUser(_))) => {
                 context.form_visibility == Visibility::PUBLIC
                     && context.allow_temporary_answers
                     && is_within_period
@@ -39,25 +39,25 @@ impl AuthorizationGuardWithContextDefinitions<AnswerEntryAuthorizationContext> f
         }
     }
 
-    fn can_read(&self, actor: &User, context: &AnswerEntryAuthorizationContext) -> bool {
+    fn can_read(&self, actor: &Actor, context: &AnswerEntryAuthorizationContext) -> bool {
         match actor {
-            User::ActiveUser(user) => {
+            Actor::User(User::ActiveUser(user)) => {
                 self.author().authenticated_user_id() == Some(*user.id())
                     || context.answer_visibility == AnswerVisibility::PUBLIC
                     || user.role() == &Role::Administrator
             }
-            User::TemporaryUser(_) | User::Anonymous => false,
+            _ => false,
         }
     }
 
-    fn can_update(&self, _actor: &User, _context: &AnswerEntryAuthorizationContext) -> bool {
+    fn can_update(&self, _actor: &Actor, _context: &AnswerEntryAuthorizationContext) -> bool {
         false
     }
 
-    fn can_delete(&self, actor: &User, _context: &AnswerEntryAuthorizationContext) -> bool {
+    fn can_delete(&self, actor: &Actor, _context: &AnswerEntryAuthorizationContext) -> bool {
         matches!(
             actor,
-            User::ActiveUser(user) if user.role() == &Role::Administrator
+            Actor::User(User::ActiveUser(user)) if user.role() == &Role::Administrator
         )
     }
 }
@@ -74,6 +74,7 @@ mod tests {
         models::Visibility,
     };
     use crate::types::authorization_guard_with_context::AuthorizationGuardWithContextDefinitions;
+    use crate::user::models::Actor;
 
     #[test]
     fn temporary_answer_creation_requires_public_form() {
@@ -93,7 +94,7 @@ mod tests {
         );
 
         assert!(!answer.can_create(
-            &crate::user::models::User::TemporaryUser(crate::user::models::TemporaryUser::new(
+            &Actor::from(crate::user::models::TemporaryUser::new(
                 "guest".to_string(),
                 "contact".to_string()
             )),
@@ -119,7 +120,7 @@ mod tests {
         );
 
         assert!(answer.can_create(
-            &crate::user::models::User::TemporaryUser(crate::user::models::TemporaryUser::new(
+            &Actor::from(crate::user::models::TemporaryUser::new(
                 "guest".to_string(),
                 "contact".to_string()
             )),
@@ -149,7 +150,7 @@ mod tests {
         );
 
         assert!(!answer.can_create(
-            &crate::user::models::User::TemporaryUser(crate::user::models::TemporaryUser::new(
+            &Actor::from(crate::user::models::TemporaryUser::new(
                 "guest".to_string(),
                 "contact".to_string()
             )),

--- a/server/domain/src/form/comment/service.rs
+++ b/server/domain/src/form/comment/service.rs
@@ -6,7 +6,7 @@ use crate::{
     types::authorization_guard_with_context::{
         Actions, AuthorizationGuardWithContext, AuthorizationGuardWithContextDefinitions,
     },
-    user::models::{Role::Administrator, User},
+    user::models::{Actor, Role::Administrator, User},
 };
 
 #[derive(Debug)]
@@ -19,43 +19,41 @@ pub struct CommentAuthorizationContext<Action: Actions> {
 impl<Action: Actions> AuthorizationGuardWithContextDefinitions<CommentAuthorizationContext<Action>>
     for Comment
 {
-    fn can_create(&self, actor: &User, context: &CommentAuthorizationContext<Action>) -> bool {
+    fn can_create(&self, actor: &Actor, context: &CommentAuthorizationContext<Action>) -> bool {
         context
             .related_answer_entry_guard
             .can_read(actor, &context.related_answer_entry_guard_context)
     }
 
-    fn can_read(&self, actor: &User, context: &CommentAuthorizationContext<Action>) -> bool {
+    fn can_read(&self, actor: &Actor, context: &CommentAuthorizationContext<Action>) -> bool {
         context
             .related_answer_entry_guard
             .can_read(actor, &context.related_answer_entry_guard_context)
     }
 
-    fn can_update(&self, actor: &User, context: &CommentAuthorizationContext<Action>) -> bool {
+    fn can_update(&self, actor: &Actor, context: &CommentAuthorizationContext<Action>) -> bool {
         match actor {
-            User::ActiveUser(actor) => {
+            Actor::User(User::ActiveUser(actor)) => {
                 (context.related_answer_entry_guard.can_read(
-                    &User::ActiveUser(actor.clone()),
+                    &Actor::from(actor.clone()),
                     &context.related_answer_entry_guard_context,
                 ) && self.commented_by() == actor.id())
                     || actor.role() == &Administrator
             }
-            User::TemporaryUser(_) | User::Anonymous => false,
+            _ => false,
         }
     }
 
-    fn can_delete(&self, actor: &User, context: &CommentAuthorizationContext<Action>) -> bool {
-        // NOTE: コメントの削除に関しては、コメント自体が全体公開されうるものなので、
-        // 適さないメッセージを Administrator が削除できる必要がある
+    fn can_delete(&self, actor: &Actor, context: &CommentAuthorizationContext<Action>) -> bool {
         match actor {
-            User::ActiveUser(actor) => {
+            Actor::User(User::ActiveUser(actor)) => {
                 (context.related_answer_entry_guard.can_read(
-                    &User::ActiveUser(actor.clone()),
+                    &Actor::from(actor.clone()),
                     &context.related_answer_entry_guard_context,
                 ) && self.commented_by() == actor.id())
                     || actor.role() == &Administrator
             }
-            User::TemporaryUser(_) | User::Anonymous => false,
+            _ => false,
         }
     }
 }

--- a/server/domain/src/form/message/service.rs
+++ b/server/domain/src/form/message/service.rs
@@ -1,7 +1,7 @@
 use crate::{
     form::{answer::models::AnswerEntry, message::models::Message},
     types::authorization_guard_with_context::AuthorizationGuardWithContextDefinitions,
-    user::models::{Role::Administrator, User},
+    user::models::{Actor, Role::Administrator, User},
 };
 
 #[derive(Debug)]
@@ -27,16 +27,16 @@ impl AuthorizationGuardWithContextDefinitions<MessageAuthorizationContext> for M
     ///         authorization_guard::AuthorizationGuardDefinitions,
     ///         authorization_guard_with_context::AuthorizationGuardWithContextDefinitions,
     ///     },
-    ///     user::models::{ActiveUser, Role, User, UserId},
+    ///     user::models::{ActiveUser, Actor, Role, User, UserId},
     /// };
     /// use uuid::Uuid;
     ///
     /// let respondent_id: UserId = Uuid::new_v4().into();
-    /// let respondent = User::ActiveUser(ActiveUser::new(
+    /// let respondent: Actor = User::ActiveUser(ActiveUser::new(
     ///     "respondent".to_string(),
     ///     respondent_id,
     ///     Role::StandardUser,
-    /// ));
+    /// )).into();
     ///
     /// let related_answer = AnswerEntry::new(
     ///     AnswerAuthor::AuthenticatedUser(respondent_id),
@@ -52,17 +52,17 @@ impl AuthorizationGuardWithContextDefinitions<MessageAuthorizationContext> for M
     /// )
     /// .unwrap();
     ///
-    /// let administrator = User::ActiveUser(ActiveUser::new(
+    /// let administrator: Actor = User::ActiveUser(ActiveUser::new(
     ///     "administrator".to_string(),
     ///     Uuid::new_v4().into(),
     ///     Role::Administrator,
-    /// ));
+    /// )).into();
     ///
-    /// let unrelated_standard_user = User::ActiveUser(ActiveUser::new(
+    /// let unrelated_standard_user: Actor = User::ActiveUser(ActiveUser::new(
     ///     "unrelated_user".to_string(),
     ///     Uuid::new_v4().into(),
     ///     Role::StandardUser,
-    /// ));
+    /// )).into();
     ///
     /// let context = MessageAuthorizationContext {
     ///     related_answer_entry: related_answer,
@@ -72,7 +72,7 @@ impl AuthorizationGuardWithContextDefinitions<MessageAuthorizationContext> for M
     /// assert!(message.can_create(&administrator, &context));
     /// assert!(!message.can_create(&unrelated_standard_user, &context));
     /// ```
-    fn can_create(&self, actor: &User, context: &MessageAuthorizationContext) -> bool {
+    fn can_create(&self, actor: &Actor, context: &MessageAuthorizationContext) -> bool {
         if context.related_answer_entry.id() != self.related_answer_id() {
             tracing::error!("The related answer entry does not match the context.");
 
@@ -81,7 +81,7 @@ impl AuthorizationGuardWithContextDefinitions<MessageAuthorizationContext> for M
 
         matches!(
             actor,
-            User::ActiveUser(actor)
+            Actor::User(User::ActiveUser(actor))
                 if actor.role() == &Administrator
                     || (*actor.id() == *self.sender_id()
                         && context
@@ -109,16 +109,16 @@ impl AuthorizationGuardWithContextDefinitions<MessageAuthorizationContext> for M
     ///         authorization_guard::AuthorizationGuardDefinitions,
     ///         authorization_guard_with_context::AuthorizationGuardWithContextDefinitions,
     ///     },
-    ///     user::models::{ActiveUser, Role, User, UserId},
+    ///     user::models::{ActiveUser, Actor, Role, User, UserId},
     /// };
     /// use uuid::Uuid;
     ///
     /// let respondent_id: UserId = Uuid::new_v4().into();
-    /// let respondent = User::ActiveUser(ActiveUser::new(
+    /// let respondent: Actor = User::ActiveUser(ActiveUser::new(
     ///     "respondent".to_string(),
     ///     respondent_id,
     ///     Role::StandardUser,
-    /// ));
+    /// )).into();
     ///
     /// let related_answer = AnswerEntry::new(
     ///     AnswerAuthor::AuthenticatedUser(respondent_id),
@@ -134,17 +134,17 @@ impl AuthorizationGuardWithContextDefinitions<MessageAuthorizationContext> for M
     /// )
     /// .unwrap();
     ///
-    /// let administrator = User::ActiveUser(ActiveUser::new(
+    /// let administrator: Actor = User::ActiveUser(ActiveUser::new(
     ///     "administrator".to_string(),
     ///     Uuid::new_v4().into(),
     ///     Role::Administrator,
-    /// ));
+    /// )).into();
     ///
-    /// let unrelated_standard_user = User::ActiveUser(ActiveUser::new(
+    /// let unrelated_standard_user: Actor = User::ActiveUser(ActiveUser::new(
     ///     "unrelated_user".to_string(),
     ///     Uuid::new_v4().into(),
     ///     Role::StandardUser,
-    /// ));
+    /// )).into();
     ///
     /// let context = MessageAuthorizationContext {
     ///     related_answer_entry: related_answer,
@@ -154,7 +154,7 @@ impl AuthorizationGuardWithContextDefinitions<MessageAuthorizationContext> for M
     /// assert!(message.can_read(&administrator, &context));
     /// assert!(!message.can_read(&unrelated_standard_user, &context));
     /// ```
-    fn can_read(&self, actor: &User, context: &MessageAuthorizationContext) -> bool {
+    fn can_read(&self, actor: &Actor, context: &MessageAuthorizationContext) -> bool {
         if context.related_answer_entry.id() != self.related_answer_id() {
             tracing::error!("The related answer entry does not match the context.");
 
@@ -163,7 +163,7 @@ impl AuthorizationGuardWithContextDefinitions<MessageAuthorizationContext> for M
 
         matches!(
             actor,
-            User::ActiveUser(actor)
+            Actor::User(User::ActiveUser(actor))
                 if actor.role() == &Administrator
                     || context
                         .related_answer_entry
@@ -192,16 +192,16 @@ impl AuthorizationGuardWithContextDefinitions<MessageAuthorizationContext> for M
     ///         authorization_guard::AuthorizationGuardDefinitions,
     ///         authorization_guard_with_context::AuthorizationGuardWithContextDefinitions,
     ///     },
-    ///     user::models::{ActiveUser, Role, User, UserId},
+    ///     user::models::{ActiveUser, Actor, Role, User, UserId},
     /// };
     /// use uuid::Uuid;
     ///
     /// let respondent_id: UserId = Uuid::new_v4().into();
-    /// let respondent = User::ActiveUser(ActiveUser::new(
+    /// let respondent: Actor = User::ActiveUser(ActiveUser::new(
     ///     "respondent".to_string(),
     ///     respondent_id,
     ///     Role::StandardUser,
-    /// ));
+    /// )).into();
     ///
     /// let related_answer = AnswerEntry::new(
     ///     AnswerAuthor::AuthenticatedUser(respondent_id),
@@ -217,17 +217,17 @@ impl AuthorizationGuardWithContextDefinitions<MessageAuthorizationContext> for M
     /// )
     /// .unwrap();
     ///
-    /// let administrator = User::ActiveUser(ActiveUser::new(
+    /// let administrator: Actor = User::ActiveUser(ActiveUser::new(
     ///     "administrator".to_string(),
     ///     Uuid::new_v4().into(),
     ///     Role::Administrator,
-    /// ));
+    /// )).into();
     ///
-    /// let unrelated_standard_user = User::ActiveUser(ActiveUser::new(
+    /// let unrelated_standard_user: Actor = User::ActiveUser(ActiveUser::new(
     ///     "unrelated_user".to_string(),
     ///     Uuid::new_v4().into(),
     ///     Role::StandardUser,
-    /// ));
+    /// )).into();
     ///
     /// let context = MessageAuthorizationContext {
     ///     related_answer_entry: related_answer,
@@ -237,8 +237,8 @@ impl AuthorizationGuardWithContextDefinitions<MessageAuthorizationContext> for M
     /// assert!(!message.can_update(&administrator, &context));
     /// assert!(!message.can_update(&unrelated_standard_user, &context));
     /// ```
-    fn can_update(&self, actor: &User, _context: &MessageAuthorizationContext) -> bool {
-        matches!(actor, User::ActiveUser(actor) if self.sender_id() == actor.id())
+    fn can_update(&self, actor: &Actor, _context: &MessageAuthorizationContext) -> bool {
+        matches!(actor, Actor::User(User::ActiveUser(actor)) if self.sender_id() == actor.id())
     }
 
     /// [`Message`] の削除権限があるかどうかを判定します。
@@ -260,16 +260,16 @@ impl AuthorizationGuardWithContextDefinitions<MessageAuthorizationContext> for M
     ///         authorization_guard::AuthorizationGuardDefinitions,
     ///         authorization_guard_with_context::AuthorizationGuardWithContextDefinitions,
     ///     },
-    ///     user::models::{ActiveUser, Role, User, UserId},
+    ///     user::models::{ActiveUser, Actor, Role, User, UserId},
     /// };
     /// use uuid::Uuid;
     ///
     /// let respondent_id: UserId = Uuid::new_v4().into();
-    /// let respondent = User::ActiveUser(ActiveUser::new(
+    /// let respondent: Actor = User::ActiveUser(ActiveUser::new(
     ///     "respondent".to_string(),
     ///     respondent_id,
     ///     Role::StandardUser,
-    /// ));
+    /// )).into();
     ///
     /// let related_answer = AnswerEntry::new(
     ///     AnswerAuthor::AuthenticatedUser(respondent_id),
@@ -285,17 +285,17 @@ impl AuthorizationGuardWithContextDefinitions<MessageAuthorizationContext> for M
     /// )
     /// .unwrap();
     ///
-    /// let administrator = User::ActiveUser(ActiveUser::new(
+    /// let administrator: Actor = User::ActiveUser(ActiveUser::new(
     ///     "administrator".to_string(),
     ///     Uuid::new_v4().into(),
     ///     Role::Administrator,
-    /// ));
+    /// )).into();
     ///
-    /// let unrelated_standard_user = User::ActiveUser(ActiveUser::new(
+    /// let unrelated_standard_user: Actor = User::ActiveUser(ActiveUser::new(
     ///     "unrelated_user".to_string(),
     ///     Uuid::new_v4().into(),
     ///     Role::StandardUser,
-    /// ));
+    /// )).into();
     ///
     /// let context = MessageAuthorizationContext {
     ///     related_answer_entry: related_answer,
@@ -305,7 +305,7 @@ impl AuthorizationGuardWithContextDefinitions<MessageAuthorizationContext> for M
     /// assert!(!message.can_delete(&administrator, &context));
     /// assert!(!message.can_delete(&unrelated_standard_user, &context));
     /// ```
-    fn can_delete(&self, actor: &User, _context: &MessageAuthorizationContext) -> bool {
-        matches!(actor, User::ActiveUser(actor) if self.sender_id() == actor.id())
+    fn can_delete(&self, actor: &Actor, _context: &MessageAuthorizationContext) -> bool {
+        matches!(actor, Actor::User(User::ActiveUser(actor)) if self.sender_id() == actor.id())
     }
 }

--- a/server/domain/src/form/models.rs
+++ b/server/domain/src/form/models.rs
@@ -20,11 +20,11 @@ use crate::{
         AnswerSettings, AnswerVisibility, DefaultAnswerTitle, ResponsePeriod,
     },
     types::authorization_guard::AuthorizationGuardDefinitions,
-    user::models::{Role::Administrator, User, UserId},
+    user::models::{Actor, Role::Administrator, User, UserId},
 };
 
-fn is_administrator(actor: &User) -> bool {
-    matches!(actor, User::ActiveUser(user) if user.role() == &Administrator)
+fn is_administrator(actor: &Actor) -> bool {
+    matches!(actor, Actor::User(User::ActiveUser(user)) if user.role() == &Administrator)
 }
 
 pub type FormId = types::Id<ActiveForm>;
@@ -79,8 +79,8 @@ impl FormSettings {
         }
     }
 
-    pub fn webhook_url(&self, user: &User) -> Result<&WebhookUrl, DomainError> {
-        if is_administrator(user) {
+    pub fn webhook_url(&self, actor: &Actor) -> Result<&WebhookUrl, DomainError> {
+        if is_administrator(actor) {
             Ok(&self.webhook_url)
         } else {
             Err(DomainError::Forbidden)
@@ -371,19 +371,19 @@ impl ArchivedForm {
 }
 
 impl AuthorizationGuardDefinitions for ArchivedForm {
-    fn can_create(&self, actor: &User) -> bool {
+    fn can_create(&self, actor: &Actor) -> bool {
         is_administrator(actor)
     }
 
-    fn can_read(&self, actor: &User) -> bool {
+    fn can_read(&self, actor: &Actor) -> bool {
+        matches!(actor, Actor::System) || is_administrator(actor)
+    }
+
+    fn can_update(&self, actor: &Actor) -> bool {
         is_administrator(actor)
     }
 
-    fn can_update(&self, actor: &User) -> bool {
-        is_administrator(actor)
-    }
-
-    fn can_delete(&self, actor: &User) -> bool {
+    fn can_delete(&self, actor: &Actor) -> bool {
         is_administrator(actor)
     }
 }
@@ -399,24 +399,24 @@ impl AuthorizationGuardDefinitions for ActiveForm {
     /// use domain::{
     ///     form::models::{ActiveForm, FormId, FormMeta, FormSettings},
     ///     types::authorization_guard::AuthorizationGuardDefinitions,
-    ///     user::models::{ActiveUser, Role, User},
+    ///     user::models::{ActiveUser, Actor, Role, User},
     /// };
     /// use uuid::Uuid;
     /// use domain::form::models::{FormDescription, FormTitle};
     /// use domain::form::answer::settings::models::{AnswerVisibility, DefaultAnswerTitle, ResponsePeriod};
     /// use domain::form::models::{FormLabelIdSet, Visibility, WebhookUrl};
     ///
-    /// let administrator = User::ActiveUser(ActiveUser::new(
+    /// let administrator: Actor = User::ActiveUser(ActiveUser::new(
     ///     "administrator".to_string(),
     ///     Uuid::new_v4().into(),
     ///     Role::Administrator,
-    /// ));
+    /// )).into();
     ///
-    /// let standard_user = User::ActiveUser(ActiveUser::new(
+    /// let standard_user: Actor = User::ActiveUser(ActiveUser::new(
     ///     "standard_user".to_string(),
     ///     Uuid::new_v4().into(),
     ///     Role::StandardUser,
-    /// ));
+    /// )).into();
     ///
     ///
     /// let form = ActiveForm::from_raw_parts(
@@ -442,7 +442,7 @@ impl AuthorizationGuardDefinitions for ActiveForm {
     /// assert!(form.can_create(&administrator));
     /// assert!(!form.can_create(&standard_user));
     /// ```
-    fn can_create(&self, actor: &User) -> bool {
+    fn can_create(&self, actor: &Actor) -> bool {
         is_administrator(actor)
     }
 
@@ -457,7 +457,7 @@ impl AuthorizationGuardDefinitions for ActiveForm {
     /// use domain::{
     ///     form::models::{ActiveForm, FormSettings},
     ///     types::authorization_guard::AuthorizationGuardDefinitions,
-    ///     user::models::{ActiveUser, Role, User},
+    ///     user::models::{ActiveUser, Actor, Role, User},
     /// };
     /// use uuid::Uuid;
     /// use domain::form::answer::settings::models::{AnswerVisibility, DefaultAnswerTitle, ResponsePeriod};
@@ -466,17 +466,17 @@ impl AuthorizationGuardDefinitions for ActiveForm {
     ///     FormLabelIdSet, FormTitle, Visibility, WebhookUrl
     /// };
     ///
-    /// let administrator = User::ActiveUser(ActiveUser::new(
+    /// let administrator: Actor = User::ActiveUser(ActiveUser::new(
     ///     "administrator".to_string(),
     ///     Uuid::new_v4().into(),
     ///     Role::Administrator,
-    /// ));
+    /// )).into();
     ///
-    /// let standard_user = User::ActiveUser(ActiveUser::new(
+    /// let standard_user: Actor = User::ActiveUser(ActiveUser::new(
     ///     "standard_user".to_string(),
     ///     Uuid::new_v4().into(),
     ///     Role::StandardUser,
-    /// ));
+    /// )).into();
     ///
     ///
     /// let sample_questions = || domain::form::models::QuestionSet::try_new(
@@ -530,8 +530,10 @@ impl AuthorizationGuardDefinitions for ActiveForm {
     /// assert!(public_form.can_read(&administrator));
     /// assert!(public_form.can_read(&standard_user));
     /// ```
-    fn can_read(&self, actor: &User) -> bool {
-        self.settings.visibility == Visibility::PUBLIC || is_administrator(actor)
+    fn can_read(&self, actor: &Actor) -> bool {
+        matches!(actor, Actor::System)
+            || self.settings.visibility == Visibility::PUBLIC
+            || is_administrator(actor)
     }
 
     /// [`ActiveForm`] の更新権限があるかどうかを判定します。
@@ -544,22 +546,22 @@ impl AuthorizationGuardDefinitions for ActiveForm {
     /// use domain::{
     ///     form::models::{ActiveForm, FormId, FormMeta, FormSettings},
     ///     types::authorization_guard::AuthorizationGuardDefinitions,
-    ///     user::models::{ActiveUser, Role, User},
+    ///     user::models::{ActiveUser, Actor, Role, User},
     /// };
     /// use uuid::Uuid;
     /// use domain::form::models::{FormDescription, FormLabelIdSet, FormTitle};
     ///
-    /// let administrator = User::ActiveUser(ActiveUser::new(
+    /// let administrator: Actor = User::ActiveUser(ActiveUser::new(
     ///     "administrator".to_string(),
     ///     Uuid::new_v4().into(),
     ///     Role::Administrator,
-    /// ));
+    /// )).into();
     ///
-    /// let standard_user = User::ActiveUser(ActiveUser::new(
+    /// let standard_user: Actor = User::ActiveUser(ActiveUser::new(
     ///     "standard_user".to_string(),
     ///     Uuid::new_v4().into(),
     ///     Role::StandardUser,
-    /// ));
+    /// )).into();
     ///
     ///
     /// let form = ActiveForm::from_raw_parts(
@@ -585,7 +587,7 @@ impl AuthorizationGuardDefinitions for ActiveForm {
     /// assert!(form.can_update(&administrator));
     /// assert!(!form.can_update(&standard_user));
     /// ```
-    fn can_update(&self, actor: &User) -> bool {
+    fn can_update(&self, actor: &Actor) -> bool {
         is_administrator(actor)
     }
 
@@ -599,22 +601,22 @@ impl AuthorizationGuardDefinitions for ActiveForm {
     /// use domain::{
     ///     form::models::{ActiveForm, FormId, FormMeta, FormSettings},
     ///     types::authorization_guard::AuthorizationGuardDefinitions,
-    ///     user::models::{ActiveUser, Role, User},
+    ///     user::models::{ActiveUser, Actor, Role, User},
     /// };
     /// use uuid::Uuid;
     /// use domain::form::models::{FormDescription, FormLabelIdSet, FormTitle};
     ///
-    /// let administrator = User::ActiveUser(ActiveUser::new(
+    /// let administrator: Actor = User::ActiveUser(ActiveUser::new(
     ///     "administrator".to_string(),
     ///     Uuid::new_v4().into(),
     ///     Role::Administrator,
-    /// ));
+    /// )).into();
     ///
-    /// let standard_user = User::ActiveUser(ActiveUser::new(
+    /// let standard_user: Actor = User::ActiveUser(ActiveUser::new(
     ///     "standard_user".to_string(),
     ///     Uuid::new_v4().into(),
     ///     Role::StandardUser,
-    /// ));
+    /// )).into();
     ///
     ///
     /// let form = ActiveForm::from_raw_parts(
@@ -640,7 +642,7 @@ impl AuthorizationGuardDefinitions for ActiveForm {
     /// assert!(!form.can_delete(&administrator));
     /// assert!(!form.can_delete(&standard_user));
     /// ```
-    fn can_delete(&self, _actor: &User) -> bool {
+    fn can_delete(&self, _actor: &Actor) -> bool {
         false
     }
 }
@@ -690,22 +692,22 @@ impl AuthorizationGuardDefinitions for FormLabel {
     /// use domain::{
     ///     form::models::{FormLabel, FormLabelName},
     ///     types::authorization_guard::AuthorizationGuardDefinitions,
-    ///     user::models::{ActiveUser, Role, User},
+    ///     user::models::{ActiveUser, Actor, Role, User},
     /// };
     /// use types::non_empty_string::NonEmptyString;
     /// use uuid::Uuid;
     ///
-    /// let administrator = User::ActiveUser(ActiveUser::new(
+    /// let administrator: Actor = User::ActiveUser(ActiveUser::new(
     ///     "administrator".to_string(),
     ///     Uuid::new_v4().into(),
     ///     Role::Administrator,
-    /// ));
+    /// )).into();
     ///
-    /// let standard_user = User::ActiveUser(ActiveUser::new(
+    /// let standard_user: Actor = User::ActiveUser(ActiveUser::new(
     ///     "standard_user".to_string(),
     ///     Uuid::new_v4().into(),
     ///     Role::StandardUser,
-    /// ));
+    /// )).into();
     ///
     /// let form_label = FormLabel::new(FormLabelName::new(
     ///     NonEmptyString::try_new("テストラベル".to_string()).unwrap(),
@@ -714,7 +716,7 @@ impl AuthorizationGuardDefinitions for FormLabel {
     /// assert!(form_label.can_create(&administrator));
     /// assert!(!form_label.can_create(&standard_user));
     /// ```
-    fn can_create(&self, actor: &User) -> bool {
+    fn can_create(&self, actor: &Actor) -> bool {
         is_administrator(actor)
     }
 
@@ -726,22 +728,22 @@ impl AuthorizationGuardDefinitions for FormLabel {
     /// use domain::{
     ///     form::models::{FormLabel, FormLabelName},
     ///     types::authorization_guard::AuthorizationGuardDefinitions,
-    ///     user::models::{ActiveUser, Role, User},
+    ///     user::models::{ActiveUser, Actor, Role, User},
     /// };
     /// use types::non_empty_string::NonEmptyString;
     /// use uuid::Uuid;
     ///
-    /// let administrator = User::ActiveUser(ActiveUser::new(
+    /// let administrator: Actor = User::ActiveUser(ActiveUser::new(
     ///     "administrator".to_string(),
     ///     Uuid::new_v4().into(),
     ///     Role::Administrator,
-    /// ));
+    /// )).into();
     ///
-    /// let standard_user = User::ActiveUser(ActiveUser::new(
+    /// let standard_user: Actor = User::ActiveUser(ActiveUser::new(
     ///     "standard_user".to_string(),
     ///     Uuid::new_v4().into(),
     ///     Role::StandardUser,
-    /// ));
+    /// )).into();
     ///
     /// let form_label = FormLabel::new(FormLabelName::new(
     ///     NonEmptyString::try_new("テストラベル".to_string()).unwrap(),
@@ -750,7 +752,7 @@ impl AuthorizationGuardDefinitions for FormLabel {
     /// assert!(form_label.can_read(&administrator));
     /// assert!(form_label.can_read(&standard_user));
     /// ```
-    fn can_read(&self, _actor: &User) -> bool {
+    fn can_read(&self, _actor: &Actor) -> bool {
         true
     }
 
@@ -764,22 +766,22 @@ impl AuthorizationGuardDefinitions for FormLabel {
     /// use domain::{
     ///     form::models::{FormLabel, FormLabelName},
     ///     types::authorization_guard::AuthorizationGuardDefinitions,
-    ///     user::models::{ActiveUser, Role, User},
+    ///     user::models::{ActiveUser, Actor, Role, User},
     /// };
     /// use types::non_empty_string::NonEmptyString;
     /// use uuid::Uuid;
     ///
-    /// let administrator = User::ActiveUser(ActiveUser::new(
+    /// let administrator: Actor = User::ActiveUser(ActiveUser::new(
     ///     "administrator".to_string(),
     ///     Uuid::new_v4().into(),
     ///     Role::Administrator,
-    /// ));
+    /// )).into();
     ///
-    /// let standard_user = User::ActiveUser(ActiveUser::new(
+    /// let standard_user: Actor = User::ActiveUser(ActiveUser::new(
     ///     "standard_user".to_string(),
     ///     Uuid::new_v4().into(),
     ///     Role::StandardUser,
-    /// ));
+    /// )).into();
     ///
     /// let form_label = FormLabel::new(FormLabelName::new(
     ///     NonEmptyString::try_new("テストラベル".to_string()).unwrap(),
@@ -788,7 +790,7 @@ impl AuthorizationGuardDefinitions for FormLabel {
     /// assert!(form_label.can_update(&administrator));
     /// assert!(!form_label.can_update(&standard_user));
     /// ```
-    fn can_update(&self, actor: &User) -> bool {
+    fn can_update(&self, actor: &Actor) -> bool {
         is_administrator(actor)
     }
 
@@ -802,22 +804,22 @@ impl AuthorizationGuardDefinitions for FormLabel {
     /// use domain::{
     ///     form::models::{FormLabel, FormLabelName},
     ///     types::authorization_guard::AuthorizationGuardDefinitions,
-    ///     user::models::{ActiveUser, Role, User},
+    ///     user::models::{ActiveUser, Actor, Role, User},
     /// };
     /// use types::non_empty_string::NonEmptyString;
     /// use uuid::Uuid;
     ///
-    /// let administrator = User::ActiveUser(ActiveUser::new(
+    /// let administrator: Actor = User::ActiveUser(ActiveUser::new(
     ///     "administrator".to_string(),
     ///     Uuid::new_v4().into(),
     ///     Role::Administrator,
-    /// ));
+    /// )).into();
     ///
-    /// let standard_user = User::ActiveUser(ActiveUser::new(
+    /// let standard_user: Actor = User::ActiveUser(ActiveUser::new(
     ///     "standard_user".to_string(),
     ///     Uuid::new_v4().into(),
     ///     Role::StandardUser,
-    /// ));
+    /// )).into();
     ///
     /// let form_label = FormLabel::new(FormLabelName::new(
     ///     NonEmptyString::try_new("テストラベル".to_string()).unwrap(),
@@ -826,7 +828,7 @@ impl AuthorizationGuardDefinitions for FormLabel {
     /// assert!(form_label.can_delete(&administrator));
     /// assert!(!form_label.can_delete(&standard_user));
     /// ```
-    fn can_delete(&self, actor: &User) -> bool {
+    fn can_delete(&self, actor: &Actor) -> bool {
         is_administrator(actor)
     }
 }

--- a/server/domain/src/form/question/models.rs
+++ b/server/domain/src/form/question/models.rs
@@ -10,6 +10,7 @@ use types::non_empty_vec::NonEmptyVec;
 
 use crate::{
     types::authorization_guard::AuthorizationGuardDefinitions,
+    user::models::Actor,
     user::models::{Role, User},
 };
 
@@ -339,20 +340,20 @@ impl Question {
 }
 
 impl AuthorizationGuardDefinitions for Question {
-    fn can_create(&self, actor: &User) -> bool {
-        matches!(actor, User::ActiveUser(actor) if actor.role() == &Role::Administrator)
+    fn can_create(&self, actor: &Actor) -> bool {
+        matches!(actor, Actor::User(User::ActiveUser(actor)) if actor.role() == &Role::Administrator)
     }
 
-    fn can_read(&self, _actor: &User) -> bool {
+    fn can_read(&self, _actor: &Actor) -> bool {
         true
     }
 
-    fn can_update(&self, actor: &User) -> bool {
-        matches!(actor, User::ActiveUser(actor) if actor.role() == &Role::Administrator)
+    fn can_update(&self, actor: &Actor) -> bool {
+        matches!(actor, Actor::User(User::ActiveUser(actor)) if actor.role() == &Role::Administrator)
     }
 
-    fn can_delete(&self, actor: &User) -> bool {
-        matches!(actor, User::ActiveUser(actor) if actor.role() == &Role::Administrator)
+    fn can_delete(&self, actor: &Actor) -> bool {
+        matches!(actor, Actor::User(User::ActiveUser(actor)) if actor.role() == &Role::Administrator)
     }
 }
 

--- a/server/domain/src/form/service.rs
+++ b/server/domain/src/form/service.rs
@@ -12,7 +12,7 @@ use crate::{
         models::{FormId, Question},
     },
     repository::form::active_form_repository::ActiveFormRepository,
-    user::models::User,
+    user::models::{Actor, User},
 };
 
 pub struct DefaultAnswerTitleDomainService<'a, FormRepo: ActiveFormRepository> {
@@ -63,7 +63,7 @@ impl<FormRepo: ActiveFormRepository> DefaultAnswerTitleDomainService<'_, FormRep
 
     pub async fn to_answer_title(
         &self,
-        actor: &User,
+        actor: &Actor,
         form_id: FormId,
         answers: &PostedAnswerContents,
     ) -> Result<AnswerTitle, Error> {
@@ -85,9 +85,9 @@ impl<FormRepo: ActiveFormRepository> DefaultAnswerTitleDomainService<'_, FormRep
             &questions,
             answers,
             match actor {
-                User::ActiveUser(actor) => actor.name(),
-                User::TemporaryUser(actor) => actor.name(),
-                User::Anonymous => unreachable!("Anonymous user cannot submit answers"),
+                Actor::User(User::ActiveUser(actor)) => actor.name(),
+                Actor::User(User::TemporaryUser(actor)) => actor.name(),
+                _ => unreachable!("Only authenticated and temporary users can submit answers"),
             },
         )
     }

--- a/server/domain/src/notification/models.rs
+++ b/server/domain/src/notification/models.rs
@@ -2,7 +2,7 @@ use derive_getters::Getters;
 
 use crate::{
     types::authorization_guard::AuthorizationGuardDefinitions,
-    user::models::{Role, User, UserId},
+    user::models::{Actor, Role, User, UserId},
 };
 
 #[derive(Debug)]
@@ -63,31 +63,31 @@ impl NotificationPreference {
 }
 
 impl AuthorizationGuardDefinitions for NotificationPreference {
-    fn can_create(&self, actor: &User) -> bool {
+    fn can_create(&self, actor: &Actor) -> bool {
         matches!(
             actor,
-            User::ActiveUser(actor)
+            Actor::User(User::ActiveUser(actor))
+                if self.recipient_id() == actor.id() || actor.role() == &Role::Administrator
+        ) || matches!(actor, Actor::System)
+    }
+
+    fn can_read(&self, actor: &Actor) -> bool {
+        matches!(
+            actor,
+            Actor::User(User::ActiveUser(actor))
+                if self.recipient_id() == actor.id() || actor.role() == &Role::Administrator
+        ) || matches!(actor, Actor::System)
+    }
+
+    fn can_update(&self, actor: &Actor) -> bool {
+        matches!(
+            actor,
+            Actor::User(User::ActiveUser(actor))
                 if self.recipient_id() == actor.id() || actor.role() == &Role::Administrator
         )
     }
 
-    fn can_read(&self, actor: &User) -> bool {
-        matches!(
-            actor,
-            User::ActiveUser(actor)
-                if self.recipient_id() == actor.id() || actor.role() == &Role::Administrator
-        )
-    }
-
-    fn can_update(&self, actor: &User) -> bool {
-        matches!(
-            actor,
-            User::ActiveUser(actor)
-                if self.recipient_id() == actor.id() || actor.role() == &Role::Administrator
-        )
-    }
-
-    fn can_delete(&self, _actor: &User) -> bool {
+    fn can_delete(&self, _actor: &Actor) -> bool {
         // NOTE: 明示的に通知設定を削除することはない(削除されるのは User が削除されたときのみ)
         false
     }

--- a/server/domain/src/repository/form/answer_repository.rs
+++ b/server/domain/src/repository/form/answer_repository.rs
@@ -13,7 +13,7 @@ use crate::{
     types::authorization_guard_with_context::{
         AuthorizationGuardWithContext, Create, Read, Update,
     },
-    user::models::{ActiveUser, User},
+    user::models::{ActiveUser, Actor},
 };
 
 #[automock]
@@ -23,7 +23,7 @@ pub trait AnswerRepository: Send + Sync + 'static {
         &self,
         context: &AnswerEntryAuthorizationContext,
         answer: AuthorizationGuardWithContext<AnswerEntry, Create, AnswerEntryAuthorizationContext>,
-        actor: &User,
+        actor: &Actor,
     ) -> Result<(), Error>;
     async fn get_answer(
         &self,

--- a/server/domain/src/types/authorization_guard.rs
+++ b/server/domain/src/types/authorization_guard.rs
@@ -5,10 +5,10 @@ use crate::{
         Actions, AuthorizationGuardWithContext, AuthorizationGuardWithContextDefinitions, Create,
         Delete, Read, Update,
     },
-    user::models::User,
+    user::models::Actor,
 };
 
-/// [`User`] による `guard_target` に対するアクセスを制御するための定義を提供します。
+/// [`Actor`] による `guard_target` に対するアクセスを制御するための定義を提供します。
 ///
 /// [`AuthorizationGuard`] は、Context を必要としない [`AuthorizationGuardWithContext`] であり、
 /// [`AuthorizationGuardWithContext<T, A, ()>`] と同等の機能を提供します。
@@ -25,7 +25,7 @@ impl<T: AuthorizationGuardDefinitions> AuthorizationGuard<T, Create> {
     }
 
     /// [`AuthorizationGuardDefinitions::can_create`] の条件で作成操作 `f` を試みます。
-    pub fn try_create<'a, R, F>(&'a self, actor: &User, f: F) -> Result<R, DomainError>
+    pub fn try_create<'a, R, F>(&'a self, actor: &Actor, f: F) -> Result<R, DomainError>
     where
         F: FnOnce(&'a T) -> R,
     {
@@ -35,7 +35,7 @@ impl<T: AuthorizationGuardDefinitions> AuthorizationGuard<T, Create> {
 
     /// [`AuthorizationGuardDefinitions::can_create`] の条件で作成操作 `f` を試みます。
     /// この関数は、`guard_target` を所有権を持つ形で操作を行います。
-    pub fn try_into_create<R, F>(self, actor: &User, f: F) -> Result<R, DomainError>
+    pub fn try_into_create<R, F>(self, actor: &Actor, f: F) -> Result<R, DomainError>
     where
         F: FnOnce(T) -> R,
     {
@@ -59,7 +59,7 @@ impl<T: AuthorizationGuardDefinitions> AuthorizationGuard<T, Create> {
 
 impl<T: AuthorizationGuardDefinitions> AuthorizationGuard<T, Update> {
     /// [`AuthorizationGuardDefinitions::can_update`] の条件で更新操作 `f` を試みます。
-    pub fn try_update<'a, R, F>(&'a self, actor: &User, f: F) -> Result<R, DomainError>
+    pub fn try_update<'a, R, F>(&'a self, actor: &Actor, f: F) -> Result<R, DomainError>
     where
         F: FnOnce(&'a T) -> R,
     {
@@ -69,7 +69,7 @@ impl<T: AuthorizationGuardDefinitions> AuthorizationGuard<T, Update> {
 
     /// [`AuthorizationGuardDefinitions::can_update`] の条件で更新操作 `f` を試みます。
     /// この関数は、`guard_target` を所有権を持つ形で操作を行います。
-    pub fn try_into_update<R, F>(self, actor: &User, f: F) -> Result<R, DomainError>
+    pub fn try_into_update<R, F>(self, actor: &Actor, f: F) -> Result<R, DomainError>
     where
         F: FnOnce(T) -> R,
     {
@@ -104,12 +104,12 @@ impl<T: AuthorizationGuardDefinitions> AuthorizationGuard<T, Update> {
 
 impl<T: AuthorizationGuardDefinitions> AuthorizationGuard<T, Read> {
     /// `actor` が `guard_target` の参照を取得することを試みます。
-    pub fn try_read(&self, actor: &User) -> Result<&T, DomainError> {
+    pub fn try_read(&self, actor: &Actor) -> Result<&T, DomainError> {
         self.authorization_guard_with_context.try_read(actor, &())
     }
 
     /// `actor` が `guard_target` を取得することを試みます。
-    pub fn try_into_read(self, actor: &User) -> Result<T, DomainError> {
+    pub fn try_into_read(self, actor: &Actor) -> Result<T, DomainError> {
         self.authorization_guard_with_context
             .try_into_read(actor, &())
     }
@@ -127,27 +127,11 @@ impl<T: AuthorizationGuardDefinitions> AuthorizationGuard<T, Read> {
             authorization_guard_with_context: self.authorization_guard_with_context.into_delete(),
         }
     }
-
-    /// 認可処理を行わずに、`guard_target` の参照を取得します。
-    ///
-    /// # Safety
-    /// システム側で実行する処理で、認可を必要としない場合にのみ使用してください。
-    pub unsafe fn read_unchecked(&self) -> &T {
-        unsafe { self.authorization_guard_with_context.read_unchecked() }
-    }
-
-    /// 認可処理を行わずに、所有権を含めて `guard_target` を取得します。
-    ///
-    /// # Safety
-    /// システム側で実行する処理で、認可を必要としない場合にのみ使用してください。
-    pub unsafe fn into_read_unchecked(self) -> T {
-        unsafe { self.authorization_guard_with_context.into_read_unchecked() }
-    }
 }
 
 impl<T: AuthorizationGuardDefinitions> AuthorizationGuard<T, Delete> {
     /// [`AuthorizationGuardDefinitions::can_delete`] の条件で削除操作 `f` を試みます。
-    pub fn try_delete<'a, R, F>(&'a self, actor: &User, f: F) -> Result<R, DomainError>
+    pub fn try_delete<'a, R, F>(&'a self, actor: &Actor, f: F) -> Result<R, DomainError>
     where
         F: FnOnce(&'a T) -> R,
     {
@@ -157,7 +141,7 @@ impl<T: AuthorizationGuardDefinitions> AuthorizationGuard<T, Delete> {
 
     /// [`AuthorizationGuardDefinitions::can_delete`] の条件で削除操作 `f` を試みます。
     /// この関数は、`guard_target` を所有権を持つ形で操作を行います。
-    pub fn try_into_delete<R, F>(self, actor: &User, f: F) -> Result<R, DomainError>
+    pub fn try_into_delete<R, F>(self, actor: &Actor, f: F) -> Result<R, DomainError>
     where
         F: FnOnce(T) -> R,
     {
@@ -172,7 +156,7 @@ impl<T: AuthorizationGuardDefinitions> AuthorizationGuard<T, Delete> {
 /// ```
 /// use domain::{
 ///     types::authorization_guard::AuthorizationGuardDefinitions,
-///     user::models::{Role, User, UserId},
+///     user::models::{Actor, Role, User, UserId},
 /// };
 /// use uuid::Uuid;
 ///
@@ -181,47 +165,47 @@ impl<T: AuthorizationGuardDefinitions> AuthorizationGuard<T, Delete> {
 /// }
 ///
 /// impl AuthorizationGuardDefinitions for GuardTarget {
-///     fn can_create(&self, actor: &User) -> bool {
-///         matches!(actor, User::ActiveUser(u) if u.role() == &Role::Administrator)
+///     fn can_create(&self, actor: &Actor) -> bool {
+///         matches!(actor, Actor::User(User::ActiveUser(u)) if u.role() == &Role::Administrator)
 ///     }
 ///
-///     fn can_read(&self, actor: &User) -> bool {
-///         matches!(actor, User::ActiveUser(u) if *u.id() == self.user_id)
+///     fn can_read(&self, actor: &Actor) -> bool {
+///         matches!(actor, Actor::User(User::ActiveUser(u)) if *u.id() == self.user_id)
 ///     }
 ///
-///     fn can_update(&self, actor: &User) -> bool {
-///         matches!(actor, User::ActiveUser(u) if *u.id() == self.user_id)
+///     fn can_update(&self, actor: &Actor) -> bool {
+///         matches!(actor, Actor::User(User::ActiveUser(u)) if *u.id() == self.user_id)
 ///     }
 ///
-///     fn can_delete(&self, actor: &User) -> bool {
-///         matches!(actor, User::ActiveUser(u) if *u.id() == self.user_id)
+///     fn can_delete(&self, actor: &Actor) -> bool {
+///         matches!(actor, Actor::User(User::ActiveUser(u)) if *u.id() == self.user_id)
 ///     }
 /// }
 /// ```
 pub trait AuthorizationGuardDefinitions {
-    fn can_create(&self, actor: &User) -> bool;
-    fn can_read(&self, actor: &User) -> bool;
-    fn can_update(&self, actor: &User) -> bool;
-    fn can_delete(&self, actor: &User) -> bool;
+    fn can_create(&self, actor: &Actor) -> bool;
+    fn can_read(&self, actor: &Actor) -> bool;
+    fn can_update(&self, actor: &Actor) -> bool;
+    fn can_delete(&self, actor: &Actor) -> bool;
 }
 
 impl<T> AuthorizationGuardWithContextDefinitions<()> for T
 where
     T: AuthorizationGuardDefinitions,
 {
-    fn can_create(&self, actor: &User, _context: &()) -> bool {
+    fn can_create(&self, actor: &Actor, _context: &()) -> bool {
         self.can_create(actor)
     }
 
-    fn can_read(&self, actor: &User, _context: &()) -> bool {
+    fn can_read(&self, actor: &Actor, _context: &()) -> bool {
         self.can_read(actor)
     }
 
-    fn can_update(&self, actor: &User, _context: &()) -> bool {
+    fn can_update(&self, actor: &Actor, _context: &()) -> bool {
         self.can_update(actor)
     }
 
-    fn can_delete(&self, actor: &User, _context: &()) -> bool {
+    fn can_delete(&self, actor: &Actor, _context: &()) -> bool {
         self.can_delete(actor)
     }
 }
@@ -266,7 +250,7 @@ mod test {
 
     use crate::{
         types::authorization_guard::{AuthorizationGuard, AuthorizationGuardDefinitions},
-        user::models::{ActiveUser, Role, User},
+        user::models::{ActiveUser, Actor, Role, User},
     };
 
     #[derive(Clone, PartialEq, Debug)]
@@ -275,41 +259,43 @@ mod test {
     }
 
     impl AuthorizationGuardDefinitions for AuthorizationGuardTestStruct {
-        fn can_create(&self, actor: &User) -> bool {
-            matches!(actor, User::ActiveUser(actor) if actor.role() == &Role::Administrator)
+        fn can_create(&self, actor: &Actor) -> bool {
+            matches!(actor, Actor::User(User::ActiveUser(actor)) if actor.role() == &Role::Administrator)
         }
 
-        fn can_read(&self, actor: &User) -> bool {
+        fn can_read(&self, actor: &Actor) -> bool {
             matches!(
                 actor,
-                User::ActiveUser(actor)
+                Actor::User(User::ActiveUser(actor))
                     if actor.role() == &Role::Administrator
                         || actor.role() == &Role::StandardUser
             )
         }
 
-        fn can_update(&self, actor: &User) -> bool {
-            matches!(actor, User::ActiveUser(actor) if actor.role() == &Role::Administrator)
+        fn can_update(&self, actor: &Actor) -> bool {
+            matches!(actor, Actor::User(User::ActiveUser(actor)) if actor.role() == &Role::Administrator)
         }
 
-        fn can_delete(&self, actor: &User) -> bool {
-            matches!(actor, User::ActiveUser(actor) if actor.role() == &Role::Administrator)
+        fn can_delete(&self, actor: &Actor) -> bool {
+            matches!(actor, Actor::User(User::ActiveUser(actor)) if actor.role() == &Role::Administrator)
         }
     }
 
     #[test]
     fn authorization_guard_test() {
-        let admin = User::ActiveUser(ActiveUser::new(
+        let admin: Actor = ActiveUser::new(
             "admin".to_string(),
             Uuid::new_v4().into(),
             Role::Administrator,
-        ));
+        )
+        .into();
 
-        let standard_user = User::ActiveUser(ActiveUser::new(
+        let standard_user: Actor = ActiveUser::new(
             "standard_user".to_string(),
             Uuid::new_v4().into(),
             Role::StandardUser,
-        ));
+        )
+        .into();
 
         let guard = AuthorizationGuard::new(AuthorizationGuardTestStruct {
             _value: "test".to_string(),
@@ -333,11 +319,12 @@ mod test {
 
     #[test]
     fn verify_same_data_for_try_read_and_try_into_read() {
-        let user = User::ActiveUser(ActiveUser::new(
+        let user: Actor = ActiveUser::new(
             "user".to_string(),
             Uuid::new_v4().into(),
             Role::Administrator,
-        ));
+        )
+        .into();
 
         let guard = AuthorizationGuard::new(AuthorizationGuardTestStruct {
             _value: "test".to_string(),

--- a/server/domain/src/types/authorization_guard_with_context.rs
+++ b/server/domain/src/types/authorization_guard_with_context.rs
@@ -2,7 +2,7 @@ use std::future::Future;
 
 use errors::{Error, domain::DomainError};
 
-use crate::user::models::User;
+use crate::user::models::Actor;
 
 pub trait Actions: private::Sealed {}
 
@@ -68,7 +68,7 @@ impl<T: AuthorizationGuardWithContextDefinitions<Context>, Context>
     /// [`AuthorizationGuardWithContextDefinitions::can_create`] の条件で作成操作 `f` を試みます。
     pub fn try_create<'a, R, F>(
         &'a self,
-        actor: &User,
+        actor: &Actor,
         f: F,
         context: &Context,
     ) -> Result<R, DomainError>
@@ -86,7 +86,7 @@ impl<T: AuthorizationGuardWithContextDefinitions<Context>, Context>
     /// この関数は、`guard_target` を所有権を持つ形で操作を行います。
     pub fn try_into_create<R, F>(
         self,
-        actor: &User,
+        actor: &Actor,
         f: F,
         context: &Context,
     ) -> Result<R, DomainError>
@@ -122,7 +122,7 @@ impl<T: AuthorizationGuardWithContextDefinitions<Context>, Context>
     /// [`AuthorizationGuardWithContextDefinitions::can_update`] の条件で更新操作 `f` を試みます。
     pub fn try_update<'a, R, F>(
         &'a self,
-        actor: &User,
+        actor: &Actor,
         f: F,
         context: &Context,
     ) -> Result<R, DomainError>
@@ -140,7 +140,7 @@ impl<T: AuthorizationGuardWithContextDefinitions<Context>, Context>
     /// この関数は、`guard_target` を所有権を持つ形で操作を行います。
     pub fn try_into_update<R, F>(
         self,
-        actor: &User,
+        actor: &Actor,
         f: F,
         context: &Context,
     ) -> Result<R, DomainError>
@@ -186,7 +186,7 @@ impl<T: AuthorizationGuardWithContextDefinitions<Context>, Context>
     AuthorizationGuardWithContext<T, Read, Context>
 {
     /// `actor` が `guard_target` の参照を取得することを試みます。
-    pub fn try_read(&self, actor: &User, context: &Context) -> Result<&T, DomainError> {
+    pub fn try_read(&self, actor: &Actor, context: &Context) -> Result<&T, DomainError> {
         if self.guard_target.can_read(actor, context) {
             Ok(&self.guard_target)
         } else {
@@ -195,7 +195,7 @@ impl<T: AuthorizationGuardWithContextDefinitions<Context>, Context>
     }
 
     /// `actor` が `guard_target` を取得することを試みます。
-    pub fn try_into_read(self, actor: &User, context: &Context) -> Result<T, DomainError> {
+    pub fn try_into_read(self, actor: &Actor, context: &Context) -> Result<T, DomainError> {
         if self.guard_target.can_read(actor, context) {
             Ok(self.guard_target)
         } else {
@@ -205,7 +205,7 @@ impl<T: AuthorizationGuardWithContextDefinitions<Context>, Context>
 
     pub async fn try_into_read_with_context_fn<Fut>(
         self,
-        actor: &User,
+        actor: &Actor,
         context_fn: impl FnOnce(&T) -> Fut,
     ) -> Result<T, Error>
     where
@@ -218,6 +218,17 @@ impl<T: AuthorizationGuardWithContextDefinitions<Context>, Context>
             Ok(self.guard_target)
         } else {
             Err(Error::from(DomainError::Forbidden))
+        }
+    }
+
+    /// [`Actor::System`] として `guard_target` を取得します。
+    ///
+    /// コンテキストを必要としないシステム処理（検索インデックスの同期など）で使用します。
+    /// [`Actor::System`] 以外の actor では [`DomainError::Forbidden`] を返します。
+    pub fn try_into_read_as_system(self, actor: &Actor) -> Result<T, DomainError> {
+        match actor {
+            Actor::System => Ok(self.guard_target),
+            _ => Err(DomainError::Forbidden),
         }
     }
 
@@ -236,22 +247,6 @@ impl<T: AuthorizationGuardWithContextDefinitions<Context>, Context>
             _phantom_data: std::marker::PhantomData,
         }
     }
-
-    /// 認可処理を行わずに、`guard_target` の参照を取得します。
-    ///
-    /// # Safety
-    /// システム側で実行する処理で、認可を必要としない場合にのみ使用してください。
-    pub unsafe fn read_unchecked(&self) -> &T {
-        &self.guard_target
-    }
-
-    /// 認可処理を行わずに、所有権を含めて `guard_target` を取得します。
-    ///
-    /// # Safety
-    /// システム側で実行する処理で、認可を必要としない場合にのみ使用してください。
-    pub unsafe fn into_read_unchecked(self) -> T {
-        self.guard_target
-    }
 }
 
 impl<T: AuthorizationGuardWithContextDefinitions<Context>, Context>
@@ -260,7 +255,7 @@ impl<T: AuthorizationGuardWithContextDefinitions<Context>, Context>
     /// [`AuthorizationGuardWithContextDefinitions::can_delete`] の条件で削除操作 `f` を試みます。
     pub fn try_delete<'a, R, F>(
         &'a self,
-        actor: &User,
+        actor: &Actor,
         f: F,
         context: &Context,
     ) -> Result<R, DomainError>
@@ -278,7 +273,7 @@ impl<T: AuthorizationGuardWithContextDefinitions<Context>, Context>
     /// この関数は、`guard_target` を所有権を持つ形で操作を行います。
     pub fn try_into_delete<R, F>(
         self,
-        actor: &User,
+        actor: &Actor,
         f: F,
         context: &Context,
     ) -> Result<R, DomainError>
@@ -306,28 +301,28 @@ impl<T: AuthorizationGuardWithContextDefinitions<Context>, Action: Actions, Cont
         context_fn(&self.guard_target).await
     }
 
-    pub fn can_create(&self, actor: &User, context: &Context) -> bool {
+    pub fn can_create(&self, actor: &Actor, context: &Context) -> bool {
         self.guard_target.can_create(actor, context)
     }
 
-    pub fn can_read(&self, actor: &User, context: &Context) -> bool {
+    pub fn can_read(&self, actor: &Actor, context: &Context) -> bool {
         self.guard_target.can_read(actor, context)
     }
 
-    pub fn can_update(&self, actor: &User, context: &Context) -> bool {
+    pub fn can_update(&self, actor: &Actor, context: &Context) -> bool {
         self.guard_target.can_update(actor, context)
     }
 
-    pub fn can_delete(&self, actor: &User, context: &Context) -> bool {
+    pub fn can_delete(&self, actor: &Actor, context: &Context) -> bool {
         self.guard_target.can_delete(actor, context)
     }
 }
 
 pub trait AuthorizationGuardWithContextDefinitions<Context> {
-    fn can_create(&self, actor: &User, context: &Context) -> bool;
-    fn can_read(&self, actor: &User, context: &Context) -> bool;
-    fn can_update(&self, actor: &User, context: &Context) -> bool;
-    fn can_delete(&self, actor: &User, context: &Context) -> bool;
+    fn can_create(&self, actor: &Actor, context: &Context) -> bool;
+    fn can_read(&self, actor: &Actor, context: &Context) -> bool;
+    fn can_update(&self, actor: &Actor, context: &Context) -> bool;
+    fn can_delete(&self, actor: &Actor, context: &Context) -> bool;
 }
 
 #[cfg(test)]
@@ -338,7 +333,7 @@ mod test {
         types::authorization_guard_with_context::{
             AuthorizationGuardWithContext, AuthorizationGuardWithContextDefinitions, Create,
         },
-        user::models::{ActiveUser, Role, User},
+        user::models::{ActiveUser, Actor, Role, User},
     };
 
     #[derive(Clone, PartialEq, Debug)]
@@ -350,41 +345,43 @@ mod test {
     struct Context {}
 
     impl AuthorizationGuardWithContextDefinitions<Context> for AuthorizationGuardWithContextTestStruct {
-        fn can_create(&self, actor: &User, _context: &Context) -> bool {
-            matches!(actor, User::ActiveUser(actor) if actor.role() == &Role::Administrator)
+        fn can_create(&self, actor: &Actor, _context: &Context) -> bool {
+            matches!(actor, Actor::User(User::ActiveUser(actor)) if actor.role() == &Role::Administrator)
         }
 
-        fn can_read(&self, actor: &User, _context: &Context) -> bool {
+        fn can_read(&self, actor: &Actor, _context: &Context) -> bool {
             matches!(
                 actor,
-                User::ActiveUser(actor)
+                Actor::User(User::ActiveUser(actor))
                     if actor.role() == &Role::Administrator
                         || actor.role() == &Role::StandardUser
             )
         }
 
-        fn can_update(&self, actor: &User, _context: &Context) -> bool {
-            matches!(actor, User::ActiveUser(actor) if actor.role() == &Role::Administrator)
+        fn can_update(&self, actor: &Actor, _context: &Context) -> bool {
+            matches!(actor, Actor::User(User::ActiveUser(actor)) if actor.role() == &Role::Administrator)
         }
 
-        fn can_delete(&self, actor: &User, _context: &Context) -> bool {
-            matches!(actor, User::ActiveUser(actor) if actor.role() == &Role::Administrator)
+        fn can_delete(&self, actor: &Actor, _context: &Context) -> bool {
+            matches!(actor, Actor::User(User::ActiveUser(actor)) if actor.role() == &Role::Administrator)
         }
     }
 
     #[test]
     fn authorization_guard_test() {
-        let admin = User::ActiveUser(ActiveUser::new(
+        let admin: Actor = ActiveUser::new(
             "admin".to_string(),
             Uuid::new_v4().into(),
             Role::Administrator,
-        ));
+        )
+        .into();
 
-        let standard_user = User::ActiveUser(ActiveUser::new(
+        let standard_user: Actor = ActiveUser::new(
             "standard_user".to_string(),
             Uuid::new_v4().into(),
             Role::StandardUser,
-        ));
+        )
+        .into();
 
         let context = Context {};
 
@@ -410,11 +407,12 @@ mod test {
 
     #[test]
     fn verify_same_data_for_try_read_and_try_into_read() {
-        let user = User::ActiveUser(ActiveUser::new(
+        let user: Actor = ActiveUser::new(
             "user".to_string(),
             Uuid::new_v4().into(),
             Role::Administrator,
-        ));
+        )
+        .into();
 
         let context = Context {};
 

--- a/server/domain/src/user/models.rs
+++ b/server/domain/src/user/models.rs
@@ -55,6 +55,12 @@ pub enum User {
     Anonymous,
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub enum Actor {
+    User(User),
+    System,
+}
+
 impl From<ActiveUser> for User {
     fn from(user: ActiveUser) -> Self {
         Self::ActiveUser(user)
@@ -64,6 +70,24 @@ impl From<ActiveUser> for User {
 impl From<TemporaryUser> for User {
     fn from(user: TemporaryUser) -> Self {
         Self::TemporaryUser(user)
+    }
+}
+
+impl From<ActiveUser> for Actor {
+    fn from(user: ActiveUser) -> Self {
+        Self::User(User::ActiveUser(user))
+    }
+}
+
+impl From<TemporaryUser> for Actor {
+    fn from(user: TemporaryUser) -> Self {
+        Self::User(User::TemporaryUser(user))
+    }
+}
+
+impl From<User> for Actor {
+    fn from(user: User) -> Self {
+        Self::User(user)
     }
 }
 
@@ -114,20 +138,20 @@ impl TemporaryUser {
 }
 
 impl AuthorizationGuardDefinitions for ActiveUser {
-    fn can_create(&self, actor: &User) -> bool {
-        matches!(actor, User::ActiveUser(actor) if actor == self)
+    fn can_create(&self, actor: &Actor) -> bool {
+        matches!(actor, Actor::User(User::ActiveUser(actor)) if actor == self)
     }
 
-    fn can_read(&self, _actor: &User) -> bool {
+    fn can_read(&self, _actor: &Actor) -> bool {
         true
     }
 
-    fn can_update(&self, actor: &User) -> bool {
-        matches!(actor, User::ActiveUser(actor) if actor == self)
+    fn can_update(&self, actor: &Actor) -> bool {
+        matches!(actor, Actor::User(User::ActiveUser(actor)) if actor == self)
     }
 
-    fn can_delete(&self, actor: &User) -> bool {
-        matches!(actor, User::ActiveUser(actor) if actor == self)
+    fn can_delete(&self, actor: &Actor) -> bool {
+        matches!(actor, Actor::User(User::ActiveUser(actor)) if actor == self)
     }
 }
 

--- a/server/infra/resource/src/database/forms/form.rs
+++ b/server/infra/resource/src/database/forms/form.rs
@@ -351,7 +351,7 @@ async fn update_form_root(
 
     let webhook_url = form
         .settings()
-        .webhook_url(&domain::user::models::User::ActiveUser(updated_by.clone()))
+        .webhook_url(&domain::user::models::Actor::from(updated_by.clone()))
         .ok()
         .map(ToOwned::to_owned)
         .and_then(WebhookUrl::into_inner)

--- a/server/infra/resource/src/repository/form_repository_impls/answer_label_repository_impl.rs
+++ b/server/infra/resource/src/repository/form_repository_impls/answer_label_repository_impl.rs
@@ -6,7 +6,7 @@ use domain::{
         authorization_guard::AuthorizationGuard,
         authorization_guard_with_context::{Create, Delete, Read, Update},
     },
-    user::models::{ActiveUser, User},
+    user::models::{ActiveUser, Actor},
 };
 use errors::Error;
 use itertools::Itertools;
@@ -24,7 +24,7 @@ impl<Client: DatabaseComponents + 'static> AnswerLabelRepository for Repository<
         actor: &ActiveUser,
         label: AuthorizationGuard<AnswerLabel, Create>,
     ) -> Result<(), Error> {
-        let actor_user = User::from(actor.clone());
+        let actor_user = Actor::from(actor.clone());
         label
             .try_create(&actor_user, |label| {
                 self.client
@@ -100,7 +100,7 @@ impl<Client: DatabaseComponents + 'static> AnswerLabelRepository for Repository<
         actor: &ActiveUser,
         label: AuthorizationGuard<AnswerLabel, Delete>,
     ) -> Result<(), Error> {
-        let actor_user = User::from(actor.clone());
+        let actor_user = Actor::from(actor.clone());
         label
             .try_delete(&actor_user, |label| {
                 self.client
@@ -117,7 +117,7 @@ impl<Client: DatabaseComponents + 'static> AnswerLabelRepository for Repository<
         actor: &ActiveUser,
         label: AuthorizationGuard<AnswerLabel, Update>,
     ) -> Result<(), Error> {
-        let actor_user = User::from(actor.clone());
+        let actor_user = Actor::from(actor.clone());
         label
             .try_update(&actor_user, |label| {
                 self.client
@@ -135,7 +135,7 @@ impl<Client: DatabaseComponents + 'static> AnswerLabelRepository for Repository<
         answer_id: AnswerId,
         labels: Vec<AuthorizationGuard<AnswerLabel, Update>>,
     ) -> Result<(), Error> {
-        let actor_user = User::from(actor.clone());
+        let actor_user = Actor::from(actor.clone());
         let label_ids = labels
             .into_iter()
             .map(|guard| guard.try_into_update(&actor_user, |label| *label.id()))

--- a/server/infra/resource/src/repository/form_repository_impls/answer_repository_impl.rs
+++ b/server/infra/resource/src/repository/form_repository_impls/answer_repository_impl.rs
@@ -11,7 +11,7 @@ use domain::{
     types::authorization_guard_with_context::{
         AuthorizationGuardWithContext, Create, Read, Update,
     },
-    user::models::{ActiveUser, User},
+    user::models::{ActiveUser, Actor},
 };
 use errors::Error;
 use itertools::Itertools;
@@ -28,7 +28,7 @@ impl<Client: DatabaseComponents + 'static> AnswerRepository for Repository<Clien
         &self,
         context: &AnswerEntryAuthorizationContext,
         answer: AuthorizationGuardWithContext<AnswerEntry, Create, AnswerEntryAuthorizationContext>,
-        actor: &User,
+        actor: &Actor,
     ) -> Result<(), Error> {
         answer
             .try_create(
@@ -110,7 +110,7 @@ impl<Client: DatabaseComponents + 'static> AnswerRepository for Repository<Clien
             AnswerEntryAuthorizationContext,
         >,
     ) -> Result<(), Error> {
-        let actor_user = User::from(actor.clone());
+        let actor_user = Actor::from(actor.clone());
         answer_entry
             .try_update(
                 &actor_user,

--- a/server/infra/resource/src/repository/form_repository_impls/comment_repository_impl.rs
+++ b/server/infra/resource/src/repository/form_repository_impls/comment_repository_impl.rs
@@ -16,7 +16,7 @@ use domain::{
     types::authorization_guard_with_context::{
         AuthorizationGuardWithContext, Create, Delete, Read,
     },
-    user::models::{ActiveUser, User},
+    user::models::{ActiveUser, Actor},
 };
 use errors::Error;
 use itertools::Itertools;
@@ -84,7 +84,7 @@ impl<Client: DatabaseComponents + 'static> CommentRepository for Repository<Clie
         actor: &ActiveUser,
         comment: AuthorizationGuardWithContext<Comment, Create, CommentAuthorizationContext<Read>>,
     ) -> Result<(), Error> {
-        let actor_user = User::from(actor.clone());
+        let actor_user = Actor::from(actor.clone());
         comment
             .try_create(
                 &actor_user,
@@ -107,7 +107,7 @@ impl<Client: DatabaseComponents + 'static> CommentRepository for Repository<Clie
         actor: &ActiveUser,
         comment: AuthorizationGuardWithContext<Comment, Update, CommentAuthorizationContext<Read>>,
     ) -> Result<(), Error> {
-        let actor_user = User::from(actor.clone());
+        let actor_user = Actor::from(actor.clone());
         comment
             .try_update(
                 &actor_user,
@@ -129,7 +129,7 @@ impl<Client: DatabaseComponents + 'static> CommentRepository for Repository<Clie
         actor: &ActiveUser,
         comment: AuthorizationGuardWithContext<Comment, Delete, CommentAuthorizationContext<Read>>,
     ) -> Result<(), Error> {
-        let actor_user = User::from(actor.clone());
+        let actor_user = Actor::from(actor.clone());
         comment
             .try_delete(
                 &actor_user,

--- a/server/infra/resource/src/repository/form_repository_impls/form_label_repository_impl.rs
+++ b/server/infra/resource/src/repository/form_repository_impls/form_label_repository_impl.rs
@@ -6,7 +6,7 @@ use domain::{
         authorization_guard::AuthorizationGuard,
         authorization_guard_with_context::{Create, Delete, Read, Update},
     },
-    user::models::{ActiveUser, User},
+    user::models::{ActiveUser, Actor},
 };
 use errors::Error;
 use itertools::Itertools;
@@ -24,7 +24,7 @@ impl<Client: DatabaseComponents + 'static> FormLabelRepository for Repository<Cl
         label: AuthorizationGuard<FormLabel, Create>,
         actor: &ActiveUser,
     ) -> Result<(), Error> {
-        let actor_user = User::from(actor.clone());
+        let actor_user = Actor::from(actor.clone());
         label
             .try_create(&actor_user, |label| {
                 self.client.form_label().create_label_for_forms(label)
@@ -81,7 +81,7 @@ impl<Client: DatabaseComponents + 'static> FormLabelRepository for Repository<Cl
         label: AuthorizationGuard<FormLabel, Delete>,
         actor: &ActiveUser,
     ) -> Result<(), Error> {
-        let actor_user = User::from(actor.clone());
+        let actor_user = Actor::from(actor.clone());
         label
             .try_into_delete(&actor_user, |label| {
                 self.client
@@ -99,7 +99,7 @@ impl<Client: DatabaseComponents + 'static> FormLabelRepository for Repository<Cl
         label: AuthorizationGuard<FormLabel, Update>,
         actor: &ActiveUser,
     ) -> Result<(), Error> {
-        let actor_user = User::from(actor.clone());
+        let actor_user = Actor::from(actor.clone());
         label
             .try_update(&actor_user, |label| {
                 self.client

--- a/server/infra/resource/src/repository/form_repository_impls/form_repository_impl.rs
+++ b/server/infra/resource/src/repository/form_repository_impls/form_repository_impl.rs
@@ -9,7 +9,7 @@ use domain::{
         authorization_guard::AuthorizationGuard,
         authorization_guard_with_context::{Create, Read, Update},
     },
-    user::models::{ActiveUser, User},
+    user::models::{ActiveUser, Actor},
 };
 use errors::Error;
 
@@ -32,7 +32,7 @@ where
         actor: &ActiveUser,
         form: AuthorizationGuard<ActiveForm, Create>,
     ) -> Result<(), Error> {
-        let actor_user = User::from(actor.clone());
+        let actor_user = Actor::from(actor.clone());
         let form = form.try_into_create(&actor_user, |form| form)?;
         self.client.form().create(&form, actor).await?;
         Ok(())
@@ -75,7 +75,7 @@ where
         actor: &ActiveUser,
         updated_form: AuthorizationGuard<ActiveForm, Update>,
     ) -> Result<(), Error> {
-        let actor_user = User::from(actor.clone());
+        let actor_user = Actor::from(actor.clone());
         let updated_form = updated_form.try_into_update(&actor_user, |form| form)?;
         self.client.form().update(&updated_form, actor).await?;
         Ok(())
@@ -133,7 +133,7 @@ where
         actor: &ActiveUser,
         form: AuthorizationGuard<ArchivedForm, Create>,
     ) -> Result<AuthorizationGuard<ArchivedForm, Read>, Error> {
-        let actor_user = User::from(actor.clone());
+        let actor_user = Actor::from(actor.clone());
         let form = form.try_into_create(&actor_user, |form| form)?;
         let archived_form = self.client.form().archive(&form).await?;
         Ok(AuthorizationGuard::<ArchivedForm, Create>::from(archived_form).into_read())
@@ -145,7 +145,7 @@ where
         actor: &ActiveUser,
         form: AuthorizationGuard<ArchivedForm, Update>,
     ) -> Result<(), Error> {
-        let actor_user = User::from(actor.clone());
+        let actor_user = Actor::from(actor.clone());
         let form = form.try_into_update(&actor_user, |form| form)?;
         let form_id = *form.form().id();
         let _restored = form.unarchive();

--- a/server/infra/resource/src/repository/form_repository_impls/message_repository_impl.rs
+++ b/server/infra/resource/src/repository/form_repository_impls/message_repository_impl.rs
@@ -11,7 +11,7 @@ use domain::{
     types::authorization_guard_with_context::{
         AuthorizationGuardWithContext, Create, Delete, Read, Update,
     },
-    user::models::{ActiveUser, User},
+    user::models::{ActiveUser, Actor},
 };
 use errors::Error;
 
@@ -29,7 +29,7 @@ impl<Client: DatabaseComponents + 'static> MessageRepository for Repository<Clie
         context: &MessageAuthorizationContext,
         message: AuthorizationGuardWithContext<Message, Create, MessageAuthorizationContext>,
     ) -> Result<(), Error> {
-        let actor_user = User::from(actor.clone());
+        let actor_user = Actor::from(actor.clone());
         Ok(message
             .try_create(
                 &actor_user,
@@ -68,7 +68,7 @@ impl<Client: DatabaseComponents + 'static> MessageRepository for Repository<Clie
         message: AuthorizationGuardWithContext<Message, Update, MessageAuthorizationContext>,
         content: String,
     ) -> Result<(), Error> {
-        let actor_user = User::from(actor.clone());
+        let actor_user = Actor::from(actor.clone());
         message
             .try_update(
                 &actor_user,
@@ -114,7 +114,7 @@ impl<Client: DatabaseComponents + 'static> MessageRepository for Repository<Clie
         context: &MessageAuthorizationContext,
         message: AuthorizationGuardWithContext<Message, Delete, MessageAuthorizationContext>,
     ) -> Result<(), Error> {
-        let actor_user = User::from(actor.clone());
+        let actor_user = Actor::from(actor.clone());
         message
             .try_delete(
                 &actor_user,

--- a/server/infra/resource/src/repository/notification_repository_impl.rs
+++ b/server/infra/resource/src/repository/notification_repository_impl.rs
@@ -6,7 +6,7 @@ use domain::{
         authorization_guard::AuthorizationGuard,
         authorization_guard_with_context::{Create, Read, Update},
     },
-    user::models::{ActiveUser, User},
+    user::models::{ActiveUser, Actor},
 };
 use errors::Error;
 use uuid::Uuid;
@@ -23,7 +23,7 @@ impl<Client: DatabaseComponents + 'static> NotificationRepository for Repository
         actor: &ActiveUser,
         notification_settings: &AuthorizationGuard<NotificationPreference, Create>,
     ) -> Result<(), Error> {
-        let actor_user = User::from(actor.clone());
+        let actor_user = Actor::from(actor.clone());
         notification_settings
             .try_create(&actor_user, |settings| {
                 self.client
@@ -54,7 +54,7 @@ impl<Client: DatabaseComponents + 'static> NotificationRepository for Repository
         actor: &ActiveUser,
         notification_settings: AuthorizationGuard<NotificationPreference, Update>,
     ) -> Result<(), Error> {
-        let actor_user = User::from(actor.clone());
+        let actor_user = Actor::from(actor.clone());
         notification_settings
             .try_update(&actor_user, |settings| {
                 self.client

--- a/server/infra/resource/src/repository/user_repository_impl.rs
+++ b/server/infra/resource/src/repository/user_repository_impl.rs
@@ -5,7 +5,7 @@ use domain::{
         authorization_guard::AuthorizationGuard,
         authorization_guard_with_context::{Create, Read, Update},
     },
-    user::models::{ActiveUser, DiscordUser, DiscordUserId, DiscordUserName, User},
+    user::models::{ActiveUser, Actor, DiscordUser, DiscordUserId, DiscordUserName},
 };
 use errors::{Error, infra::InfraError::Reqwest};
 use itertools::Itertools;
@@ -46,7 +46,7 @@ impl<Client: DatabaseComponents + 'static> UserRepository for Repository<Client>
         actor: &ActiveUser,
         user: AuthorizationGuard<ActiveUser, Create>,
     ) -> Result<(), Error> {
-        let actor_user = User::from(actor.clone());
+        let actor_user = Actor::from(actor.clone());
         user.try_create(&actor_user, |user| self.client.user().upsert_user(user))?
             .await
             .map_err(Into::into)
@@ -57,7 +57,7 @@ impl<Client: DatabaseComponents + 'static> UserRepository for Repository<Client>
         actor: &ActiveUser,
         user: AuthorizationGuard<ActiveUser, Update>,
     ) -> Result<(), Error> {
-        let actor_user = User::from(actor.clone());
+        let actor_user = Actor::from(actor.clone());
         user.try_update(&actor_user, |user| {
             self.client
                 .user()
@@ -142,7 +142,7 @@ impl<Client: DatabaseComponents + 'static> UserRepository for Repository<Client>
         discord_user: &DiscordUser,
         user: AuthorizationGuard<ActiveUser, Update>,
     ) -> Result<(), Error> {
-        let actor_user = User::from(actor.clone());
+        let actor_user = Actor::from(actor.clone());
         user.try_update(&actor_user, |user| {
             self.client.user().link_discord_user(discord_user, user)
         })?
@@ -155,7 +155,7 @@ impl<Client: DatabaseComponents + 'static> UserRepository for Repository<Client>
         actor: &ActiveUser,
         user: AuthorizationGuard<ActiveUser, Update>,
     ) -> Result<(), Error> {
-        let actor_user = User::from(actor.clone());
+        let actor_user = Actor::from(actor.clone());
         user.try_update(&actor_user, |user| {
             self.client.user().unlink_discord_user(user)
         })?
@@ -168,7 +168,7 @@ impl<Client: DatabaseComponents + 'static> UserRepository for Repository<Client>
         actor: &ActiveUser,
         user: &AuthorizationGuard<ActiveUser, Read>,
     ) -> Result<Option<DiscordUser>, Error> {
-        let actor_user = User::from(actor.clone());
+        let actor_user = Actor::from(actor.clone());
         let user = user.try_read(&actor_user)?;
 
         Ok(self

--- a/server/presentation/src/api/notificator_impl.rs
+++ b/server/presentation/src/api/notificator_impl.rs
@@ -3,7 +3,7 @@ use domain::notification::models::{NotificationContent, NotificationPreference, 
 use domain::notification::notificator::Notificator;
 use domain::repository::Repositories;
 use domain::repository::user_repository::UserRepository;
-use domain::user::models::UserId;
+use domain::user::models::{Actor, UserId};
 use errors::Error;
 use errors::usecase::UseCaseError::UserNotFound;
 use resource::outgoing::connection::ConnectionPool;
@@ -42,9 +42,7 @@ impl<R: Repositories> Notificator for DiscordNotificator<R> {
             .await?
             .ok_or(Error::from(UserNotFound))?;
 
-        // SAFETY: 通知送信はシステム的な処理であり、特定のアクターに依存しない。
-        // 適切なシステム権限の仕組みは別途対応する。
-        let user = unsafe { user_guard.read_unchecked() };
+        let user = user_guard.try_read(&Actor::System)?;
 
         let discord_user = self
             .repositories

--- a/server/presentation/src/handlers/form/form_handler.rs
+++ b/server/presentation/src/handlers/form/form_handler.rs
@@ -9,7 +9,7 @@ use axum::{
 use domain::{
     form::{models::FormId, question::models::QuestionSet},
     repository::Repositories,
-    user::models::{ActiveUser, User},
+    user::models::{ActiveUser, Actor, User},
 };
 use itertools::Itertools;
 use resource::repository::RealInfrastructureRepository;
@@ -152,7 +152,7 @@ fn build_form_use_case(repository: &RealInfrastructureRepository) -> ResourceFor
 }
 
 fn archived_form_schema_from_parts(
-    user: &User,
+    actor: &Actor,
     form: domain::form::models::ArchivedForm,
     archived_by: ActiveUser,
     labels: Vec<domain::form::models::FormLabel>,
@@ -161,7 +161,7 @@ fn archived_form_schema_from_parts(
         id: form.form().id().to_owned(),
         title: form.form().title().to_owned(),
         description: form.form().description().to_owned(),
-        settings: FormSettingsSchema::from_settings_ref(user, form.form().settings()),
+        settings: FormSettingsSchema::from_settings_ref(actor, form.form().settings()),
         metadata: FormMetaSchema::from_meta_ref(form.form().metadata()),
         archived_at: *form.archived_at(),
         archived_by,
@@ -227,7 +227,10 @@ pub async fn create_form_handler(
         id: form.id().to_owned(),
         title: form.title().to_owned(),
         description: form.description().to_owned(),
-        settings: FormSettingsSchema::from_settings_ref(&User::from(user.clone()), form.settings()),
+        settings: FormSettingsSchema::from_settings_ref(
+            &Actor::from(user.clone()),
+            form.settings(),
+        ),
         metadata: FormMetaSchema::from_meta_ref(form.metadata()),
         questions: form
             .questions()
@@ -265,7 +268,11 @@ pub async fn form_list_handler(
     let form_use_case = build_form_use_case(&repository);
 
     let forms = form_use_case
-        .form_list(&user, offset_and_limit.offset, offset_and_limit.limit)
+        .form_list(
+            &Actor::from(user.clone()),
+            offset_and_limit.offset,
+            offset_and_limit.limit,
+        )
         .await
         .map_err(handle_error)?;
 
@@ -275,7 +282,10 @@ pub async fn form_list_handler(
             id: form.id().to_owned(),
             title: form.title().to_owned(),
             description: form.description().to_owned(),
-            settings: FormSettingsSchema::from_settings_ref(&user, form.settings()),
+            settings: FormSettingsSchema::from_settings_ref(
+                &Actor::from(user.clone()),
+                form.settings(),
+            ),
             metadata: FormMetaSchema::from_meta_ref(form.metadata()),
             questions: form
                 .questions()
@@ -318,7 +328,7 @@ pub async fn get_form_handler(
     let Path(form_id) = path.map_err_to_error().map_err(handle_error)?;
 
     let ActiveFormWithLabels { form, labels } = form_use_case
-        .get_form(&user, form_id)
+        .get_form(&Actor::from(user.clone()), form_id)
         .await
         .map_err(handle_error)?;
 
@@ -326,7 +336,10 @@ pub async fn get_form_handler(
         id: form.id().to_owned(),
         title: form.title().to_owned(),
         description: form.description().to_owned(),
-        settings: FormSettingsSchema::from_settings_ref(&user, form.settings()),
+        settings: FormSettingsSchema::from_settings_ref(
+            &Actor::from(user.clone()),
+            form.settings(),
+        ),
         metadata: FormMetaSchema::from_meta_ref(form.metadata()),
         questions: form
             .questions()
@@ -373,7 +386,7 @@ pub async fn archive_form_handler(
     Ok((
         StatusCode::OK,
         Json(archived_form_schema_from_parts(
-            &User::from(user.clone()),
+            &Actor::from(user.clone()),
             archived_form,
             user,
             vec![],
@@ -474,7 +487,7 @@ pub async fn update_form_handler(
         title: updated_form.title().to_owned(),
         description: updated_form.description().to_owned(),
         settings: FormSettingsSchema::from_settings_ref(
-            &User::from(user.clone()),
+            &Actor::from(user.clone()),
             updated_form.settings(),
         ),
         metadata: FormMetaSchema::from_meta_ref(updated_form.metadata()),
@@ -533,7 +546,7 @@ pub async fn archived_form_list_handler(
         .await
         .map_err(handle_error)?;
 
-    let actor = User::from(user);
+    let actor = Actor::from(user);
     Ok(ArchivedFormListResponse::Ok(
         forms
             .into_iter()
@@ -585,7 +598,7 @@ pub async fn get_archived_form_handler(
         .map_err(handle_error)?;
 
     Ok(ArchivedFormResponse::Ok(archived_form_schema_from_parts(
-        &User::from(user.clone()),
+        &Actor::from(user.clone()),
         form,
         archived_by,
         labels,

--- a/server/presentation/src/schemas/form/form_response_schemas.rs
+++ b/server/presentation/src/schemas/form/form_response_schemas.rs
@@ -69,7 +69,7 @@ pub struct FormSettingsSchema {
 }
 
 impl FormSettingsSchema {
-    pub fn from_settings_ref(actor: &domain::user::models::User, settings: &FormSettings) -> Self {
+    pub fn from_settings_ref(actor: &domain::user::models::Actor, settings: &FormSettings) -> Self {
         FormSettingsSchema {
             webhook_url: settings
                 .webhook_url(actor)

--- a/server/usecase/src/forms/answer.rs
+++ b/server/usecase/src/forms/answer.rs
@@ -18,7 +18,7 @@ use domain::{
     },
     repository::user_repository::UserRepository,
     types::authorization_guard_with_context::AuthorizationGuardWithContext,
-    user::models::{ActiveUser, TemporaryUser, User},
+    user::models::{ActiveUser, Actor, TemporaryUser, User},
 };
 use errors::{
     Error,
@@ -114,7 +114,7 @@ impl<
 
         let form = form
             .ok_or(Error::from(FormNotFound))?
-            .try_into_read(&User::from(user.clone()))?;
+            .try_into_read(&Actor::from(user.clone()))?;
         let questions = form.questions().as_slice().to_vec();
         let posted_answers = PostedAnswerContents::try_new(&questions, answers)?;
         let title = DefaultAnswerTitleDomainService::<R2>::to_answer_title_from_questions(
@@ -143,7 +143,7 @@ impl<
         };
 
         let guard = AuthorizationGuardWithContext::new(answer_entry);
-        let actor = User::from(user);
+        let actor = Actor::from(user);
 
         self.answer_repository
             .post_answer(&context, guard, &actor)
@@ -159,7 +159,7 @@ impl<
         let form = self.active_form_repository.get(form_id).await?;
 
         let form_guard = form.ok_or(Error::from(FormNotFound))?;
-        let form = form_guard.try_into_read(&User::Anonymous)?;
+        let form = form_guard.try_into_read(&Actor::from(User::Anonymous))?;
         let questions = form.questions().as_slice().to_vec();
         let posted_answers = PostedAnswerContents::try_new(&questions, answers)?;
         let title = DefaultAnswerTitleDomainService::<R2>::to_answer_title_from_questions(
@@ -180,7 +180,7 @@ impl<
             allow_temporary_answers: form_settings.allow_temporary_answers(),
         };
 
-        let actor = User::TemporaryUser(temporary_user.clone());
+        let actor = Actor::from(temporary_user.clone());
         let answer_entry = AnswerEntry::new(
             AnswerAuthor::TemporaryUser(temporary_user),
             form_id,
@@ -207,7 +207,7 @@ impl<
                 .await?
                 .ok_or(FormNotFound)?;
 
-            let user_ref = User::from(user.clone());
+            let user_ref = Actor::from(user.clone());
             let form = form_guard.try_read(&user_ref)?;
             let form_settings = form.settings();
 
@@ -264,7 +264,7 @@ impl<
             .await?
             .ok_or(FormNotFound)?;
 
-        let actor_ref = User::from(actor.clone());
+        let actor_ref = Actor::from(actor.clone());
         let form_settings = form.try_read(&actor_ref)?.settings();
 
         let context = AnswerEntryAuthorizationContext {
@@ -329,7 +329,7 @@ impl<
             .then(|form_answer_guard| {
                 let user = user.clone();
                 async move {
-                    let user_ref = User::from(user.clone());
+                    let user_ref = Actor::from(user.clone());
                     let context_user = user_ref.clone();
                     let context = form_answer_guard
                         .create_context(move |entry| {
@@ -418,7 +418,7 @@ impl<
             .await?
             .ok_or(FormNotFound)?;
 
-        let actor_ref = User::from(actor.clone());
+        let actor_ref = Actor::from(actor.clone());
         let form = form_guard.try_read(&actor_ref)?;
         let form_settings = form.settings();
 

--- a/server/usecase/src/forms/answer_label.rs
+++ b/server/usecase/src/forms/answer_label.rs
@@ -1,7 +1,7 @@
 use domain::{
     form::answer::models::{AnswerId, AnswerLabel, AnswerLabelId},
     repository::form::answer_label_repository::AnswerLabelRepository,
-    user::models::{ActiveUser, User},
+    user::models::{ActiveUser, Actor},
 };
 use errors::{Error, usecase::UseCaseError::LabelNotFound};
 use types::non_empty_string::NonEmptyString;
@@ -16,7 +16,7 @@ impl<R1: AnswerLabelRepository> AnswerLabelUseCase<'_, R1> {
         actor: &ActiveUser,
         label_name: NonEmptyString,
     ) -> Result<AnswerLabel, Error> {
-        let actor_user = User::from(actor.clone());
+        let actor_user = Actor::from(actor.clone());
         let answer_label = AnswerLabel::new(label_name);
         let label_id = answer_label.id().to_owned();
 
@@ -36,7 +36,7 @@ impl<R1: AnswerLabelRepository> AnswerLabelUseCase<'_, R1> {
         &self,
         actor: &ActiveUser,
     ) -> Result<Vec<AnswerLabel>, Error> {
-        let actor_user = User::from(actor.clone());
+        let actor_user = Actor::from(actor.clone());
         Ok(self
             .answer_label_repository
             .get_labels_for_answers()
@@ -68,7 +68,7 @@ impl<R1: AnswerLabelRepository> AnswerLabelUseCase<'_, R1> {
         label_id: AnswerLabelId,
         name: Option<NonEmptyString>,
     ) -> Result<AnswerLabel, Error> {
-        let actor_user = User::from(actor.clone());
+        let actor_user = Actor::from(actor.clone());
         let current_label = self
             .answer_label_repository
             .get_label_for_answers(label_id)

--- a/server/usecase/src/forms/comment.rs
+++ b/server/usecase/src/forms/comment.rs
@@ -14,7 +14,7 @@ use domain::{
     },
     repository::user_repository::UserRepository,
     types::authorization_guard_with_context::AuthorizationGuardWithContext,
-    user::models::{ActiveUser, User},
+    user::models::{ActiveUser, Actor},
 };
 use errors::{
     Error,
@@ -68,7 +68,7 @@ impl<R1: CommentRepository, R2: AnswerRepository, R3: ActiveFormRepository, R4: 
         form_id: FormId,
         answer_id: AnswerId,
     ) -> Result<Vec<CommentWithAuthor>, Error> {
-        let actor_user = User::from(actor.clone());
+        let actor_user = Actor::from(actor.clone());
         let answer_guard = self
             .answer_repository
             .get_answer(answer_id)
@@ -114,7 +114,7 @@ impl<R1: CommentRepository, R2: AnswerRepository, R3: ActiveFormRepository, R4: 
         answer_id: AnswerId,
         comment: Comment,
     ) -> Result<(), Error> {
-        let actor_user = User::from(actor.clone());
+        let actor_user = Actor::from(actor.clone());
         let answer_guard = self
             .answer_repository
             .get_answer(answer_id)
@@ -157,7 +157,7 @@ impl<R1: CommentRepository, R2: AnswerRepository, R3: ActiveFormRepository, R4: 
         comment_id: CommentId,
         content: Option<CommentContent>,
     ) -> Result<(), Error> {
-        let actor_user = User::from(actor.clone());
+        let actor_user = Actor::from(actor.clone());
         let answer_guard = self
             .answer_repository
             .get_answer(answer_id)
@@ -211,7 +211,7 @@ impl<R1: CommentRepository, R2: AnswerRepository, R3: ActiveFormRepository, R4: 
         answer_id: AnswerId,
         comment_id: CommentId,
     ) -> Result<(), Error> {
-        let actor_user = User::from(actor.clone());
+        let actor_user = Actor::from(actor.clone());
         let comment_guard = self
             .comment_repository
             .get_comment(comment_id)

--- a/server/usecase/src/forms/form.rs
+++ b/server/usecase/src/forms/form.rs
@@ -16,7 +16,7 @@ use domain::{
         notification_repository::NotificationRepository,
         user_repository::UserRepository,
     },
-    user::models::{ActiveUser, User},
+    user::models::{ActiveUser, Actor},
 };
 use errors::{
     Error,
@@ -75,7 +75,7 @@ impl<
             form = form.change_settings(settings);
         }
         let form_id = *form.id();
-        let user_as_user = User::from(user.clone());
+        let user_as_user = Actor::from(user.clone());
 
         self.active_form_repository
             .create(user, form.into())
@@ -92,7 +92,7 @@ impl<
     /// `actor` が参照可能なフォームのリストを取得する
     pub async fn form_list(
         &self,
-        actor: &User,
+        actor: &Actor,
         offset: Option<u32>,
         limit: Option<u32>,
     ) -> Result<Vec<(ActiveForm, Vec<FormLabel>)>, Error> {
@@ -128,7 +128,7 @@ impl<
 
     pub async fn get_form(
         &self,
-        actor: &User,
+        actor: &Actor,
         form_id: FormId,
     ) -> Result<ActiveFormWithLabels, Error> {
         let form = self
@@ -155,7 +155,7 @@ impl<
         limit: Option<u32>,
         query: Option<String>,
     ) -> Result<Vec<ArchivedFormDetails>, Error> {
-        let actor_user = User::from(actor.clone());
+        let actor_user = Actor::from(actor.clone());
         let forms = self
             .archived_form_repository
             .list(offset, limit, query)
@@ -202,7 +202,7 @@ impl<
         actor: &ActiveUser,
         form_id: FormId,
     ) -> Result<ArchivedFormDetails, Error> {
-        let actor_user = User::from(actor.clone());
+        let actor_user = Actor::from(actor.clone());
         let form = self
             .archived_form_repository
             .get(form_id)
@@ -236,7 +236,7 @@ impl<
         actor: &ActiveUser,
         form_id: FormId,
     ) -> Result<ArchivedForm, Error> {
-        let actor_user = User::from(actor.clone());
+        let actor_user = Actor::from(actor.clone());
         let form = self
             .active_form_repository
             .get(form_id)
@@ -280,7 +280,7 @@ impl<
         questions: Option<Vec<UpsertQuestionInput>>,
         label_ids: Option<Vec<FormLabelId>>,
     ) -> Result<(ActiveForm, Vec<FormLabel>), Error> {
-        let actor_user = User::from(actor.clone());
+        let actor_user = Actor::from(actor.clone());
         let current_form = self
             .active_form_repository
             .get(form_id)

--- a/server/usecase/src/forms/form_label.rs
+++ b/server/usecase/src/forms/form_label.rs
@@ -1,7 +1,7 @@
 use domain::{
     form::models::{FormLabel, FormLabelId, FormLabelName},
     repository::form::form_label_repository::FormLabelRepository,
-    user::models::{ActiveUser, User},
+    user::models::{ActiveUser, Actor},
 };
 use errors::{Error, usecase::UseCaseError};
 
@@ -15,7 +15,7 @@ impl<R: FormLabelRepository> FormLabelUseCase<'_, R> {
         actor: &ActiveUser,
         label_name: FormLabelName,
     ) -> Result<FormLabel, Error> {
-        let actor_user = User::from(actor.clone());
+        let actor_user = Actor::from(actor.clone());
         let label = FormLabel::new(label_name);
         let label_id = label.id().to_owned();
 
@@ -32,7 +32,7 @@ impl<R: FormLabelRepository> FormLabelUseCase<'_, R> {
     }
 
     pub async fn get_labels_for_forms(&self, actor: &ActiveUser) -> Result<Vec<FormLabel>, Error> {
-        let actor_user = User::from(actor.clone());
+        let actor_user = Actor::from(actor.clone());
         self.form_label_repository
             .fetch_labels()
             .await?

--- a/server/usecase/src/forms/message.rs
+++ b/server/usecase/src/forms/message.rs
@@ -23,7 +23,7 @@ use domain::{
         authorization_guard::AuthorizationGuard,
         authorization_guard_with_context::{AuthorizationGuardWithContext, Create},
     },
-    user::models::{ActiveUser, User},
+    user::models::{ActiveUser, Actor},
 };
 use errors::{
     Error,
@@ -63,7 +63,7 @@ impl<
         answer_id: AnswerId,
         notificator: &N,
     ) -> Result<(), Error> {
-        let actor_user = User::from(actor.clone());
+        let actor_user = Actor::from(actor.clone());
         let form_guard = self
             .active_form_repository
             .get(form_id)
@@ -117,10 +117,8 @@ impl<
                             .fetch_notification_settings(notification_recipient_id.into_inner())
                             .await?;
 
-                        // SAFETY: 通知設定の読み取りはシステム的な処理であり、メッセージ送信者が
-                        // 受信者の通知設定を読める必要がある。適切なシステム権限の仕組みは別途対応する。
                         let notification_preference = match fetched_notification_preference {
-                            Some(settings) => unsafe { settings.into_read_unchecked() },
+                            Some(settings) => settings.try_into_read(&Actor::System)?,
                             None => {
                                 let recipient = self
                                     .user_repository
@@ -136,7 +134,7 @@ impl<
                                     .create_notification_settings(&recipient, &settings)
                                     .await?;
 
-                                unsafe { settings.into_read().into_read_unchecked() }
+                                settings.into_read().try_into_read(&Actor::System)?
                             }
                         };
 
@@ -170,7 +168,7 @@ impl<
         form_id: FormId,
         answer_id: AnswerId,
     ) -> Result<Vec<MessageWithSender>, Error> {
-        let actor_user = User::from(actor.clone());
+        let actor_user = Actor::from(actor.clone());
         let form_guard = self
             .active_form_repository
             .get(form_id)
@@ -228,7 +226,7 @@ impl<
         message_id: &MessageId,
         body: Option<String>,
     ) -> Result<(), Error> {
-        let actor_user = User::from(actor.clone());
+        let actor_user = Actor::from(actor.clone());
         let message = self
             .message_repository
             .fetch_message(message_id)
@@ -284,7 +282,7 @@ impl<
         answer_id: AnswerId,
         message_id: &MessageId,
     ) -> Result<(), Error> {
-        let actor_user = User::from(actor.clone());
+        let actor_user = Actor::from(actor.clone());
         let message = self
             .message_repository
             .fetch_message(message_id)

--- a/server/usecase/src/notification.rs
+++ b/server/usecase/src/notification.rs
@@ -5,7 +5,7 @@ use domain::{
     repository::{
         notification_repository::NotificationRepository, user_repository::UserRepository,
     },
-    user::models::{ActiveUser, User},
+    user::models::{ActiveUser, Actor},
 };
 use errors::{Error, usecase::UseCaseError};
 use uuid::Uuid;
@@ -25,7 +25,7 @@ impl<R1: NotificationRepository, R2: UserRepository> NotificationUseCase<'_, R1,
         actor: ActiveUser,
         target: Uuid,
     ) -> Result<NotificationPreference, Error> {
-        let actor_user = User::from(actor);
+        let actor_user = Actor::from(actor);
         let notification_settings = self.repository.fetch_notification_settings(target).await?;
 
         match notification_settings {

--- a/server/usecase/src/search.rs
+++ b/server/usecase/src/search.rs
@@ -15,7 +15,7 @@ use domain::{
         search_repository::SearchRepository,
     },
     search::models::SearchableFieldsWithOperation,
-    user::models::{ActiveUser, User},
+    user::models::{ActiveUser, Actor},
 };
 use errors::{
     Error,
@@ -61,7 +61,7 @@ impl<
         actor: &ActiveUser,
         query: String,
     ) -> Result<CrossSearchOutput, Error> {
-        let actor = User::ActiveUser(actor.clone());
+        let actor = Actor::from(actor.clone());
         let (forms, users, label_for_forms, label_for_answers, answers, comments) = try_join!(
             self.search_repository.search_forms(&query),
             self.search_repository.search_users(&query),
@@ -267,15 +267,17 @@ impl<
                     let sync_rate = search_engine_records.try_into_sync_rate(&repository_records)?;
 
                     if sync_rate.is_out_of_sync() {
+                        let system = Actor::System;
+
                         let forms = self
                             .active_form_repository
                             .list(None, None)
                             .await?
                             .into_iter()
                             .map(|guard| {
-                                let form = unsafe { guard.into_read_unchecked() };
+                                let form = guard.try_into_read(&system)?;
 
-                                (
+                                Ok((
                                     domain::search::models::SearchableFields::FormMetaData(
                                         domain::search::models::FormMetaData {
                                             id: form.id().to_owned(),
@@ -284,19 +286,19 @@ impl<
                                         },
                                     ),
                                     Operation::Update,
-                                )
+                                ))
                             })
-                            .collect::<Vec<_>>();
+                            .collect::<Result<Vec<_>, errors::Error>>()?;
 
                         let answers = self
                             .answer_repository
                             .get_all_answers()
                             .await?
                             .into_iter()
-                            .flat_map(|guard| {
-                                let entry = unsafe { guard.into_read_unchecked() };
+                            .map(|guard| {
+                                let entry = guard.try_into_read_as_system(&system)?;
 
-                                entry
+                                Ok(entry
                                     .contents()
                                     .iter()
                                     .map(|content| {
@@ -312,8 +314,11 @@ impl<
                                             Operation::Update,
                                         )
                                     })
-                                    .collect::<Vec<_>>()
+                                    .collect::<Vec<_>>())
                             })
+                            .collect::<Result<Vec<_>, errors::Error>>()?
+                            .into_iter()
+                            .flatten()
                             .collect::<Vec<_>>();
 
                         let comments = self
@@ -322,9 +327,9 @@ impl<
                             .await?
                             .into_iter()
                             .map(|guard| {
-                                let comment = unsafe { guard.into_read_unchecked() };
+                                let comment = guard.try_into_read_as_system(&system)?;
 
-                                (
+                                Ok((
                                     domain::search::models::SearchableFields::FormAnswerComments(
                                         domain::search::models::FormAnswerComments {
                                             id: comment.comment_id().to_owned(),
@@ -333,9 +338,9 @@ impl<
                                         },
                                     ),
                                     Operation::Update,
-                                )
+                                ))
                             })
-                            .collect::<Vec<_>>();
+                            .collect::<Result<Vec<_>, errors::Error>>()?;
 
                         let labels_for_forms = self
                             .form_label_repository
@@ -343,9 +348,9 @@ impl<
                             .await?
                             .into_iter()
                             .map(|guard| {
-                                let label = unsafe { guard.into_read_unchecked() };
+                                let label = guard.try_into_read(&system)?;
 
-                                (
+                                Ok((
                                     domain::search::models::SearchableFields::LabelForForms(
                                         domain::search::models::LabelForForms {
                                             id: label.id().to_owned(),
@@ -353,9 +358,9 @@ impl<
                                         },
                                     ),
                                     Operation::Update,
-                                )
+                                ))
                             })
-                            .collect::<Vec<_>>();
+                            .collect::<Result<Vec<_>, errors::Error>>()?;
 
                         let labels_for_answers = self
                             .form_answer_label_repository
@@ -363,9 +368,9 @@ impl<
                             .await?
                             .into_iter()
                             .map(|guard| {
-                                let label = unsafe { guard.into_read_unchecked() };
+                                let label = guard.try_into_read(&system)?;
 
-                                (
+                                Ok((
                                     domain::search::models::SearchableFields::LabelForFormAnswers(
                                         domain::search::models::LabelForFormAnswers {
                                             id: label.id().to_owned(),
@@ -373,9 +378,9 @@ impl<
                                         },
                                     ),
                                     Operation::Update,
-                                )
+                                ))
                             })
-                            .collect::<Vec<_>>();
+                            .collect::<Result<Vec<_>, errors::Error>>()?;
 
                         let users = self
                             .user_repository
@@ -383,9 +388,9 @@ impl<
                             .await?
                             .into_iter()
                             .map(|guard| {
-                                let user = unsafe { guard.into_read_unchecked() };
+                                let user = guard.try_into_read(&system)?;
 
-                                (
+                                Ok((
                                     domain::search::models::SearchableFields::Users(
                                         domain::search::models::Users {
                                             id: user.id().into_inner(),
@@ -393,9 +398,9 @@ impl<
                                         },
                                     ),
                                     Operation::Update,
-                                )
+                                ))
                             })
-                            .collect::<Vec<_>>();
+                            .collect::<Result<Vec<_>, errors::Error>>()?;
 
                         let data = forms
                             .into_iter()

--- a/server/usecase/src/user.rs
+++ b/server/usecase/src/user.rs
@@ -1,6 +1,6 @@
 use domain::{
     repository::user_repository::UserRepository,
-    user::models::{ActiveUser, Role, User},
+    user::models::{ActiveUser, Actor, Role},
 };
 use errors::{Error, usecase::UseCaseError};
 use uuid::Uuid;
@@ -13,7 +13,7 @@ pub struct UserUseCase<'a, UserRepo: UserRepository> {
 
 impl<R: UserRepository> UserUseCase<'_, R> {
     pub async fn find_by(&self, actor: &ActiveUser, uuid: Uuid) -> Result<ActiveUser, Error> {
-        let actor_ref = User::from(actor.clone());
+        let actor_ref = Actor::from(actor.clone());
         self.repository
             .find_by(uuid)
             .await?
@@ -38,7 +38,7 @@ impl<R: UserRepository> UserUseCase<'_, R> {
         uuid: Uuid,
         role: Role,
     ) -> Result<ActiveUser, Error> {
-        let actor_ref = User::from(actor.clone());
+        let actor_ref = Actor::from(actor.clone());
         let current_user_guard = self
             .repository
             .find_by(uuid)
@@ -65,7 +65,7 @@ impl<R: UserRepository> UserUseCase<'_, R> {
     }
 
     pub async fn fetch_all_users(&self, actor: &ActiveUser) -> Result<Vec<ActiveUser>, Error> {
-        let actor_ref = User::from(actor.clone());
+        let actor_ref = Actor::from(actor.clone());
         self.repository
             .fetch_all_users()
             .await?
@@ -84,7 +84,7 @@ impl<R: UserRepository> UserUseCase<'_, R> {
         match fetched_user {
             Some(user) => {
                 let guard = user.to_owned().into();
-                let user_ref = User::from(user.clone());
+                let user_ref = Actor::from(user.clone());
                 self.repository.upsert_user(&user, guard).await?;
                 // NOTE: リクエスト時点では token しかわからないので
                 //  token で検索したユーザーが操作者であるとする
@@ -154,7 +154,7 @@ impl<R: UserRepository> UserUseCase<'_, R> {
             .await?
             .ok_or(Error::from(UseCaseError::UserNotFound))?;
 
-        let actor_ref = User::from(actor.clone());
+        let actor_ref = Actor::from(actor.clone());
         let discord_user = self.repository.fetch_discord_user(actor, &guard).await?;
 
         let user = guard.try_into_read(&actor_ref)?;

--- a/server/usecase/src/user_reference_resolver.rs
+++ b/server/usecase/src/user_reference_resolver.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use domain::{
     repository::user_repository::UserRepository,
-    user::models::{ActiveUser, User, UserId},
+    user::models::{ActiveUser, Actor, UserId},
 };
 use errors::Error;
 
@@ -15,7 +15,7 @@ pub(crate) async fn resolve_user_references<R: UserRepository + ?Sized>(
         return Ok(HashMap::new());
     }
 
-    let actor_user = User::from(actor.clone());
+    let actor_user = Actor::from(actor.clone());
     let uuids = user_ids
         .into_iter()
         .map(UserId::into_inner)


### PR DESCRIPTION
## Summary

- `AuthorizationGuardDefinitions` と `AuthorizationGuardWithContextDefinitions` の actor パラメータを `&User` から `&Actor` に変更
- `Actor` enum (`User(User)` | `System`) を `user::models` に追加し、`From<ActiveUser>`, `From<TemporaryUser>`, `From<User>` を実装
- `unsafe fn into_read_unchecked` / `read_unchecked` を完全に廃止
- 検索インデックス同期・通知送信・通知設定読み取りなどのシステム処理を `Actor::System` による明示的な認可チェックに移行
- コンテキスト付きガードに対するシステムアクセス用メソッド `try_into_read_as_system` を追加

## 背景

従来、システム制御的な処理（検索インデックスの同期、通知の送信など）では Actor が存在せず、`unsafe fn into_read_unchecked` を経由してデータを取得していました。この `unsafe` は Rust の memory safety とは無関係な独自の安全性契約であり、認可を完全にバイパスするものでした。

この PR では `Actor` 型を導入し、すべての認可チェックで「誰が操作しているか」を明示的に表現できるようにしました。`Actor::System` はシステムプロセスを表し、各ドメインモデルの `can_read` 等で System に対する権限を宣言的に定義しています。

## Test plan

- [x] `cargo build` — コンパイル成功
- [x] `cargo nextest run` — 56 テスト全て PASS
- [x] `cargo test --doc` — 15 doctest 全て PASS
- [x] `cargo clippy -- -D warnings` — 警告なし
- [x] `cargo fmt` — フォーマット済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)