### PR TITLE
refactor: AnswerEntryAuthorizationContext の構築を from_form_settings に集約

### DIFF
--- a/server/domain/src/form/answer/service.rs
+++ b/server/domain/src/form/answer/service.rs
@@ -6,7 +6,7 @@ use crate::{
             models::{AnswerAuthor, AnswerEntry},
             settings::models::{AnswerVisibility, ResponsePeriod},
         },
-        models::Visibility,
+        models::{FormSettings, Visibility},
     },
     types::authorization_guard_with_context::AuthorizationGuardWithContextDefinitions,
     user::models::{Actor, Role, User},
@@ -18,6 +18,17 @@ pub struct AnswerEntryAuthorizationContext {
     pub response_period: ResponsePeriod,
     pub answer_visibility: AnswerVisibility,
     pub allow_temporary_answers: bool,
+}
+
+impl AnswerEntryAuthorizationContext {
+    pub fn from_form_settings(settings: &FormSettings) -> Self {
+        Self {
+            form_visibility: *settings.visibility(),
+            response_period: settings.answer_settings().response_period().to_owned(),
+            answer_visibility: *settings.answer_settings().visibility(),
+            allow_temporary_answers: settings.allow_temporary_answers(),
+        }
+    }
 }
 
 impl AuthorizationGuardWithContextDefinitions<AnswerEntryAuthorizationContext> for AnswerEntry {

--- a/server/usecase/src/forms/answer.rs
+++ b/server/usecase/src/forms/answer.rs
@@ -127,20 +127,13 @@ impl<
             user.name(),
         )?;
 
-        let form_settings = form.settings();
-
         let answer_entry = AnswerEntry::new(
             AnswerAuthor::AuthenticatedUser(*user.id()),
             form_id,
             title,
             posted_answers,
         );
-        let context = AnswerEntryAuthorizationContext {
-            form_visibility: form_settings.visibility().to_owned(),
-            response_period: form_settings.answer_settings().response_period().to_owned(),
-            answer_visibility: form_settings.answer_settings().visibility().to_owned(),
-            allow_temporary_answers: form_settings.allow_temporary_answers(),
-        };
+        let context = AnswerEntryAuthorizationContext::from_form_settings(form.settings());
 
         let guard = AuthorizationGuardWithContext::new(answer_entry);
         let actor = Actor::from(user);
@@ -172,13 +165,7 @@ impl<
             temporary_user.name(),
         )?;
 
-        let form_settings = form.settings();
-        let context = AnswerEntryAuthorizationContext {
-            form_visibility: form_settings.visibility().to_owned(),
-            response_period: form_settings.answer_settings().response_period().to_owned(),
-            answer_visibility: form_settings.answer_settings().visibility().to_owned(),
-            allow_temporary_answers: form_settings.allow_temporary_answers(),
-        };
+        let context = AnswerEntryAuthorizationContext::from_form_settings(form.settings());
 
         let actor = Actor::from(temporary_user.clone());
         let answer_entry = AnswerEntry::new(
@@ -209,14 +196,8 @@ impl<
 
             let user_ref = Actor::from(user.clone());
             let form = form_guard.try_read(&user_ref)?;
-            let form_settings = form.settings();
 
-            let context = AnswerEntryAuthorizationContext {
-                form_visibility: form_settings.visibility().to_owned(),
-                response_period: form_settings.answer_settings().response_period().to_owned(),
-                answer_visibility: form_settings.answer_settings().visibility().to_owned(),
-                allow_temporary_answers: form_settings.allow_temporary_answers(),
-            };
+            let context = AnswerEntryAuthorizationContext::from_form_settings(form.settings());
             let fetch_labels = self
                 .answer_label_repository
                 .get_labels_for_answers_by_answer_id(answer_id);
@@ -265,14 +246,9 @@ impl<
             .ok_or(FormNotFound)?;
 
         let actor_ref = Actor::from(actor.clone());
-        let form_settings = form.try_read(&actor_ref)?.settings();
+        let form = form.try_read(&actor_ref)?;
 
-        let context = AnswerEntryAuthorizationContext {
-            form_visibility: form_settings.visibility().to_owned(),
-            response_period: form_settings.answer_settings().response_period().to_owned(),
-            answer_visibility: form_settings.answer_settings().visibility().to_owned(),
-            allow_temporary_answers: form_settings.allow_temporary_answers(),
-        };
+        let context = AnswerEntryAuthorizationContext::from_form_settings(form.settings());
         stream::iter(
             self.answer_repository
                 .get_answers_by_form_id(form_id)
@@ -290,12 +266,8 @@ impl<
 
             let comment_authorization_context = CommentAuthorizationContext {
                 related_answer_entry_guard: form_answer_guard,
-                related_answer_entry_guard_context: AnswerEntryAuthorizationContext {
-                    form_visibility: form_settings.visibility().to_owned(),
-                    response_period: form_settings.answer_settings().response_period().to_owned(),
-                    answer_visibility: form_settings.answer_settings().visibility().to_owned(),
-                    allow_temporary_answers: form_settings.allow_temporary_answers(),
-                },
+                related_answer_entry_guard_context:
+                    AnswerEntryAuthorizationContext::from_form_settings(form.settings()),
             };
 
             let comments = comments
@@ -344,21 +316,10 @@ impl<
                                     .ok_or(FormNotFound)?;
 
                                 let form = guard.try_read(&user)?;
-                                let form_settings = form.settings();
 
-                                Ok(AnswerEntryAuthorizationContext {
-                                    form_visibility: form_settings.visibility().to_owned(),
-                                    response_period: form_settings
-                                        .answer_settings()
-                                        .response_period()
-                                        .to_owned(),
-                                    answer_visibility: form_settings
-                                        .answer_settings()
-                                        .visibility()
-                                        .to_owned(),
-                                    allow_temporary_answers: form_settings
-                                        .allow_temporary_answers(),
-                                })
+                                Ok(AnswerEntryAuthorizationContext::from_form_settings(
+                                    form.settings(),
+                                ))
                             }
                         })
                         .await?;
@@ -420,14 +381,8 @@ impl<
 
         let actor_ref = Actor::from(actor.clone());
         let form = form_guard.try_read(&actor_ref)?;
-        let form_settings = form.settings();
 
-        let context = AnswerEntryAuthorizationContext {
-            form_visibility: form_settings.visibility().to_owned(),
-            response_period: form_settings.answer_settings().response_period().to_owned(),
-            answer_visibility: form_settings.answer_settings().visibility().to_owned(),
-            allow_temporary_answers: form_settings.allow_temporary_answers(),
-        };
+        let context = AnswerEntryAuthorizationContext::from_form_settings(form.settings());
         if let Some(title) = title {
             let answer_entry = self
                 .answer_repository

--- a/server/usecase/src/forms/comment.rs
+++ b/server/usecase/src/forms/comment.rs
@@ -82,14 +82,8 @@ impl<R1: CommentRepository, R2: AnswerRepository, R3: ActiveFormRepository, R4: 
             .ok_or(Error::from(FormNotFound))?;
 
         let form = form_guard.try_read(&actor_user)?;
-        let form_settings = form.settings();
-
-        let answer_entry_context = AnswerEntryAuthorizationContext {
-            form_visibility: form_settings.visibility().to_owned(),
-            response_period: form_settings.answer_settings().response_period().to_owned(),
-            answer_visibility: form_settings.answer_settings().visibility().to_owned(),
-            allow_temporary_answers: form_settings.allow_temporary_answers(),
-        };
+        let answer_entry_context =
+            AnswerEntryAuthorizationContext::from_form_settings(form.settings());
 
         let comment_context = CommentAuthorizationContext {
             related_answer_entry_guard: answer_guard,
@@ -128,14 +122,8 @@ impl<R1: CommentRepository, R2: AnswerRepository, R3: ActiveFormRepository, R4: 
             .ok_or(Error::from(FormNotFound))?;
 
         let form = form_guard.try_read(&actor_user)?;
-        let form_settings = form.settings();
-
-        let answer_entry_context = AnswerEntryAuthorizationContext {
-            form_visibility: form_settings.visibility().to_owned(),
-            response_period: form_settings.answer_settings().response_period().to_owned(),
-            answer_visibility: form_settings.answer_settings().visibility().to_owned(),
-            allow_temporary_answers: form_settings.allow_temporary_answers(),
-        };
+        let answer_entry_context =
+            AnswerEntryAuthorizationContext::from_form_settings(form.settings());
 
         let comment_context = CommentAuthorizationContext {
             related_answer_entry_guard: answer_guard,
@@ -171,14 +159,8 @@ impl<R1: CommentRepository, R2: AnswerRepository, R3: ActiveFormRepository, R4: 
             .ok_or(Error::from(FormNotFound))?;
 
         let form = form_guard.try_read(&actor_user)?;
-        let form_settings = form.settings();
-
-        let answer_entry_context = AnswerEntryAuthorizationContext {
-            form_visibility: form_settings.visibility().to_owned(),
-            response_period: form_settings.answer_settings().response_period().to_owned(),
-            answer_visibility: form_settings.answer_settings().visibility().to_owned(),
-            allow_temporary_answers: form_settings.allow_temporary_answers(),
-        };
+        let answer_entry_context =
+            AnswerEntryAuthorizationContext::from_form_settings(form.settings());
 
         let comment_context = CommentAuthorizationContext {
             related_answer_entry_guard: answer_guard,
@@ -226,14 +208,8 @@ impl<R1: CommentRepository, R2: AnswerRepository, R3: ActiveFormRepository, R4: 
             .ok_or(Error::from(FormNotFound))?;
 
         let form = form_guard.try_read(&actor_user)?;
-        let form_settings = form.settings();
-
-        let answer_entry_context = AnswerEntryAuthorizationContext {
-            form_visibility: form_settings.visibility().to_owned(),
-            response_period: form_settings.answer_settings().response_period().to_owned(),
-            answer_visibility: form_settings.answer_settings().visibility().to_owned(),
-            allow_temporary_answers: form_settings.allow_temporary_answers(),
-        };
+        let answer_entry_context =
+            AnswerEntryAuthorizationContext::from_form_settings(form.settings());
 
         let answer_guard = self
             .answer_repository

--- a/server/usecase/src/forms/message.rs
+++ b/server/usecase/src/forms/message.rs
@@ -73,12 +73,8 @@ impl<
         let form = form_guard.try_read(&actor_user)?;
         let form_settings = form.settings();
 
-        let answer_entry_authorization_context = AnswerEntryAuthorizationContext {
-            form_visibility: form_settings.visibility().to_owned(),
-            response_period: form_settings.answer_settings().response_period().to_owned(),
-            answer_visibility: form_settings.answer_settings().visibility().to_owned(),
-            allow_temporary_answers: form_settings.allow_temporary_answers(),
-        };
+        let answer_entry_authorization_context =
+            AnswerEntryAuthorizationContext::from_form_settings(form_settings);
         let form_answer = self
             .answer_repository
             .get_answer(answer_id)
@@ -177,12 +173,8 @@ impl<
 
         let form = form_guard.try_read(&actor_user)?;
         let form_settings = form.settings();
-        let answer_entry_authorization_context = AnswerEntryAuthorizationContext {
-            form_visibility: form_settings.visibility().to_owned(),
-            response_period: form_settings.answer_settings().response_period().to_owned(),
-            answer_visibility: form_settings.answer_settings().visibility().to_owned(),
-            allow_temporary_answers: form_settings.allow_temporary_answers(),
-        };
+        let answer_entry_authorization_context =
+            AnswerEntryAuthorizationContext::from_form_settings(form_settings);
         let answers = self
             .answer_repository
             .get_answer(answer_id)
@@ -241,12 +233,8 @@ impl<
         let form = form_guard.try_read(&actor_user)?;
         let form_settings = form.settings();
 
-        let answer_entry_authorization_context = AnswerEntryAuthorizationContext {
-            form_visibility: form_settings.visibility().to_owned(),
-            response_period: form_settings.answer_settings().response_period().to_owned(),
-            answer_visibility: form_settings.answer_settings().visibility().to_owned(),
-            allow_temporary_answers: form_settings.allow_temporary_answers(),
-        };
+        let answer_entry_authorization_context =
+            AnswerEntryAuthorizationContext::from_form_settings(form_settings);
         let answer_entry = self
             .answer_repository
             .get_answer(answer_id)
@@ -297,12 +285,8 @@ impl<
         let form = form_guard.try_read(&actor_user)?;
         let form_settings = form.settings();
 
-        let answer_entry_authorization_context = AnswerEntryAuthorizationContext {
-            form_visibility: form_settings.visibility().to_owned(),
-            response_period: form_settings.answer_settings().response_period().to_owned(),
-            answer_visibility: form_settings.answer_settings().visibility().to_owned(),
-            allow_temporary_answers: form_settings.allow_temporary_answers(),
-        };
+        let answer_entry_authorization_context =
+            AnswerEntryAuthorizationContext::from_form_settings(form_settings);
         let answer_entry = self
             .answer_repository
             .get_answer(answer_id)

--- a/server/usecase/src/search.rs
+++ b/server/usecase/src/search.rs
@@ -109,21 +109,10 @@ impl<
                                     .ok_or(Error::from(FormNotFound))?;
 
                                 let form = form_guard.try_read(&actor)?;
-                                let form_settings = form.settings();
 
-                                Ok(AnswerEntryAuthorizationContext {
-                                    form_visibility: form_settings.visibility().to_owned(),
-                                    response_period: form_settings
-                                        .answer_settings()
-                                        .response_period()
-                                        .to_owned(),
-                                    answer_visibility: form_settings
-                                        .answer_settings()
-                                        .visibility()
-                                        .to_owned(),
-                                    allow_temporary_answers: form_settings
-                                        .allow_temporary_answers(),
-                                })
+                                Ok(AnswerEntryAuthorizationContext::from_form_settings(
+                                    form.settings(),
+                                ))
                             }
                         })
                         .await?;
@@ -167,23 +156,10 @@ impl<
                                                 .ok_or(Error::from(FormNotFound))?;
 
                                             let form = form_guard.try_read(&actor)?;
-                                            let form_settings = form.settings();
 
-                                            Ok(AnswerEntryAuthorizationContext {
-                                                form_visibility: form_settings
-                                                    .visibility()
-                                                    .to_owned(),
-                                                response_period: form_settings
-                                                    .answer_settings()
-                                                    .response_period()
-                                                    .to_owned(),
-                                                answer_visibility: form_settings
-                                                    .answer_settings()
-                                                    .visibility()
-                                                    .to_owned(),
-                                                allow_temporary_answers: form_settings
-                                                    .allow_temporary_answers(),
-                                            })
+                                            Ok(AnswerEntryAuthorizationContext::from_form_settings(
+                                                form.settings(),
+                                            ))
                                         }
                                     })
                                     .await?;


### PR DESCRIPTION
usecase 層で FormSettings から AnswerEntryAuthorizationContext を手動構築していた
15箇所以上の重複コードを、ヘルパーコンストラクタに集約した。
AnswerEntrySet 集約導入 (#1102) の準備として、
今後の変更箇所を最小化するための前処理。

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
