### PR TITLE
認可の自己ガードと親委譲を関連型で型レベルに排他化する

### DIFF
--- a/server/domain/src/form/answer/models.rs
+++ b/server/domain/src/form/answer/models.rs
@@ -10,7 +10,9 @@ use types::non_empty_string::NonEmptyString;
 
 use crate::{
     form::question::models::{Question, QuestionId},
-    types::authorization_guard::AuthorizationGuardDefinitions,
+    types::authorization_guard::{
+        AuthorizationGuardDefinitions, AuthorizationRole, ParentGuarded, SelfGuarded,
+    },
     user::models::{Actor, Role, TemporaryUser, User, UserId},
 };
 
@@ -203,6 +205,10 @@ impl AnswerEntry {
     }
 }
 
+impl AuthorizationRole for AnswerEntry {
+    type Role = ParentGuarded;
+}
+
 pub type AnswerLabelId = types::Id<AnswerLabel>;
 
 #[cfg_attr(test, derive(Arbitrary))]
@@ -231,6 +237,10 @@ impl AnswerLabel {
     pub fn renamed(self, name: NonEmptyString) -> Self {
         Self { name, ..self }
     }
+}
+
+impl AuthorizationRole for AnswerLabel {
+    type Role = SelfGuarded;
 }
 
 impl AuthorizationGuardDefinitions for AnswerLabel {

--- a/server/domain/src/form/answer_entry_set/models.rs
+++ b/server/domain/src/form/answer_entry_set/models.rs
@@ -3,11 +3,13 @@ use errors::domain::DomainError;
 use crate::{
     form::{
         answer::models::{AnswerEntry, AnswerId},
-        comment::models::Comment,
+        comment::models::{Comment, CommentContent},
         models::FormId,
     },
-    types::authorization_guard::{Allowed, Authorizes, Read},
-    user::models::Actor,
+    types::authorization_guard::{
+        Allowed, AuthorizationRole, Authorizes, Create, Delete, ParentGuarded, Read, Update,
+    },
+    user::models::{Actor, Role, User},
 };
 
 /// あるフォームに紐づく回答 ([`AnswerEntry`]) の集合です。
@@ -60,9 +62,59 @@ impl AnswerEntrySet {
     }
 }
 
+impl AuthorizationRole for AnswerEntrySet {
+    type Role = ParentGuarded;
+}
+
 impl Authorizes<Comment, Read> for AnswerEntry {
     fn check(&self, _actor: &Actor, child: &Comment) -> Result<(), DomainError> {
         if child.answer_id() == self.id() {
+            Ok(())
+        } else {
+            Err(DomainError::Forbidden)
+        }
+    }
+}
+
+impl Authorizes<Comment, Create> for AnswerEntry {
+    fn check(&self, actor: &Actor, child: &Comment) -> Result<(), DomainError> {
+        if child.answer_id() != self.id() {
+            return Err(DomainError::Forbidden);
+        }
+
+        match actor {
+            Actor::User(User::ActiveUser(_)) => Ok(()),
+            _ => Err(DomainError::Forbidden),
+        }
+    }
+}
+
+impl Authorizes<Comment, Update> for AnswerEntry {
+    fn check(&self, actor: &Actor, child: &Comment) -> Result<(), DomainError> {
+        if child.answer_id() != self.id() {
+            return Err(DomainError::Forbidden);
+        }
+
+        if matches!(actor, Actor::User(User::ActiveUser(user)) if user.id() == child.commented_by())
+        {
+            Ok(())
+        } else {
+            Err(DomainError::Forbidden)
+        }
+    }
+}
+
+impl Authorizes<Comment, Delete> for AnswerEntry {
+    fn check(&self, actor: &Actor, child: &Comment) -> Result<(), DomainError> {
+        if child.answer_id() != self.id() {
+            return Err(DomainError::Forbidden);
+        }
+
+        if matches!(
+            actor,
+            Actor::User(User::ActiveUser(user))
+                if user.id() == child.commented_by() || user.role() == &Role::Administrator
+        ) {
             Ok(())
         } else {
             Err(DomainError::Forbidden)
@@ -76,6 +128,20 @@ impl Allowed<AnswerEntry, Read> {
         comment: Comment,
     ) -> Result<Allowed<Comment, Read>, DomainError> {
         self.authorize_read(comment)
+    }
+
+    pub fn create_comment(
+        &self,
+        content: CommentContent,
+    ) -> Result<Allowed<Comment, Create>, DomainError> {
+        let commented_by = match self.actor() {
+            Actor::User(User::ActiveUser(user)) => *user.id(),
+            _ => return Err(DomainError::Forbidden),
+        };
+
+        let comment = Comment::new(*self.value().id(), content, commented_by);
+
+        self.authorize_create(comment)
     }
 }
 

--- a/server/domain/src/form/answer_entry_set/models.rs
+++ b/server/domain/src/form/answer_entry_set/models.rs
@@ -83,7 +83,7 @@ impl Authorizes<Comment, Create> for AnswerEntry {
         }
 
         match actor {
-            Actor::User(User::ActiveUser(_)) => Ok(()),
+            Actor::User(User::ActiveUser(user)) if user.id() == child.commented_by() => Ok(()),
             _ => Err(DomainError::Forbidden),
         }
     }

--- a/server/domain/src/form/comment/models.rs
+++ b/server/domain/src/form/comment/models.rs
@@ -6,8 +6,8 @@ use types::non_empty_string::NonEmptyString;
 
 use crate::{
     form::answer::models::AnswerId,
-    types::authorization_guard::AuthorizationGuardDefinitions,
-    user::models::{Actor, Role::Administrator, User, UserId},
+    types::authorization_guard::{AuthorizationRole, ParentGuarded},
+    user::models::UserId,
 };
 
 pub type CommentId = types::Id<Comment>;
@@ -72,28 +72,12 @@ impl Comment {
     }
 }
 
-/// [`Comment`] 自身で完結する認可のみをここで定義します。
-///
-/// 「紐づく [`AnswerEntry`](crate::form::answer::models::AnswerEntry) が閲覧可能か」
-/// という文脈依存の判定は AnswerEntry 側のゲートが担うため、ここには含めません。
-impl AuthorizationGuardDefinitions for Comment {
-    fn can_create(&self, actor: &Actor) -> bool {
-        matches!(actor, Actor::User(User::ActiveUser(user)) if *user.id() == self.commented_by)
-    }
+// [`Comment`] は自己ガード ([`crate::types::authorization_guard::AuthorizationGuardDefinitions`])
+// を実装しない。コメントは親である
+// [`AnswerEntry`](crate::form::answer::models::AnswerEntry) のガードを起点としてのみ
+// 認可され、その条件 (閲覧・作成・更新・削除) は
+// [`crate::form::answer_entry_set::models`] の `Authorizes<Comment, _>` が担う。
 
-    fn can_read(&self, _actor: &Actor) -> bool {
-        false
-    }
-
-    fn can_update(&self, actor: &Actor) -> bool {
-        matches!(actor, Actor::User(User::ActiveUser(user)) if *user.id() == self.commented_by)
-    }
-
-    fn can_delete(&self, actor: &Actor) -> bool {
-        matches!(
-            actor,
-            Actor::User(User::ActiveUser(user))
-                if *user.id() == self.commented_by || user.role() == &Administrator
-        )
-    }
+impl AuthorizationRole for Comment {
+    type Role = ParentGuarded;
 }

--- a/server/domain/src/form/message/models.rs
+++ b/server/domain/src/form/message/models.rs
@@ -3,9 +3,16 @@ use derive_getters::Getters;
 use errors::domain::DomainError;
 use serde::{Deserialize, Serialize};
 
-use crate::user::models::UserId;
+use crate::{
+    types::authorization_guard::{AuthorizationRole, ParentGuarded},
+    user::models::UserId,
+};
 
 pub type MessageId = types::Id<Message>;
+
+impl AuthorizationRole for Message {
+    type Role = ParentGuarded;
+}
 
 #[derive(Getters, Clone, PartialEq, Debug, Serialize, Deserialize)]
 pub struct Message {

--- a/server/domain/src/form/message_thread/models.rs
+++ b/server/domain/src/form/message_thread/models.rs
@@ -6,7 +6,8 @@ use crate::{
         message::models::{Message, MessageId},
     },
     types::authorization_guard::{
-        Allowed, AuthorizationGuardDefinitions, Authorizes, Delete, Update,
+        Allowed, AuthorizationGuardDefinitions, AuthorizationRole, Authorizes, Delete, SelfGuarded,
+        Update,
     },
     user::models::{Actor, Role::Administrator, User, UserId},
 };
@@ -158,6 +159,10 @@ fn is_answer_author_or_administrator(actor: &Actor, answer_author_id: &UserId) -
             if user.role() == &Administrator
                 || *user.id() == *answer_author_id
     )
+}
+
+impl AuthorizationRole for MessageThread {
+    type Role = SelfGuarded;
 }
 
 impl AuthorizationGuardDefinitions for MessageThread {

--- a/server/domain/src/form/models.rs
+++ b/server/domain/src/form/models.rs
@@ -19,11 +19,10 @@ use crate::{
     form::{
         answer::models::{AnswerAuthor, AnswerEntry, AnswerId, AnswerTitle, PostedAnswerContents},
         answer_entry_set::models::AnswerEntrySet,
-        comment::models::{Comment, CommentContent},
     },
     types::authorization_guard::{
-        Allowed, AuthorizationGuard, AuthorizationGuardDefinitions, Authorizes, Create, Read,
-        Update,
+        Allowed, AuthorizationGuardDefinitions, AuthorizationRole, Authorizes, Create, Read,
+        SelfGuarded, Update,
     },
     user::models::{Actor, Role::Administrator, User, UserId},
 };
@@ -275,16 +274,11 @@ impl AnswerSettings {
 
     /// `author` / `actor` の組み合わせと受付期間・仮回答可否から、新しい [`AnswerEntry`] を
     /// 受理してよいかを判断し、受理できる場合のみ [`AnswerEntry`] を生成します。
-    pub fn try_accept_answer(
-        &self,
-        author: AnswerAuthor,
-        actor: &Actor,
-        title: AnswerTitle,
-        posted_answers: PostedAnswerContents,
-    ) -> Result<AnswerEntry, DomainError> {
+    /// `actor` が `author` として回答を作成してよいかを、受付期間と一時回答の可否から判定する。
+    fn can_accept_answer(&self, author: &AnswerAuthor, actor: &Actor) -> bool {
         let is_within_period = self.response_period.is_within_period(Utc::now());
 
-        let allowed = match (&author, actor) {
+        match (author, actor) {
             (AnswerAuthor::AuthenticatedUser(user_id), Actor::User(User::ActiveUser(user))) => {
                 *user_id == *user.id() && (is_within_period || user.role() == &Administrator)
             }
@@ -292,9 +286,17 @@ impl AnswerSettings {
                 self.allow_temporary_answers && is_within_period
             }
             _ => false,
-        };
+        }
+    }
 
-        if !allowed {
+    pub fn try_accept_answer(
+        &self,
+        author: AnswerAuthor,
+        actor: &Actor,
+        title: AnswerTitle,
+        posted_answers: PostedAnswerContents,
+    ) -> Result<AnswerEntry, DomainError> {
+        if !self.can_accept_answer(&author, actor) {
             return Err(DomainError::Forbidden);
         }
 
@@ -536,6 +538,19 @@ impl Authorizes<AnswerEntry, Update> for ActiveForm {
     }
 }
 
+impl Authorizes<AnswerEntry, Create> for ActiveForm {
+    fn check(&self, actor: &Actor, entry: &AnswerEntry) -> Result<(), DomainError> {
+        if self
+            .answer_settings
+            .can_accept_answer(entry.author(), actor)
+        {
+            Ok(())
+        } else {
+            Err(DomainError::Forbidden)
+        }
+    }
+}
+
 impl Allowed<ActiveForm, Read> {
     /// 回答にまつわるポリシー ([`AnswerSettings`]) に委譲して、新しい [`AnswerEntry`] を
     /// 受理してよいかを判断し、認可済みの [`Allowed<AnswerEntry, Create>`] を返します。
@@ -551,7 +566,7 @@ impl Allowed<ActiveForm, Read> {
             title,
             posted_answers,
         )?;
-        Ok(Allowed::mint(entry, self.actor().clone()))
+        self.authorize_create(entry)
     }
 
     /// `set` のうち `actor` が閲覧可能な [`AnswerEntry`] だけを認可済みで返します。
@@ -588,40 +603,6 @@ impl Allowed<ActiveForm, Read> {
             .clone();
 
         self.authorize_read(entry)
-    }
-
-    fn read_entry_for_comment(
-        &self,
-        set: &Allowed<AnswerEntrySet, Read>,
-        answer_id: AnswerId,
-    ) -> Result<Allowed<AnswerEntry, Read>, DomainError> {
-        let entry = self.read_entry(set, answer_id)?;
-        match self.actor() {
-            Actor::User(User::ActiveUser(_)) => Ok(entry),
-            _ => Err(DomainError::Forbidden),
-        }
-    }
-
-    /// 対象の [`AnswerEntry`] が `actor` から閲覧可能であることをゲートとして検証したうえで、
-    /// 新しい [`Comment`] の作成ガードを生成します。
-    pub fn create_comment(
-        &self,
-        set: &Allowed<AnswerEntrySet, Read>,
-        answer_id: AnswerId,
-        content: CommentContent,
-    ) -> Result<AuthorizationGuard<Comment, Create>, DomainError> {
-        self.read_entry_for_comment(set, answer_id)?;
-
-        let commented_by = match self.actor() {
-            Actor::User(User::ActiveUser(user)) => *user.id(),
-            _ => return Err(DomainError::Forbidden),
-        };
-
-        Ok(AuthorizationGuard::from(Comment::new(
-            answer_id,
-            content,
-            commented_by,
-        )))
     }
 }
 
@@ -683,6 +664,10 @@ impl ArchivedForm {
     }
 }
 
+impl AuthorizationRole for ArchivedForm {
+    type Role = SelfGuarded;
+}
+
 impl AuthorizationGuardDefinitions for ArchivedForm {
     fn can_create(&self, actor: &Actor) -> bool {
         is_administrator(actor)
@@ -699,6 +684,10 @@ impl AuthorizationGuardDefinitions for ArchivedForm {
     fn can_delete(&self, actor: &Actor) -> bool {
         is_administrator(actor)
     }
+}
+
+impl AuthorizationRole for ActiveForm {
+    type Role = SelfGuarded;
 }
 
 impl AuthorizationGuardDefinitions for ActiveForm {
@@ -959,6 +948,10 @@ impl FormLabel {
     pub unsafe fn from_raw_parts(id: FormLabelId, name: FormLabelName) -> Self {
         Self { id, name }
     }
+}
+
+impl AuthorizationRole for FormLabel {
+    type Role = SelfGuarded;
 }
 
 impl AuthorizationGuardDefinitions for FormLabel {

--- a/server/domain/src/form/question/models.rs
+++ b/server/domain/src/form/question/models.rs
@@ -9,7 +9,7 @@ use types::non_empty_string::NonEmptyString;
 use types::non_empty_vec::NonEmptyVec;
 
 use crate::{
-    types::authorization_guard::AuthorizationGuardDefinitions,
+    types::authorization_guard::{AuthorizationGuardDefinitions, AuthorizationRole, SelfGuarded},
     user::models::Actor,
     user::models::{Role, User},
 };
@@ -368,6 +368,10 @@ impl Question {
             )?)),
         }
     }
+}
+
+impl AuthorizationRole for Question {
+    type Role = SelfGuarded;
 }
 
 impl AuthorizationGuardDefinitions for Question {

--- a/server/domain/src/notification/models.rs
+++ b/server/domain/src/notification/models.rs
@@ -1,7 +1,7 @@
 use derive_getters::Getters;
 
 use crate::{
-    types::authorization_guard::AuthorizationGuardDefinitions,
+    types::authorization_guard::{AuthorizationGuardDefinitions, AuthorizationRole, SelfGuarded},
     user::models::{Actor, Role, User, UserId},
 };
 
@@ -64,6 +64,10 @@ impl NotificationPreference {
             NotificationType::MessageReceived => self.is_send_message_notification,
         }
     }
+}
+
+impl AuthorizationRole for NotificationPreference {
+    type Role = SelfGuarded;
 }
 
 impl AuthorizationGuardDefinitions for NotificationPreference {

--- a/server/domain/src/types/authorization_guard.rs
+++ b/server/domain/src/types/authorization_guard.rs
@@ -27,6 +27,34 @@ mod private {
     impl Sealed for super::Read {}
     impl Sealed for super::Update {}
     impl Sealed for super::Delete {}
+
+    pub trait SealedRole {}
+
+    impl SealedRole for super::SelfGuarded {}
+    impl SealedRole for super::ParentGuarded {}
+}
+
+/// 認可対象がどの方式で認可されるかを型レベルで表すマーカー ([`AuthorizationRole::Role`])。
+///
+/// [`SelfGuarded`] は [`AuthorizationGuard`] で自分自身を直接ガードするルート集約、
+/// [`ParentGuarded`] は親要素の [`Allowed`] を起点とした [`Authorizes`] 経由でのみ
+/// 認可される子要素を表します。
+#[derive(Debug, Clone, Copy)]
+pub struct SelfGuarded;
+#[derive(Debug, Clone, Copy)]
+pub struct ParentGuarded;
+
+/// 認可対象が「自己ガードするルート集約 ([`SelfGuarded`])」か
+/// 「親に認可を委譲する子要素 ([`ParentGuarded`])」かを、型ごとに一意な関連型で宣言します。
+///
+/// 関連型は型ごとに一意であるため、この宣言はそのまま両方式の**排他**を表します。
+/// [`AuthorizationGuardDefinitions`] は `Role = SelfGuarded` を、[`Authorizes`] の対象 (子) は
+/// `Role = ParentGuarded` をそれぞれ要求するので、ひとつの型で自己ガードと親委譲を
+/// 同時に成立させることはできません (両立させようとするとコンパイルエラーになります)。
+/// これにより、親ゲートを通すべき子要素が誤って自己ガードを実装し、[`AuthorizationGuard`]
+/// 経由で前提検証をスキップする、という事故を型レベルで防ぎます。
+pub trait AuthorizationRole {
+    type Role: private::SealedRole;
 }
 
 /// 認可チェック前の値を、実行したい操作と一緒に保持する型です。
@@ -70,7 +98,7 @@ pub struct Allowed<T, A: Actions> {
 }
 
 impl<T, A: Actions> Allowed<T, A> {
-    pub(crate) fn mint(value: T, actor: Actor) -> Self {
+    fn mint(value: T, actor: Actor) -> Self {
         Self {
             value,
             actor,
@@ -139,6 +167,7 @@ impl<T, A: Actions> Allowed<T, A> {
     pub fn authorize<C>(&self, child: C) -> Result<Allowed<C, A>, DomainError>
     where
         T: Authorizes<C, A>,
+        C: AuthorizationRole<Role = ParentGuarded>,
     {
         self.value.check(&self.actor, &child)?;
         Ok(Allowed::mint(child, self.actor.clone()))
@@ -150,6 +179,7 @@ impl<T> Allowed<T, Update> {
     pub fn authorize_update<C>(&self, child: C) -> Result<Allowed<C, Update>, DomainError>
     where
         T: Authorizes<C, Update>,
+        C: AuthorizationRole<Role = ParentGuarded>,
     {
         self.authorize(child)
     }
@@ -161,6 +191,7 @@ impl<T> Allowed<T, Update> {
     pub fn authorize_delete<C>(&self, child: C) -> Result<Allowed<C, Delete>, DomainError>
     where
         T: Authorizes<C, Delete>,
+        C: AuthorizationRole<Role = ParentGuarded>,
     {
         self.value.check(&self.actor, &child)?;
         Ok(Allowed::mint(child, self.actor.clone()))
@@ -172,8 +203,47 @@ impl<T> Allowed<T, Read> {
     pub fn authorize_read<C>(&self, child: C) -> Result<Allowed<C, Read>, DomainError>
     where
         T: Authorizes<C, Read>,
+        C: AuthorizationRole<Role = ParentGuarded>,
     {
         self.authorize(child)
+    }
+
+    /// 読み取り認可済みの親要素から、子要素の作成認可済み値を作ります。
+    ///
+    /// 親要素を読める利用者に、その配下の子要素の作成を許可する場合に使います。
+    /// 親要素が実装する [`Authorizes`] で所属や所有者などを検証し、成功した場合だけ
+    /// 同じ [`Actor`] の [`Allowed<C, Create>`] を返します。
+    pub fn authorize_create<C>(&self, child: C) -> Result<Allowed<C, Create>, DomainError>
+    where
+        T: Authorizes<C, Create>,
+        C: AuthorizationRole<Role = ParentGuarded>,
+    {
+        self.value.check(&self.actor, &child)?;
+        Ok(Allowed::mint(child, self.actor.clone()))
+    }
+
+    /// 読み取り認可済みの親要素から、子要素の更新認可済み値を作ります。
+    ///
+    /// 親要素を読める利用者に、その配下の子要素の更新を許可する場合に使います。
+    pub fn authorize_update<C>(&self, child: C) -> Result<Allowed<C, Update>, DomainError>
+    where
+        T: Authorizes<C, Update>,
+        C: AuthorizationRole<Role = ParentGuarded>,
+    {
+        self.value.check(&self.actor, &child)?;
+        Ok(Allowed::mint(child, self.actor.clone()))
+    }
+
+    /// 読み取り認可済みの親要素から、子要素の削除認可済み値を作ります。
+    ///
+    /// 親要素を読める利用者に、その配下の子要素の削除を許可する場合に使います。
+    pub fn authorize_delete<C>(&self, child: C) -> Result<Allowed<C, Delete>, DomainError>
+    where
+        T: Authorizes<C, Delete>,
+        C: AuthorizationRole<Role = ParentGuarded>,
+    {
+        self.value.check(&self.actor, &child)?;
+        Ok(Allowed::mint(child, self.actor.clone()))
     }
 
     /// 読み取り認可済みの値を、同じ [`Actor`] で更新認可に昇格します。
@@ -205,7 +275,7 @@ impl<T> Allowed<T, Read> {
 ///
 /// 例えば回答が読める利用者に、その回答に紐づくコメントの読み取りも許可する場合に使います。
 /// 例えば回答集合を更新できる利用者に、その集合に含まれる回答タイトルの更新も許可する場合に使います。
-pub trait Authorizes<Child, A: Actions> {
+pub trait Authorizes<Child: AuthorizationRole<Role = ParentGuarded>, A: Actions> {
     fn check(&self, actor: &Actor, child: &Child) -> Result<(), DomainError>;
 }
 
@@ -323,13 +393,19 @@ impl<T: AuthorizationGuardDefinitions> AuthorizationGuard<T, Delete> {
 /// # Examples
 /// ```
 /// use domain::{
-///     types::authorization_guard::AuthorizationGuardDefinitions,
+///     types::authorization_guard::{
+///         AuthorizationGuardDefinitions, AuthorizationRole, SelfGuarded,
+///     },
 ///     user::models::{Actor, Role, User, UserId},
 /// };
 /// use uuid::Uuid;
 ///
 /// struct GuardTarget {
 ///     pub user_id: UserId,
+/// }
+///
+/// impl AuthorizationRole for GuardTarget {
+///     type Role = SelfGuarded;
 /// }
 ///
 /// impl AuthorizationGuardDefinitions for GuardTarget {
@@ -350,7 +426,7 @@ impl<T: AuthorizationGuardDefinitions> AuthorizationGuard<T, Delete> {
 ///     }
 /// }
 /// ```
-pub trait AuthorizationGuardDefinitions {
+pub trait AuthorizationGuardDefinitions: AuthorizationRole<Role = SelfGuarded> {
     fn can_create(&self, actor: &Actor) -> bool;
     fn can_read(&self, actor: &Actor) -> bool;
     fn can_update(&self, actor: &Actor) -> bool;
@@ -396,7 +472,8 @@ mod test {
 
     use crate::{
         types::authorization_guard::{
-            Allowed, AuthorizationGuard, AuthorizationGuardDefinitions, Delete,
+            Allowed, AuthorizationGuard, AuthorizationGuardDefinitions, AuthorizationRole, Delete,
+            SelfGuarded,
         },
         user::models::{ActiveUser, Actor, Role, User},
     };
@@ -404,6 +481,10 @@ mod test {
     #[derive(Clone, PartialEq, Debug)]
     struct AuthorizationGuardTestStruct {
         pub _value: String,
+    }
+
+    impl AuthorizationRole for AuthorizationGuardTestStruct {
+        type Role = SelfGuarded;
     }
 
     impl AuthorizationGuardDefinitions for AuthorizationGuardTestStruct {

--- a/server/domain/src/user/models.rs
+++ b/server/domain/src/user/models.rs
@@ -8,7 +8,9 @@ use serde::{Deserialize, Serialize};
 use strum_macros::{Display, EnumString};
 use uuid::Uuid;
 
-use crate::types::authorization_guard::AuthorizationGuardDefinitions;
+use crate::types::authorization_guard::{
+    AuthorizationGuardDefinitions, AuthorizationRole, SelfGuarded,
+};
 
 #[derive(DerivingVia, Debug, PartialOrd, PartialEq, Eq, Hash)]
 #[cfg_attr(test, derive(Arbitrary))]
@@ -141,6 +143,10 @@ impl TemporaryUser {
     }
 }
 
+impl AuthorizationRole for ActiveUser {
+    type Role = SelfGuarded;
+}
+
 impl AuthorizationGuardDefinitions for ActiveUser {
     fn can_create(&self, actor: &Actor) -> bool {
         matches!(actor, Actor::User(User::ActiveUser(actor)) if actor == self)
@@ -235,6 +241,10 @@ impl DiscordAccountLink {
             discord_user,
         }
     }
+}
+
+impl AuthorizationRole for DiscordAccountLink {
+    type Role = SelfGuarded;
 }
 
 impl AuthorizationGuardDefinitions for DiscordAccountLink {

--- a/server/usecase/src/forms/comment.rs
+++ b/server/usecase/src/forms/comment.rs
@@ -124,9 +124,14 @@ impl<
         let actor_user = Actor::from(actor.clone());
         let (form, answer_entry_set) = self.read_form_and_entry_set(&actor_user, form_id).await?;
 
-        let comment = form
-            .create_comment(&answer_entry_set, answer_id, content)?
-            .try_create(actor_user.clone())?;
+        let entry = form
+            .read_entry(&answer_entry_set, answer_id)
+            .map_err(|error| match error {
+                DomainError::NotFound => Error::from(AnswerNotFound),
+                error => Error::from(error),
+            })?;
+
+        let comment = entry.create_comment(content)?;
 
         self.comment_repository.create(comment).await
     }
@@ -156,9 +161,8 @@ impl<
             .ok_or(Error::from(CommentNotFound))?;
 
         if let Some(content) = content {
-            let updated = current_comment
-                .try_into_update()?
-                .map(|c| c.with_updated_content(content));
+            let updated = entry
+                .authorize_update(current_comment.into_inner().with_updated_content(content))?;
             self.comment_repository.update(updated).await?;
         }
 
@@ -188,7 +192,7 @@ impl<
             .find(|comment| *comment.value().comment_id() == comment_id)
             .ok_or(Error::from(CommentNotFound))?;
 
-        let comment = comment.try_into_delete()?;
+        let comment = entry.authorize_delete(comment.into_inner())?;
 
         self.comment_repository.delete(comment).await
     }


### PR DESCRIPTION
## 概要
- 子要素が誤って自己ガード (`AuthorizationGuardDefinitions`) を実装し、`AuthorizationGuard` 経由で親の前提検証をスキップしてしまう事故を、型レベルで防ぐ。stable Rust では negative trait bound が使えないため、`AuthorizationRole` 関連型で `SelfGuarded` / `ParentGuarded` を宣言し、`AuthorizationGuardDefinitions` は `Role = SelfGuarded` を、`Authorizes` の子は `Role = ParentGuarded` を要求するようにした。関連型は型ごとに一意なので、これがそのまま両方式の排他になる（例: `impl AuthorizationGuardDefinitions for Comment` はその行自体がコンパイルエラーになる）。
- `Comment` を `ParentGuarded` とし、認可を親 `AnswerEntry` の `Authorizes<Comment, _>` と `Allowed<AnswerEntry, Read>::create_comment` へ移管。自己ガードを撤廃し、`can_read => false` のハックを削除した。
- `Allowed::mint` をモジュール private にし、`Allowed` の生成を `try_*` / `authorize*`（role 境界か親の `check` を必ず通る経路）だけに限定。これに伴い `try_accept_answer` を `ActiveForm: Authorizes<AnswerEntry, Create>` 経由に変更した。

## 確認事項
- `cargo build --workspace`（presentation / entrypoint 含む全クレート）が通ることを確認。
- `cargo test -p domain -p usecase` でユニット + doctest が通過（11 passed）。`AuthorizationGuardDefinitions` の doc example も `AuthorizationRole` 実装を追記して更新済み。
- `makers pretty`（`cargo clippy -- -D warnings` + `rustfmt`）が通過。pre-commit hook の OpenAPI 差分チェックも差分なしで通過。
- レビュー観点: 役割マーカー（`SelfGuarded` / `ParentGuarded`）の割り当てが各ドメイン型の意図と一致しているか。特に `Comment` の作成/更新/削除を親 `AnswerEntry` 側の `check`（所属 + 著者本人、削除は管理者も可）に移した判定ロジックが従来と等価か。

## 補足
- 型で防げない残課題: 「本来は子なのに親ゲート `Authorizes<Child>` を実装し忘れ、自己ガードだけで済ませる」という認可の書き忘れは、その型が子であるという情報がコード上に現れないため型では検出できず、レビューで担保する領域（negative bound を使っても同様）。

🤖 Generated with Claude Code