### PR TITLE
Authorizes::check が条件だけを記述すれば良いようにする

### DIFF
--- a/server/domain/src/form/answer_entry_set/models.rs
+++ b/server/domain/src/form/answer_entry_set/models.rs
@@ -60,58 +60,33 @@ impl AuthorizationRole for AnswerEntrySet {
 }
 
 impl Authorizes<Comment, Read> for AnswerEntry {
-    fn check(&self, _actor: &Actor, child: &Comment) -> Result<(), DomainError> {
-        if child.answer_id() == self.id() {
-            Ok(())
-        } else {
-            Err(DomainError::Forbidden)
-        }
+    fn check(&self, _actor: &Actor, child: &Comment) -> bool {
+        child.answer_id() == self.id()
     }
 }
 
 impl Authorizes<Comment, Create> for AnswerEntry {
-    fn check(&self, actor: &Actor, child: &Comment) -> Result<(), DomainError> {
-        if child.answer_id() != self.id() {
-            return Err(DomainError::Forbidden);
-        }
-
-        match actor {
-            Actor::User(User::ActiveUser(user)) if user.id() == child.commented_by() => Ok(()),
-            _ => Err(DomainError::Forbidden),
-        }
+    fn check(&self, actor: &Actor, child: &Comment) -> bool {
+        child.answer_id() == self.id()
+            && matches!(actor, Actor::User(User::ActiveUser(user)) if user.id() == child.commented_by())
     }
 }
 
 impl Authorizes<Comment, Update> for AnswerEntry {
-    fn check(&self, actor: &Actor, child: &Comment) -> Result<(), DomainError> {
-        if child.answer_id() != self.id() {
-            return Err(DomainError::Forbidden);
-        }
-
-        if matches!(actor, Actor::User(User::ActiveUser(user)) if user.id() == child.commented_by())
-        {
-            Ok(())
-        } else {
-            Err(DomainError::Forbidden)
-        }
+    fn check(&self, actor: &Actor, child: &Comment) -> bool {
+        child.answer_id() == self.id()
+            && matches!(actor, Actor::User(User::ActiveUser(user)) if user.id() == child.commented_by())
     }
 }
 
 impl Authorizes<Comment, Delete> for AnswerEntry {
-    fn check(&self, actor: &Actor, child: &Comment) -> Result<(), DomainError> {
-        if child.answer_id() != self.id() {
-            return Err(DomainError::Forbidden);
-        }
-
-        if matches!(
-            actor,
-            Actor::User(User::ActiveUser(user))
-                if user.id() == child.commented_by() || user.role() == &Role::Administrator
-        ) {
-            Ok(())
-        } else {
-            Err(DomainError::Forbidden)
-        }
+    fn check(&self, actor: &Actor, child: &Comment) -> bool {
+        child.answer_id() == self.id()
+            && matches!(
+                actor,
+                Actor::User(User::ActiveUser(user))
+                    if user.id() == child.commented_by() || user.role() == &Role::Administrator
+            )
     }
 }
 

--- a/server/domain/src/form/message_thread/models.rs
+++ b/server/domain/src/form/message_thread/models.rs
@@ -84,24 +84,18 @@ impl MessageThread {
 }
 
 impl Authorizes<Message, Update> for MessageThread {
-    fn check(&self, actor: &Actor, message: &Message) -> Result<(), DomainError> {
-        match actor {
-            Actor::User(User::ActiveUser(user)) if message.sender_id() == user.id() => Ok(()),
-            _ => Err(DomainError::Forbidden),
-        }
+    fn check(&self, actor: &Actor, message: &Message) -> bool {
+        matches!(actor, Actor::User(User::ActiveUser(user)) if message.sender_id() == user.id())
     }
 }
 
 impl Authorizes<Message, Delete> for MessageThread {
-    fn check(&self, actor: &Actor, message: &Message) -> Result<(), DomainError> {
-        match actor {
+    fn check(&self, actor: &Actor, message: &Message) -> bool {
+        matches!(
+            actor,
             Actor::User(User::ActiveUser(user))
-                if message.sender_id() == user.id() || user.role() == &Administrator =>
-            {
-                Ok(())
-            }
-            _ => Err(DomainError::Forbidden),
-        }
+                if message.sender_id() == user.id() || user.role() == &Administrator
+        )
     }
 }
 

--- a/server/domain/src/form/models.rs
+++ b/server/domain/src/form/models.rs
@@ -451,55 +451,33 @@ impl ActiveForm {
 /// [`ActiveForm`] が保持する [`AnswerSettings`] のポリシーで判断される。所属検証と
 /// ポリシー判断のいずれもドメイン内で完結する。
 impl Authorizes<AnswerEntrySet, Read> for ActiveForm {
-    fn check(&self, _actor: &Actor, set: &AnswerEntrySet) -> Result<(), DomainError> {
-        if set.form_id() == self.id() {
-            Ok(())
-        } else {
-            Err(DomainError::Forbidden)
-        }
+    fn check(&self, _actor: &Actor, set: &AnswerEntrySet) -> bool {
+        set.form_id() == self.id()
     }
 }
 
 impl Authorizes<AnswerEntrySet, Update> for ActiveForm {
-    fn check(&self, _actor: &Actor, set: &AnswerEntrySet) -> Result<(), DomainError> {
-        if set.form_id() == self.id() {
-            Ok(())
-        } else {
-            Err(DomainError::Forbidden)
-        }
+    fn check(&self, _actor: &Actor, set: &AnswerEntrySet) -> bool {
+        set.form_id() == self.id()
     }
 }
 
 impl Authorizes<AnswerEntry, Read> for ActiveForm {
-    fn check(&self, actor: &Actor, entry: &AnswerEntry) -> Result<(), DomainError> {
-        if self.answer_settings.can_read_entry(entry, actor) {
-            Ok(())
-        } else {
-            Err(DomainError::Forbidden)
-        }
+    fn check(&self, actor: &Actor, entry: &AnswerEntry) -> bool {
+        self.answer_settings.can_read_entry(entry, actor)
     }
 }
 
 impl Authorizes<AnswerEntry, Update> for ActiveForm {
-    fn check(&self, actor: &Actor, _entry: &AnswerEntry) -> Result<(), DomainError> {
-        if is_administrator(actor) {
-            Ok(())
-        } else {
-            Err(DomainError::Forbidden)
-        }
+    fn check(&self, actor: &Actor, _entry: &AnswerEntry) -> bool {
+        is_administrator(actor)
     }
 }
 
 impl Authorizes<AnswerEntry, Create> for ActiveForm {
-    fn check(&self, actor: &Actor, entry: &AnswerEntry) -> Result<(), DomainError> {
-        if self
-            .answer_settings
+    fn check(&self, actor: &Actor, entry: &AnswerEntry) -> bool {
+        self.answer_settings
             .can_accept_answer(entry.author(), actor)
-        {
-            Ok(())
-        } else {
-            Err(DomainError::Forbidden)
-        }
     }
 }
 

--- a/server/domain/src/types/authorization_guard.rs
+++ b/server/domain/src/types/authorization_guard.rs
@@ -169,8 +169,11 @@ impl<T, A: Actions> Allowed<T, A> {
         T: Authorizes<C, A>,
         C: AuthorizationRole<Role = ParentGuarded>,
     {
-        self.value.check(&self.actor, &child)?;
-        Ok(Allowed::mint(child, self.actor.clone()))
+        if self.value.check(&self.actor, &child) {
+            Ok(Allowed::mint(child, self.actor.clone()))
+        } else {
+            Err(DomainError::Forbidden)
+        }
     }
 }
 
@@ -193,8 +196,11 @@ impl<T> Allowed<T, Update> {
         T: Authorizes<C, Delete>,
         C: AuthorizationRole<Role = ParentGuarded>,
     {
-        self.value.check(&self.actor, &child)?;
-        Ok(Allowed::mint(child, self.actor.clone()))
+        if self.value.check(&self.actor, &child) {
+            Ok(Allowed::mint(child, self.actor.clone()))
+        } else {
+            Err(DomainError::Forbidden)
+        }
     }
 }
 
@@ -218,8 +224,11 @@ impl<T> Allowed<T, Read> {
         T: Authorizes<C, Create>,
         C: AuthorizationRole<Role = ParentGuarded>,
     {
-        self.value.check(&self.actor, &child)?;
-        Ok(Allowed::mint(child, self.actor.clone()))
+        if self.value.check(&self.actor, &child) {
+            Ok(Allowed::mint(child, self.actor.clone()))
+        } else {
+            Err(DomainError::Forbidden)
+        }
     }
 
     /// 読み取り認可済みの親要素から、子要素の更新認可済み値を作ります。
@@ -230,8 +239,11 @@ impl<T> Allowed<T, Read> {
         T: Authorizes<C, Update>,
         C: AuthorizationRole<Role = ParentGuarded>,
     {
-        self.value.check(&self.actor, &child)?;
-        Ok(Allowed::mint(child, self.actor.clone()))
+        if self.value.check(&self.actor, &child) {
+            Ok(Allowed::mint(child, self.actor.clone()))
+        } else {
+            Err(DomainError::Forbidden)
+        }
     }
 
     /// 読み取り認可済みの親要素から、子要素の削除認可済み値を作ります。
@@ -242,8 +254,11 @@ impl<T> Allowed<T, Read> {
         T: Authorizes<C, Delete>,
         C: AuthorizationRole<Role = ParentGuarded>,
     {
-        self.value.check(&self.actor, &child)?;
-        Ok(Allowed::mint(child, self.actor.clone()))
+        if self.value.check(&self.actor, &child) {
+            Ok(Allowed::mint(child, self.actor.clone()))
+        } else {
+            Err(DomainError::Forbidden)
+        }
     }
 
     /// 読み取り認可済みの値を、同じ [`Actor`] で更新認可に昇格します。
@@ -272,11 +287,8 @@ impl<T> Allowed<T, Read> {
 }
 
 /// 認可済みの親要素が、子要素の同じ操作も認可できることを表すトレイトです。
-///
-/// 例えば回答が読める利用者に、その回答に紐づくコメントの読み取りも許可する場合に使います。
-/// 例えば回答集合を更新できる利用者に、その集合に含まれる回答タイトルの更新も許可する場合に使います。
 pub trait Authorizes<Child: AuthorizationRole<Role = ParentGuarded>, A: Actions> {
-    fn check(&self, actor: &Actor, child: &Child) -> Result<(), DomainError>;
+    fn check(&self, actor: &Actor, child: &Child) -> bool;
 }
 
 impl<T: AuthorizationGuardDefinitions> AuthorizationGuard<T, Create> {

--- a/server/domain/src/types/authorization_guard.rs
+++ b/server/domain/src/types/authorization_guard.rs
@@ -169,6 +169,20 @@ impl<T, A: Actions> Allowed<T, A> {
         T: Authorizes<C, A>,
         C: AuthorizationRole<Role = ParentGuarded>,
     {
+        self.authorize_any(child)
+    }
+
+    /// 親要素が実装する [`Authorizes`] で子要素を検証し、成功した場合だけ
+    /// 同じ [`Actor`] の [`Allowed<C, TargetAction>`] を作る共通処理です。
+    fn authorize_any<C, TargetAction>(
+        &self,
+        child: C,
+    ) -> Result<Allowed<C, TargetAction>, DomainError>
+    where
+        T: Authorizes<C, TargetAction>,
+        C: AuthorizationRole<Role = ParentGuarded>,
+        TargetAction: Actions,
+    {
         if self.value.check(&self.actor, &child) {
             Ok(Allowed::mint(child, self.actor.clone()))
         } else {
@@ -196,11 +210,7 @@ impl<T> Allowed<T, Update> {
         T: Authorizes<C, Delete>,
         C: AuthorizationRole<Role = ParentGuarded>,
     {
-        if self.value.check(&self.actor, &child) {
-            Ok(Allowed::mint(child, self.actor.clone()))
-        } else {
-            Err(DomainError::Forbidden)
-        }
+        self.authorize_any(child)
     }
 }
 
@@ -224,11 +234,7 @@ impl<T> Allowed<T, Read> {
         T: Authorizes<C, Create>,
         C: AuthorizationRole<Role = ParentGuarded>,
     {
-        if self.value.check(&self.actor, &child) {
-            Ok(Allowed::mint(child, self.actor.clone()))
-        } else {
-            Err(DomainError::Forbidden)
-        }
+        self.authorize_any(child)
     }
 
     /// 読み取り認可済みの親要素から、子要素の更新認可済み値を作ります。
@@ -239,11 +245,7 @@ impl<T> Allowed<T, Read> {
         T: Authorizes<C, Update>,
         C: AuthorizationRole<Role = ParentGuarded>,
     {
-        if self.value.check(&self.actor, &child) {
-            Ok(Allowed::mint(child, self.actor.clone()))
-        } else {
-            Err(DomainError::Forbidden)
-        }
+        self.authorize_any(child)
     }
 
     /// 読み取り認可済みの親要素から、子要素の削除認可済み値を作ります。
@@ -254,11 +256,7 @@ impl<T> Allowed<T, Read> {
         T: Authorizes<C, Delete>,
         C: AuthorizationRole<Role = ParentGuarded>,
     {
-        if self.value.check(&self.actor, &child) {
-            Ok(Allowed::mint(child, self.actor.clone()))
-        } else {
-            Err(DomainError::Forbidden)
-        }
+        self.authorize_any(child)
     }
 
     /// 読み取り認可済みの値を、同じ [`Actor`] で更新認可に昇格します。


### PR DESCRIPTION
check は本来、認可の権限判定 (Forbidden) だけを担うべきところ、
各 impl が if cond { Ok(()) } else { Err(Forbidden) } を手書きし、
全実装が Forbidden 以外を返さないにもかかわらず Result の表現力を
未使用のまま抱えていた。

Forbidden への変換を authorize* 系メソッドへ集約し、check は条件のみを
返す bool 述語にする。これにより can_* (自己ガード) と責任分担が対称になり、
ボイラープレートも除去される。挙動は不変 (false → Forbidden)。

なお所属検証 (child の親 id 一致) は現状どおり bool 条件に畳んで残す。
これを NotFound として切り出すかは別途検討する。

Co-authored-by: Claude <noreply@anthropic.com>
