### PR TITLE
from_raw_parts の単純実装を derive 化する

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1013,6 +1013,7 @@ dependencies = [
  "common",
  "derive-getters",
  "deriving_via",
+ "domain-derive",
  "errors",
  "mockall",
  "proptest",
@@ -1026,6 +1027,15 @@ dependencies = [
  "tracing",
  "types",
  "uuid",
+]
+
+[[package]]
+name = "domain-derive"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "server/common",
     "server/domain",
+    "server/domain-derive",
     "server/entrypoint",
     "server/errors",
     "server/infra/resource",

--- a/server/domain-derive/Cargo.toml
+++ b/server/domain-derive/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "domain-derive"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0"
+quote = "1.0"
+syn = { version = "2.0", features = ["derive"] }

--- a/server/domain-derive/src/lib.rs
+++ b/server/domain-derive/src/lib.rs
@@ -1,0 +1,59 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{Data, DeriveInput, Fields, parse_macro_input};
+
+#[proc_macro_derive(UnsafeFromRawParts)]
+pub fn derive_unsafe_from_raw_parts(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+
+    match expand_unsafe_from_raw_parts(input) {
+        Ok(tokens) => tokens.into(),
+        Err(error) => error.into_compile_error().into(),
+    }
+}
+
+fn expand_unsafe_from_raw_parts(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
+    let name = input.ident;
+    let generics = input.generics;
+
+    let Data::Struct(data) = input.data else {
+        return Err(syn::Error::new_spanned(
+            name,
+            "UnsafeFromRawParts can only be derived for structs",
+        ));
+    };
+
+    let Fields::Named(fields) = data.fields else {
+        return Err(syn::Error::new_spanned(
+            name,
+            "UnsafeFromRawParts can only be derived for structs with named fields",
+        ));
+    };
+
+    let field_names = fields
+        .named
+        .iter()
+        .map(|field| field.ident.as_ref().expect("named field"));
+    let field_args = fields.named.iter().map(|field| {
+        let name = field.ident.as_ref().expect("named field");
+        let ty = &field.ty;
+        quote! { #name: #ty }
+    });
+
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    Ok(quote! {
+        impl #impl_generics #name #ty_generics #where_clause {
+            /// 永続化済みのフィールド値から復元します。
+            ///
+            /// # Safety
+            /// 新規作成ではなく、データベースなど信頼できる永続化済みデータの復元にのみ使用してください。
+            #[allow(clippy::too_many_arguments)]
+            pub unsafe fn from_raw_parts(#(#field_args),*) -> Self {
+                Self {
+                    #(#field_names),*
+                }
+            }
+        }
+    })
+}

--- a/server/domain/Cargo.toml
+++ b/server/domain/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 async-trait = { workspace = true }
 chrono = { workspace = true }
 derive-getters = "0.5.0"
+domain-derive = { path = "../domain-derive" }
 deriving_via = { workspace = true }
 errors = { path = "../errors" }
 mockall = { workspace = true }

--- a/server/domain/src/form/answer/models.rs
+++ b/server/domain/src/form/answer/models.rs
@@ -1,6 +1,7 @@
 use chrono::{DateTime, Utc};
 use derive_getters::Getters;
 use deriving_via::DerivingVia;
+use domain_derive::UnsafeFromRawParts;
 use errors::domain::DomainError;
 #[cfg(test)]
 use proptest_derive::Arbitrary;
@@ -157,7 +158,7 @@ impl PostedAnswerContents {
     }
 }
 
-#[derive(Serialize, Deserialize, Getters, Clone, PartialEq, Debug)]
+#[derive(UnsafeFromRawParts, Serialize, Deserialize, Getters, Clone, PartialEq, Debug)]
 pub struct AnswerEntry {
     id: AnswerId,
     author: AnswerAuthor,
@@ -178,28 +179,6 @@ impl AnswerEntry {
         }
     }
 
-    /// [`AnswerEntry`] の各フィールドを指定して新しく作成します。
-    ///
-    /// # Safety
-    /// この関数はオブジェクトを新しく作成しない場合
-    /// (例えば、データベースから取得した場合)にのみ使用してください。
-    #[allow(clippy::too_many_arguments)]
-    pub unsafe fn from_raw_parts(
-        id: AnswerId,
-        author: AnswerAuthor,
-        timestamp: DateTime<Utc>,
-        title: AnswerTitle,
-        contents: Vec<FormAnswerContent>,
-    ) -> Self {
-        Self {
-            id,
-            author,
-            timestamp,
-            title,
-            contents,
-        }
-    }
-
     pub fn with_title(self, title: AnswerTitle) -> Self {
         Self { title, ..self }
     }
@@ -212,7 +191,7 @@ impl AuthorizationRole for AnswerEntry {
 pub type AnswerLabelId = types::Id<AnswerLabel>;
 
 #[cfg_attr(test, derive(Arbitrary))]
-#[derive(Serialize, Deserialize, Getters, Debug, PartialEq)]
+#[derive(UnsafeFromRawParts, Serialize, Deserialize, Getters, Debug, PartialEq)]
 pub struct AnswerLabel {
     id: AnswerLabelId,
     name: NonEmptyString,
@@ -224,14 +203,6 @@ impl AnswerLabel {
             id: AnswerLabelId::new(),
             name,
         }
-    }
-
-    /// [`AnswerLabel`] を永続化済みのフィールド値から復元します。
-    ///
-    /// # Safety
-    /// 新規作成ではなく、データベースなど信頼できる永続化済みデータの復元にのみ使用してください。
-    pub unsafe fn from_raw_parts(id: AnswerLabelId, name: NonEmptyString) -> Self {
-        Self { id, name }
     }
 
     pub fn renamed(self, name: NonEmptyString) -> Self {

--- a/server/domain/src/form/answer_entry_set/models.rs
+++ b/server/domain/src/form/answer_entry_set/models.rs
@@ -1,3 +1,4 @@
+use domain_derive::UnsafeFromRawParts;
 use errors::domain::DomainError;
 
 use crate::{
@@ -23,7 +24,7 @@ use crate::{
 /// 個々の回答の閲覧可否は [`ActiveForm`] のガードを起点とした連鎖で行われます。
 ///
 /// [`ActiveForm`]: crate::form::models::ActiveForm
-#[derive(Clone, Debug, PartialEq)]
+#[derive(UnsafeFromRawParts, Clone, Debug, PartialEq)]
 pub struct AnswerEntrySet {
     form_id: FormId,
     entries: Vec<AnswerEntry>,
@@ -35,14 +36,6 @@ impl AnswerEntrySet {
             form_id,
             entries: Vec::new(),
         }
-    }
-
-    /// [`AnswerEntrySet`] を永続化済みのフィールド値から復元します。
-    ///
-    /// # Safety
-    /// `entries` が `form_id` に属することを永続化層などで検証済みの場合にのみ使用してください。
-    pub unsafe fn from_raw_parts(form_id: FormId, entries: Vec<AnswerEntry>) -> Self {
-        Self { form_id, entries }
     }
 
     pub fn form_id(&self) -> &FormId {

--- a/server/domain/src/form/comment/models.rs
+++ b/server/domain/src/form/comment/models.rs
@@ -1,6 +1,7 @@
 use chrono::{DateTime, Utc};
 use derive_getters::Getters;
 use deriving_via::DerivingVia;
+use domain_derive::UnsafeFromRawParts;
 use serde::{Deserialize, Serialize};
 use types::non_empty_string::NonEmptyString;
 
@@ -22,7 +23,7 @@ impl CommentContent {
     }
 }
 
-#[derive(Serialize, Deserialize, Getters, Clone, Debug, PartialEq)]
+#[derive(UnsafeFromRawParts, Serialize, Deserialize, Getters, Clone, Debug, PartialEq)]
 pub struct Comment {
     answer_id: AnswerId,
     comment_id: CommentId,
@@ -49,26 +50,6 @@ impl Comment {
 
     pub fn with_updated_content(self, content: CommentContent) -> Self {
         Self { content, ..self }
-    }
-
-    /// [`Comment`] を永続化済みのフィールド値から復元します。
-    ///
-    /// # Safety
-    /// 新規作成ではなく、データベースなど信頼できる永続化済みデータの復元にのみ使用してください。
-    pub unsafe fn from_raw_parts(
-        answer_id: AnswerId,
-        comment_id: CommentId,
-        content: CommentContent,
-        timestamp: DateTime<Utc>,
-        commented_by: UserId,
-    ) -> Self {
-        Self {
-            answer_id,
-            comment_id,
-            content,
-            timestamp,
-            commented_by,
-        }
     }
 }
 

--- a/server/domain/src/form/message/models.rs
+++ b/server/domain/src/form/message/models.rs
@@ -1,5 +1,6 @@
 use chrono::{DateTime, Utc};
 use derive_getters::Getters;
+use domain_derive::UnsafeFromRawParts;
 use errors::domain::DomainError;
 use serde::{Deserialize, Serialize};
 
@@ -14,7 +15,7 @@ impl AuthorizationRole for Message {
     type Role = ParentGuarded;
 }
 
-#[derive(Getters, Clone, PartialEq, Debug, Serialize, Deserialize)]
+#[derive(UnsafeFromRawParts, Getters, Clone, PartialEq, Debug, Serialize, Deserialize)]
 pub struct Message {
     id: MessageId,
     sender_id: UserId,
@@ -63,46 +64,5 @@ impl Message {
         }
 
         Ok(Self { body, ..self })
-    }
-
-    /// [`Message`] の各フィールドの値を受け取り、[`Message`] を生成します。
-    ///
-    /// # Examples
-    /// ```
-    /// use chrono::Utc;
-    /// use domain::{
-    ///     form::message::models::{Message, MessageId},
-    ///     user::models::UserId,
-    /// };
-    /// use uuid::Uuid;
-    ///
-    /// let user_id: UserId = Uuid::new_v4().into();
-    ///
-    /// unsafe {
-    ///     let message = Message::from_raw_parts(
-    ///         MessageId::new(),
-    ///         user_id,
-    ///         "test message".to_string(),
-    ///         Utc::now(),
-    ///     );
-    /// }
-    /// ```
-    ///
-    /// # Safety
-    /// この関数は [`Message`] のバリデーションをスキップするため、
-    /// データベースからすでにバリデーションされているデータを読み出すときなど、
-    /// データの信頼性が保証されている場合にのみ使用してください。
-    pub unsafe fn from_raw_parts(
-        id: MessageId,
-        sender_id: UserId,
-        body: String,
-        timestamp: DateTime<Utc>,
-    ) -> Self {
-        Self {
-            id,
-            sender_id,
-            body,
-            timestamp,
-        }
     }
 }

--- a/server/domain/src/form/message_thread/models.rs
+++ b/server/domain/src/form/message_thread/models.rs
@@ -1,3 +1,4 @@
+use domain_derive::UnsafeFromRawParts;
 use errors::domain::DomainError;
 
 use crate::{
@@ -12,7 +13,7 @@ use crate::{
     user::models::{Actor, Role::Administrator, User, UserId},
 };
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(UnsafeFromRawParts, Clone, Debug, PartialEq)]
 pub struct MessageThread {
     answer_id: AnswerId,
     answer_author_id: UserId,
@@ -25,22 +26,6 @@ impl MessageThread {
             answer_id,
             answer_author_id,
             messages: Vec::new(),
-        }
-    }
-
-    /// [`MessageThread`] を永続化済みのフィールド値から復元します。
-    ///
-    /// # Safety
-    /// `messages` が `answer_id` に属することを永続化層などで検証済みの場合にのみ使用してください。
-    pub unsafe fn from_raw_parts(
-        answer_id: AnswerId,
-        answer_author_id: UserId,
-        messages: Vec<Message>,
-    ) -> Self {
-        Self {
-            answer_id,
-            answer_author_id,
-            messages,
         }
     }
 

--- a/server/domain/src/form/models.rs
+++ b/server/domain/src/form/models.rs
@@ -3,6 +3,7 @@ use chrono::{DateTime, Utc};
 use common::test_utils::{arbitrary_date_time, arbitrary_opt_date_time};
 use derive_getters::Getters;
 use deriving_via::DerivingVia;
+use domain_derive::UnsafeFromRawParts;
 use errors::domain::DomainError;
 #[cfg(test)]
 use proptest::{collection::SizeRange, prelude::*, strategy::BoxedStrategy};
@@ -58,7 +59,7 @@ impl FormDescription {
 }
 
 #[cfg_attr(test, derive(Arbitrary))]
-#[derive(Serialize, Deserialize, Clone, Default, Debug, PartialEq)]
+#[derive(UnsafeFromRawParts, Serialize, Deserialize, Clone, Default, Debug, PartialEq)]
 pub struct FormSettings {
     #[serde(default)]
     webhook_url: WebhookUrl,
@@ -95,17 +96,6 @@ impl FormSettings {
 
     pub fn change_visibility(self, visibility: Visibility) -> Self {
         Self { visibility, ..self }
-    }
-
-    /// [`FormSettings`] を永続化済みのフィールド値から復元します。
-    ///
-    /// # Safety
-    /// 新規作成ではなく、データベースなど信頼できる永続化済みデータの復元にのみ使用してください。
-    pub unsafe fn from_raw_parts(webhook_url: WebhookUrl, visibility: Visibility) -> Self {
-        Self {
-            webhook_url,
-            visibility,
-        }
     }
 }
 
@@ -318,7 +308,7 @@ impl AnswerSettings {
 }
 
 #[cfg_attr(test, derive(Arbitrary))]
-#[derive(Serialize, Deserialize, Clone, Default, Debug, PartialEq)]
+#[derive(UnsafeFromRawParts, Serialize, Deserialize, Clone, Default, Debug, PartialEq)]
 pub struct FormMeta {
     #[cfg_attr(test, proptest(strategy = "arbitrary_date_time()"))]
     #[serde(default = "chrono::Utc::now")]
@@ -333,17 +323,6 @@ impl FormMeta {
         Self {
             created_at: Utc::now(),
             updated_at: Utc::now(),
-        }
-    }
-
-    /// [`FormMeta`] を永続化済みのフィールド値から復元します。
-    ///
-    /// # Safety
-    /// 新規作成ではなく、データベースなど信頼できる永続化済みデータの復元にのみ使用してください。
-    pub unsafe fn from_raw_parts(created_at: DateTime<Utc>, updated_at: DateTime<Utc>) -> Self {
-        Self {
-            created_at,
-            updated_at,
         }
     }
 }
@@ -398,7 +377,7 @@ impl Arbitrary for FormLabelIdSet {
 }
 
 #[cfg_attr(test, derive(Arbitrary))]
-#[derive(Serialize, Deserialize, Getters, Clone, Debug, PartialEq)]
+#[derive(UnsafeFromRawParts, Serialize, Deserialize, Getters, Clone, Debug, PartialEq)]
 pub struct ActiveForm {
     #[serde(default)]
     id: FormId,
@@ -458,33 +437,6 @@ impl ActiveForm {
 
     pub fn replace_label_ids(self, label_ids: FormLabelIdSet) -> Self {
         Self { label_ids, ..self }
-    }
-
-    /// [`ActiveForm`] を永続化済みのフィールド値から復元します。
-    ///
-    /// # Safety
-    /// 新規作成ではなく、データベースなど信頼できる永続化済みデータの復元にのみ使用してください。
-    #[allow(clippy::too_many_arguments)]
-    pub unsafe fn from_raw_parts(
-        id: FormId,
-        title: FormTitle,
-        description: FormDescription,
-        metadata: FormMeta,
-        settings: FormSettings,
-        answer_settings: AnswerSettings,
-        questions: QuestionSet,
-        label_ids: FormLabelIdSet,
-    ) -> Self {
-        Self {
-            id,
-            title,
-            description,
-            metadata,
-            settings,
-            answer_settings,
-            questions,
-            label_ids,
-        }
     }
 
     pub fn archive(self, archived_at: DateTime<Utc>, archived_by: UserId) -> ArchivedForm {
@@ -923,7 +875,7 @@ impl FormLabelName {
 }
 
 #[cfg_attr(test, derive(Arbitrary))]
-#[derive(Serialize, Deserialize, Getters, Debug, PartialEq)]
+#[derive(UnsafeFromRawParts, Serialize, Deserialize, Getters, Debug, PartialEq)]
 pub struct FormLabel {
     id: FormLabelId,
     name: FormLabelName,
@@ -939,14 +891,6 @@ impl FormLabel {
 
     pub fn renamed(&self, name: FormLabelName) -> Self {
         Self { id: self.id, name }
-    }
-
-    /// [`FormLabel`] を永続化済みのフィールド値から復元します。
-    ///
-    /// # Safety
-    /// 新規作成ではなく、データベースなど信頼できる永続化済みデータの復元にのみ使用してください。
-    pub unsafe fn from_raw_parts(id: FormLabelId, name: FormLabelName) -> Self {
-        Self { id, name }
     }
 }
 

--- a/server/domain/src/notification/models.rs
+++ b/server/domain/src/notification/models.rs
@@ -1,4 +1,5 @@
 use derive_getters::Getters;
+use domain_derive::UnsafeFromRawParts;
 
 use crate::{
     types::authorization_guard::{AuthorizationGuardDefinitions, AuthorizationRole, SelfGuarded},
@@ -25,7 +26,7 @@ impl NotificationContent {
     }
 }
 
-#[derive(Getters, Debug, Clone)]
+#[derive(UnsafeFromRawParts, Getters, Debug, Clone)]
 pub struct NotificationPreference {
     recipient_id: UserId,
     is_send_message_notification: bool,
@@ -43,17 +44,6 @@ impl NotificationPreference {
         Self {
             is_send_message_notification,
             ..self
-        }
-    }
-
-    /// [`NotificationPreference`] を永続化済みのフィールド値から復元します。
-    ///
-    /// # Safety
-    /// 新規作成ではなく、データベースなど信頼できる永続化済みデータの復元にのみ使用してください。
-    pub unsafe fn from_raw_parts(recipient_id: UserId, is_send_message_notification: bool) -> Self {
-        Self {
-            recipient_id,
-            is_send_message_notification,
         }
     }
 }

--- a/server/domain/src/user/models.rs
+++ b/server/domain/src/user/models.rs
@@ -2,6 +2,7 @@
 use common::test_utils::arbitrary_uuid_v4;
 use derive_getters::Getters;
 use deriving_via::DerivingVia;
+use domain_derive::UnsafeFromRawParts;
 #[cfg(test)]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
@@ -114,7 +115,7 @@ pub struct TemporaryUserId(#[underlying] Uuid);
 /// `name` と `contact_text` は、管理者や回答閲覧者が回答者を識別し、必要に応じて
 /// 連絡するための入力値である。権限判定上は回答の作成主体としてだけ使われ、
 /// 通常の `User` と同じ閲覧・更新権限は持たない。
-#[derive(Serialize, Deserialize, Getters, Debug, Clone, PartialEq, Eq)]
+#[derive(UnsafeFromRawParts, Serialize, Deserialize, Getters, Debug, Clone, PartialEq, Eq)]
 pub struct TemporaryUser {
     id: TemporaryUserId,
     name: String,
@@ -125,18 +126,6 @@ impl TemporaryUser {
     pub fn new(name: String, contact_text: String) -> Self {
         Self {
             id: TemporaryUserId::from(Uuid::new_v4()),
-            name,
-            contact_text,
-        }
-    }
-
-    /// [`TemporaryUser`] を永続化済みのフィールド値から復元します。
-    ///
-    /// # Safety
-    /// 新規作成ではなく、データベースなど信頼できる永続化済みデータの復元にのみ使用してください。
-    pub unsafe fn from_raw_parts(id: TemporaryUserId, name: String, contact_text: String) -> Self {
-        Self {
-            id,
             name,
             contact_text,
         }


### PR DESCRIPTION
## 概要
- ドメイン層の単純な `from_raw_parts` 実装を `#[derive(UnsafeFromRawParts)]` で生成できるようにしました。
- `from_raw_parts` は引き続き `unsafe fn` として生成し、永続化済みデータからの復元という既存の信頼境界を維持しています。
- `Question` / `Choice` のように復元時の整合性チェックや `Result` が必要なものは手書き実装のまま残しています。

## 確認事項
- `cargo build` で workspace がコンパイルできることを確認しました。
- `makers pretty` で nextest 59 件、doctest、clippy `-D warnings`、rustfmt が通ることを確認しました。
- コミット時 hook の OpenAPI 差分チェックで `docs/openapi.json` に差分が出ないことを確認しました。

🤖 Generated with Codex
