### PR TITLE
ArchivedForm の永続化復元を derive に寄せる

### DIFF
--- a/server/domain/src/form/models.rs
+++ b/server/domain/src/form/models.rs
@@ -200,7 +200,7 @@ impl Allowed<ActiveForm, Update> {
     }
 }
 
-#[derive(Serialize, Deserialize, Getters, Clone, Debug, PartialEq)]
+#[derive(UnsafeFromRawParts, Serialize, Deserialize, Getters, Clone, Debug, PartialEq)]
 pub struct ArchivedForm {
     form: ActiveForm,
     archived_at: DateTime<Utc>,
@@ -214,18 +214,6 @@ impl ArchivedForm {
             archived_at,
             archived_by,
         }
-    }
-
-    /// [`ArchivedForm`] の各フィールドを指定して再構築します。
-    ///
-    /// データベースから復元したデータなど、通常のアーカイブ操作を経ずに
-    /// [`ArchivedForm`] を組み立てる場合に使用します。
-    pub fn from_persisted(
-        form: ActiveForm,
-        archived_at: DateTime<Utc>,
-        archived_by: UserId,
-    ) -> Self {
-        Self::new(form, archived_at, archived_by)
     }
 
     pub fn unarchive(self) -> ActiveForm {

--- a/server/infra/resource/src/records.rs
+++ b/server/infra/resource/src/records.rs
@@ -186,13 +186,15 @@ impl TryFrom<ArchivedFormRecord> for ArchivedForm {
     type Error = Error;
 
     fn try_from(value: ArchivedFormRecord) -> Result<Self, Self::Error> {
-        Ok(ArchivedForm::from_persisted(
-            value.form.try_into()?,
-            value.archived_at,
-            Uuid::from_str(&value.archived_by_id)
-                .map_err(Into::<InfraError>::into)?
-                .into(),
-        ))
+        Ok(unsafe {
+            ArchivedForm::from_raw_parts(
+                value.form.try_into()?,
+                value.archived_at,
+                Uuid::from_str(&value.archived_by_id)
+                    .map_err(Into::<InfraError>::into)?
+                    .into(),
+            )
+        })
     }
 }
 

--- a/server/infra/resource/src/records.rs
+++ b/server/infra/resource/src/records.rs
@@ -186,15 +186,12 @@ impl TryFrom<ArchivedFormRecord> for ArchivedForm {
     type Error = Error;
 
     fn try_from(value: ArchivedFormRecord) -> Result<Self, Self::Error> {
-        Ok(unsafe {
-            ArchivedForm::from_raw_parts(
-                value.form.try_into()?,
-                value.archived_at,
-                Uuid::from_str(&value.archived_by_id)
-                    .map_err(Into::<InfraError>::into)?
-                    .into(),
-            )
-        })
+        let form = value.form.try_into()?;
+        let archived_by = Uuid::from_str(&value.archived_by_id)
+            .map_err(Into::<InfraError>::into)?
+            .into();
+
+        Ok(unsafe { ArchivedForm::from_raw_parts(form, value.archived_at, archived_by) })
     }
 }
 


### PR DESCRIPTION
## 概要
- `ArchivedForm` の永続化復元 API を、既存モデルと同じ `UnsafeFromRawParts` derive に統一
- 手書きの `from_persisted` を削除し、infra 側の復元処理を `from_raw_parts` 呼び出しに変更

## 確認事項
- `makers pretty` により clippy fix、nextest、doctest、`cargo clippy -- -D warnings`、rustfmt が通ることを確認
- コミット時フックの `check-openapi` で `docs/openapi.json` に差分が出ないことを確認

🤖 Generated with Codex
