### PR TITLE
回答Webhookのタイトル表示を修正する

### DIFF
--- a/server/presentation/src/handlers/form/answer_handler.rs
+++ b/server/presentation/src/handlers/form/answer_handler.rs
@@ -85,7 +85,7 @@ impl DiscordAnswerWebhookNotifier for ResourceDiscordAnswerWebhookNotifier {
             let attempts = DiscordWebhookSender::retry_policy().max_attempts();
             let message = DiscordWebhookMessage {
                 discord_webhook_url: notification.discord_webhook_url,
-                title: "回答が送信されました".to_string(),
+                title: notification.title,
                 link_url: notification.answer_url,
                 fields: notification
                     .fields

--- a/server/usecase/src/forms/answer.rs
+++ b/server/usecase/src/forms/answer.rs
@@ -133,12 +133,12 @@ impl<
         let form_id = form.id().into_inner().to_string();
         let answer_id = answer_entry.id().into_inner().to_string();
         let answer_url = format!("{}/forms/{form_id}/answers/{answer_id}", FRONTEND.url);
-        let answer_title = answer_entry
+        let title = answer_entry
             .title()
             .to_owned()
             .into_inner()
             .map(|title| title.into_inner())
-            .unwrap_or_default();
+            .unwrap_or_else(|| "回答が送信されました".to_string());
         let questions = form.questions().as_slice();
         let answer_fields = answer_entry
             .contents()
@@ -159,7 +159,6 @@ impl<
                     "フォーム名".to_string(),
                     form.title().to_owned().into_inner().into_inner(),
                 ),
-                DiscordAnswerWebhookField::new("タイトル".to_string(), answer_title),
                 DiscordAnswerWebhookField::new("回答者".to_string(), respondent),
             ],
             answer_fields,
@@ -171,6 +170,7 @@ impl<
         notifier
             .notify_answer_posted(DiscordAnswerWebhookNotification {
                 discord_webhook_url,
+                title,
                 answer_url,
                 form_id,
                 answer_id,

--- a/server/usecase/src/forms/discord_answer_webhook.rs
+++ b/server/usecase/src/forms/discord_answer_webhook.rs
@@ -15,6 +15,7 @@ impl DiscordAnswerWebhookField {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct DiscordAnswerWebhookNotification {
     pub discord_webhook_url: String,
+    pub title: String,
     pub answer_url: String,
     pub form_id: String,
     pub answer_id: String,


### PR DESCRIPTION
## 概要
- フォーム回答送信時の Discord Webhook で、回答タイトルを embed タイトルとして送るようにしました。
- 本文の field から「タイトル」を削除し、フォーム名・回答者・回答内容だけが本文に出るようにしました。
- 回答タイトルがない場合は、従来の「回答が送信されました」を embed タイトルのフォールバックとして使います。

## 確認事項
- `FRONTEND_URL=http://localhost:3000 cargo test -p usecase post_answers_uses_answer_title_as_discord_webhook_title` で、回答タイトルが通知タイトルになり、本文 field に「タイトル」が含まれないことを確認しました。
- `cargo build` でワークスペース全体がコンパイルできることを確認しました。
- `makers pretty` で clippy、nextest、doctest、clippy `-D warnings`、rustfmt が通ることを確認しました。

🤖 Generated with Codex
