### PR TITLE
順序付きユニーク Vec 型を導入する

### DIFF
--- a/server/domain/src/form/label.rs
+++ b/server/domain/src/form/label.rs
@@ -6,8 +6,8 @@ use errors::domain::DomainError;
 use proptest::{collection::SizeRange, prelude::*, strategy::BoxedStrategy};
 #[cfg(test)]
 use proptest_derive::Arbitrary;
-use serde::{Deserialize, Deserializer, Serialize, de};
-use types::non_empty_string::NonEmptyString;
+use serde::{Deserialize, Serialize};
+use types::{non_empty_string::NonEmptyString, ordered_unique_vec::OrderedUniqueVec};
 
 use crate::{
     form::is_administrator,
@@ -80,38 +80,28 @@ impl AuthorizationGuardDefinitions for FormLabel {
     }
 }
 
-#[derive(Serialize, Clone, DerivingVia, Default, Debug, PartialEq)]
-#[deriving(IntoInner)]
-pub struct FormLabelAssignment(Vec<FormLabelId>);
+#[derive(Serialize, Deserialize, Clone, Default, Debug, PartialEq)]
+pub struct FormLabelAssignment(OrderedUniqueVec<FormLabelId>);
 
 impl FormLabelAssignment {
     pub fn try_new(label_ids: Vec<FormLabelId>) -> Result<Self, DomainError> {
-        if label_ids
-            .iter()
-            .enumerate()
-            .any(|(index, label_id)| label_ids[..index].contains(label_id))
-        {
-            return Err(DomainError::InvalidEntity {
+        OrderedUniqueVec::try_new(label_ids)
+            .map(Self)
+            .map_err(|_| DomainError::InvalidEntity {
                 message: "form label ids must be unique within a form".to_string(),
-            });
-        }
-
-        Ok(Self(label_ids))
+            })
     }
 
     pub fn empty() -> Self {
-        Self(Vec::new())
+        Self(OrderedUniqueVec::empty())
     }
 
     pub fn as_slice(&self) -> &[FormLabelId] {
-        &self.0
+        self.0.as_slice()
     }
-}
 
-impl<'de> Deserialize<'de> for FormLabelAssignment {
-    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        Vec::<FormLabelId>::deserialize(deserializer)
-            .and_then(|value| FormLabelAssignment::try_new(value).map_err(de::Error::custom))
+    pub fn into_inner(self) -> Vec<FormLabelId> {
+        self.0.into_inner()
     }
 }
 
@@ -147,22 +137,5 @@ mod tests {
         let label_ids = FormLabelAssignment::try_new(vec![first, second]).unwrap();
 
         assert_eq!(label_ids.as_slice(), &[first, second]);
-    }
-
-    #[test]
-    fn form_label_assignment_rejects_duplicate_ids() {
-        let label_id = FormLabelId::new();
-        let result = FormLabelAssignment::try_new(vec![label_id, label_id]);
-
-        assert!(matches!(result, Err(DomainError::InvalidEntity { .. })));
-    }
-
-    #[test]
-    fn form_label_assignment_deserialize_rejects_duplicate_ids() {
-        let label_id = FormLabelId::new();
-        let serialized = serde_json::to_string(&vec![label_id, label_id]).unwrap();
-        let result = serde_json::from_str::<FormLabelAssignment>(&serialized);
-
-        assert!(result.is_err());
     }
 }

--- a/server/errors/src/validation.rs
+++ b/server/errors/src/validation.rs
@@ -6,4 +6,6 @@ pub enum ValidationError {
     EmptyValue,
     #[error("Negative value.")]
     NegativeValue,
+    #[error("Duplicate element.")]
+    DuplicateElement,
 }

--- a/server/presentation/src/handlers/error_handler.rs
+++ b/server/presentation/src/handlers/error_handler.rs
@@ -295,6 +295,12 @@ fn handle_validation_error(err: ValidationError) -> impl IntoResponse {
             "Negative value error.",
             "NEGATIVE_VALUE",
         ),
+        ValidationError::DuplicateElement => problem_response(
+            StatusCode::BAD_REQUEST,
+            "Bad Request",
+            "Duplicate element error.",
+            "DUPLICATE_ELEMENT",
+        ),
     }
 }
 

--- a/server/types/Cargo.toml
+++ b/server/types/Cargo.toml
@@ -17,3 +17,6 @@ uuid = { workspace = true }
 common = { path = "../common", optional = true }
 errors = { path = "../errors" }
 utoipa = { workspace = true }
+
+[dev-dependencies]
+proptest = { workspace = true }

--- a/server/types/src/lib.rs
+++ b/server/types/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod natural_f32;
 pub mod non_empty_string;
 pub mod non_empty_vec;
+pub mod ordered_unique_vec;
 
 #[cfg(feature = "arbitrary")]
 use common::test_utils::arbitrary_uuid_v7;

--- a/server/types/src/ordered_unique_vec.rs
+++ b/server/types/src/ordered_unique_vec.rs
@@ -1,0 +1,133 @@
+use std::ops::Deref;
+
+use errors::validation::{ValidationError, ValidationError::DuplicateElement};
+#[cfg(any(test, feature = "arbitrary"))]
+use proptest::{
+    arbitrary::Arbitrary,
+    collection::SizeRange,
+    strategy::{BoxedStrategy, Strategy},
+};
+use serde::{Deserialize, Serialize};
+
+/// 要素の順序を保持し、重複する要素を拒否する Vec です。
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+pub struct OrderedUniqueVec<T>(Vec<T>);
+
+impl<T: PartialEq> OrderedUniqueVec<T> {
+    pub fn try_new(value: Vec<T>) -> Result<Self, ValidationError> {
+        if value
+            .iter()
+            .enumerate()
+            .any(|(index, item)| value[..index].contains(item))
+        {
+            return Err(DuplicateElement);
+        }
+
+        Ok(Self(value))
+    }
+
+    pub fn empty() -> Self {
+        Self(Vec::new())
+    }
+}
+
+impl<T> OrderedUniqueVec<T> {
+    pub fn as_slice(&self) -> &[T] {
+        &self.0
+    }
+
+    pub fn into_inner(self) -> Vec<T> {
+        self.0
+    }
+}
+
+impl<T> Deref for OrderedUniqueVec<T> {
+    type Target = Vec<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T: Serialize> Serialize for OrderedUniqueVec<T> {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.0.serialize(serializer)
+    }
+}
+
+impl<'de, T> Deserialize<'de> for OrderedUniqueVec<T>
+where
+    T: Deserialize<'de> + PartialEq,
+{
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        Vec::<T>::deserialize(deserializer)
+            .and_then(|value| OrderedUniqueVec::try_new(value).map_err(serde::de::Error::custom))
+    }
+}
+
+#[cfg(any(test, feature = "arbitrary"))]
+impl<T> Arbitrary for OrderedUniqueVec<T>
+where
+    T: Arbitrary + PartialEq + 'static,
+    T::Strategy: 'static,
+{
+    type Parameters = (SizeRange, T::Parameters);
+    type Strategy = BoxedStrategy<Self>;
+
+    fn arbitrary_with(args: Self::Parameters) -> Self::Strategy {
+        Vec::<T>::arbitrary_with(args)
+            .prop_map(|value| {
+                let mut unique = Vec::new();
+                for item in value {
+                    if !unique.contains(&item) {
+                        unique.push(item);
+                    }
+                }
+                OrderedUniqueVec(unique)
+            })
+            .boxed()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn allows_empty_vec() {
+        let value = OrderedUniqueVec::<i32>::try_new(vec![]).unwrap();
+
+        assert!(value.as_slice().is_empty());
+    }
+
+    #[test]
+    fn preserves_unique_values_in_order() {
+        let value = OrderedUniqueVec::try_new(vec![3, 1, 2]).unwrap();
+
+        assert_eq!(value.as_slice(), &[3, 1, 2]);
+    }
+
+    #[test]
+    fn rejects_duplicate_values() {
+        let result = OrderedUniqueVec::try_new(vec![1, 2, 1]);
+
+        assert_eq!(result, Err(DuplicateElement));
+    }
+
+    #[test]
+    fn serialize_deserialize() {
+        let value = OrderedUniqueVec::try_new(vec![1, 2, 3]).unwrap();
+        let serialized = serde_json::to_string(&value).unwrap();
+        let deserialized: OrderedUniqueVec<i32> = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(serialized, "[1,2,3]");
+        assert_eq!(value, deserialized);
+    }
+
+    #[test]
+    fn deserialize_rejects_duplicate_values() {
+        let result = serde_json::from_str::<OrderedUniqueVec<i32>>("[1,2,1]");
+
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
## 概要
- フォームラベル割り当てに閉じていた「順序を保持し、重複を拒否する」制約を `OrderedUniqueVec` として `types` に切り出しました。
- `FormLabelAssignment` はドメイン語彙として残しつつ、内部表現と重複検証を汎用型へ委譲しました。
- 重複要素は `ValidationError::DuplicateElement` として表現し、presentation のエラー変換も追加しています。

## 確認事項
- `cargo test -p types` により、`OrderedUniqueVec` の空配列、順序保持、重複拒否、serde 往復、deserialize 時の重複拒否を確認しました。
- `cargo test -p domain form_label_assignment` により、`FormLabelAssignment` が空および unique な label id 群を受け入れることを確認しました。
- `cargo build` とコミット hook の `check-openapi` が通り、全体の型整合性と OpenAPI 差分がないことを確認しました。

🤖 Generated with Codex