### PR TITLE
ci: 独立したステップを parallel で並列実行する

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,15 +16,14 @@ jobs:
     env:
       RUST_VERSION: "$(grep -oP '(?<=channel = \").*(?=\")' rust-toolchain.toml)"
     steps:
-      - parallel:
-          - name: Checkout
-            uses: actions/checkout@master
-          - name: Setup rust toolchain
-            uses: dtolnay/rust-toolchain@stable
-            with:
-              toolchain: ${{ env.RUST_VERSION }}
-              target: ${{ matrix.cross-target }}
-              components: rustfmt
+      - name: Checkout
+        uses: actions/checkout@master
+      - name: Setup rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+          target: ${{ matrix.cross-target }}
+          components: rustfmt
       - name: Rustfmt check
         run: cargo fmt --all -- --check
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,14 +16,15 @@ jobs:
     env:
       RUST_VERSION: "$(grep -oP '(?<=channel = \").*(?=\")' rust-toolchain.toml)"
     steps:
-      - name: Checkout
-        uses: actions/checkout@master
-      - name: Setup rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: ${{ env.RUST_VERSION }}
-          target: ${{ matrix.cross-target }}
-          components: rustfmt
+      - parallel:
+          - name: Checkout
+            uses: actions/checkout@master
+          - name: Setup rust toolchain
+            uses: dtolnay/rust-toolchain@stable
+            with:
+              toolchain: ${{ env.RUST_VERSION }}
+              target: ${{ matrix.cross-target }}
+              components: rustfmt
       - name: Rustfmt check
         run: cargo fmt --all -- --check
 
@@ -34,25 +35,28 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - run: echo "RUST_VERSION=$(sed -n 's/channel = "\(.*\)\"/\1/p' rust-toolchain.toml)" >> $GITHUB_ENV
-      - uses: actions/cache@v6
-        with:
-          key: rust-${{ env.RUST_VERSION }}-build-${{ hashFiles('**/Cargo.toml') }}
-          path: |
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            ~/.cache/sccache/
-            target/
-          restore-keys: |
-            rust-${{ env.RUST_VERSION }}-build-
-            rust-${{ env.RUST_VERSION }}-
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: ${{ env.RUST_VERSION }}
-          components: clippy, rustfmt
-      - uses: mozilla-actions/sccache-action@v0.0.10
-        with:
-          version: "v0.10.0"
+
+      - parallel:
+          - uses: actions/cache@v6
+            with:
+              key: rust-${{ env.RUST_VERSION }}-build-${{ hashFiles('**/Cargo.toml') }}
+              path: |
+                ~/.cargo/registry/index/
+                ~/.cargo/registry/cache/
+                ~/.cargo/git/db/
+                ~/.cache/sccache/
+                target/
+              restore-keys: |
+                rust-${{ env.RUST_VERSION }}-build-
+                rust-${{ env.RUST_VERSION }}-
+          - uses: dtolnay/rust-toolchain@stable
+            with:
+              toolchain: ${{ env.RUST_VERSION }}
+              components: clippy, rustfmt
+          - uses: mozilla-actions/sccache-action@v0.0.10
+            with:
+              version: "v0.10.0"
+
       - run: |
           echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
           echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
@@ -107,21 +111,24 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - run: echo "RUST_VERSION=$(sed -n 's/channel = \"\(.*\)\"/\1/p' rust-toolchain.toml)" >> $GITHUB_ENV
-      - uses: actions/cache@v6
-        with:
-          key: rust-${{ env.RUST_VERSION }}-build-${{ hashFiles('**/Cargo.toml') }}
-          path: |
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            ~/.cache/sccache/
-            target/
-          restore-keys: |
-            rust-${{ env.RUST_VERSION }}-build-
-            rust-${{ env.RUST_VERSION }}-
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: ${{ env.RUST_VERSION }}
+
+      - parallel:
+          - uses: actions/cache@v6
+            with:
+              key: rust-${{ env.RUST_VERSION }}-build-${{ hashFiles('**/Cargo.toml') }}
+              path: |
+                ~/.cargo/registry/index/
+                ~/.cargo/registry/cache/
+                ~/.cargo/git/db/
+                ~/.cache/sccache/
+                target/
+              restore-keys: |
+                rust-${{ env.RUST_VERSION }}-build-
+                rust-${{ env.RUST_VERSION }}-
+          - uses: dtolnay/rust-toolchain@stable
+            with:
+              toolchain: ${{ env.RUST_VERSION }}
+
       - name: Install sqlx CLI
         run: cargo install sqlx-cli --version 0.8.6 --locked --no-default-features --features rustls,mysql
       - name: Apply migrations

--- a/.github/workflows/image-release.yaml
+++ b/.github/workflows/image-release.yaml
@@ -20,15 +20,14 @@ jobs:
     env:
       RUST_VERSION: "$(grep -oP '(?<=channel = \").*(?=\")' rust-toolchain.toml)"
     steps:
-      - parallel:
-          - name: Checkout
-            uses: actions/checkout@master
-          - name: Setup rust toolchain
-            uses: dtolnay/rust-toolchain@stable
-            with:
-              toolchain: ${{ env.RUST_VERSION }}
-              target: ${{ matrix.cross-target }}
-              components: clippy, rustfmt
+      - name: Checkout
+        uses: actions/checkout@master
+      - name: Setup rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+          target: ${{ matrix.cross-target }}
+          components: clippy, rustfmt
       - name: Build binary using cross
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/image-release.yaml
+++ b/.github/workflows/image-release.yaml
@@ -20,14 +20,15 @@ jobs:
     env:
       RUST_VERSION: "$(grep -oP '(?<=channel = \").*(?=\")' rust-toolchain.toml)"
     steps:
-      - name: Checkout
-        uses: actions/checkout@master
-      - name: Setup rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: ${{ env.RUST_VERSION }}
-          target: ${{ matrix.cross-target }}
-          components: clippy, rustfmt
+      - parallel:
+          - name: Checkout
+            uses: actions/checkout@master
+          - name: Setup rust toolchain
+            uses: dtolnay/rust-toolchain@stable
+            with:
+              toolchain: ${{ env.RUST_VERSION }}
+              target: ${{ matrix.cross-target }}
+              components: clippy, rustfmt
       - name: Build binary using cross
         uses: actions-rs/cargo@v1
         with:
@@ -47,26 +48,30 @@ jobs:
     env:
       image_name: seichi-portal-backend
     steps:
-      - name: Checkout
-        uses: actions/checkout@master
-      - uses: actions/download-artifact@v8
-        with:
-          name: x86_64-unknown-linux-gnu
-          path: docker/artifacts/x86_64-unknown-linux-gnu
-      - uses: actions/download-artifact@v8
-        with:
-          name: aarch64-unknown-linux-gnu
-          path: docker/artifacts/aarch64-unknown-linux-gnu
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+      - parallel:
+          - name: Checkout
+            uses: actions/checkout@master
+          - name: Set up QEMU
+            uses: docker/setup-qemu-action@v4
+          - name: Set up Docker Buildx
+            uses: docker/setup-buildx-action@v4
+          - name: Login to GitHub Container Registry
+            uses: docker/login-action@v4
+            with:
+              registry: ghcr.io
+              username: ${{ github.repository_owner }}
+              password: ${{ secrets.GITHUB_TOKEN }}
+
+      - parallel:
+          - uses: actions/download-artifact@v8
+            with:
+              name: x86_64-unknown-linux-gnu
+              path: docker/artifacts/x86_64-unknown-linux-gnu
+          - uses: actions/download-artifact@v8
+            with:
+              name: aarch64-unknown-linux-gnu
+              path: docker/artifacts/aarch64-unknown-linux-gnu
+
       - id: prepare_image_id
         name: Prepare image id's components
         run: |


### PR DESCRIPTION
## Summary

- GitHub Actions の `parallel` 機能（2025-06-25 GA）を使い、同一 job 内で依存関係のないステップを同時実行する
- checkout と toolchain install、cache restore と toolchain install、Docker セットアップ系など、互いに書き込み競合しないステップを並列化
- build 後の clippy / test / openapi check など `target/` に書き込むステップは競合回避のため逐次のまま

## 並列化箇所

| ファイル | ジョブ | 並列化した箇所 |
|---|---|---|
| `ci.yaml` | `rustfmt` | checkout + toolchain install |
| `ci.yaml` | `lint-and-test` | cache restore + toolchain install + sccache install |
| `ci.yaml` | `sqlx-prepare-check` | cache restore + toolchain install |
| `image-release.yaml` | `build` | checkout + toolchain install |
| `image-release.yaml` | `release-all` | checkout + QEMU + Buildx + Login / x86_64 download + aarch64 download |

## Test plan

- [ ] CI ワークフローが正常に展開・実行されることを確認する（`parallel` は actionlint 1.7.12 未対応のためローカル lint は失敗する可能性あり）
- [ ] 各 job のステップが期待どおり並列実行されていることを Actions ログで確認する

🤖 Generated with [Claude Code](https://claude.com/claude-code)