### PR TITLE
フォームと回答一覧をカーソルでページ取得する

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -18,31 +18,29 @@
         "operationId": "archived_form_list_handler",
         "parameters": [
           {
-            "name": "offset",
+            "name": "limit",
             "in": "query",
-            "description": "Offset for pagination",
+            "description": "Maximum number of forms to return",
             "required": false,
             "schema": {
               "type": "integer",
               "format": "int32",
-              "minimum": 0
+              "maximum": 100,
+              "minimum": 1
             }
           },
           {
-            "name": "limit",
+            "name": "cursor",
             "in": "query",
-            "description": "Limit for pagination",
+            "description": "Cursor returned by the previous page",
             "required": false,
             "schema": {
-              "type": "integer",
-              "format": "int32",
-              "minimum": 0
+              "type": "string"
             }
           },
           {
             "name": "query",
             "in": "query",
-            "description": "Search query",
             "required": false,
             "schema": {
               "type": "string"
@@ -55,10 +53,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ArchivedFormSchema"
-                  }
+                  "$ref": "#/components/schemas/ArchivedFormListPageResponse"
                 }
               }
             }
@@ -287,25 +282,24 @@
         "operationId": "form_list_handler",
         "parameters": [
           {
-            "name": "offset",
+            "name": "limit",
             "in": "query",
-            "description": "Offset for pagination",
+            "description": "Maximum number of forms to return",
             "required": false,
             "schema": {
               "type": "integer",
               "format": "int32",
-              "minimum": 0
+              "maximum": 100,
+              "minimum": 1
             }
           },
           {
-            "name": "limit",
+            "name": "cursor",
             "in": "query",
-            "description": "Limit for pagination",
+            "description": "Cursor returned by the previous page",
             "required": false,
             "schema": {
-              "type": "integer",
-              "format": "int32",
-              "minimum": 0
+              "type": "string"
             }
           }
         ],
@@ -315,10 +309,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/FormSchema"
-                  }
+                  "$ref": "#/components/schemas/FormListPageResponse"
                 }
               }
             }
@@ -463,16 +454,36 @@
         ],
         "summary": "すべての回答をフォームを横断して取得",
         "operationId": "get_all_answers",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum number of answers to return",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "maximum": 100,
+              "minimum": 1
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Cursor returned by the previous page",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "The request has succeeded.",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/FormAnswer"
-                  }
+                  "$ref": "#/components/schemas/AnswerListPageResponse"
                 }
               }
             }
@@ -1914,6 +1925,27 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum number of answers to return",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "maximum": 100,
+              "minimum": 1
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Cursor returned by the previous page",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -1922,10 +1954,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/FormAnswer"
-                  }
+                  "$ref": "#/components/schemas/AnswerListPageResponse"
                 }
               }
             }

--- a/server/domain/src/form/answer/entry.rs
+++ b/server/domain/src/form/answer/entry.rs
@@ -20,6 +20,21 @@ use crate::{
 
 pub type AnswerId = types::Id<AnswerEntry>;
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct AnswerPagePosition {
+    last_answer_id: AnswerId,
+}
+
+impl AnswerPagePosition {
+    pub fn new(last_answer_id: AnswerId) -> Self {
+        Self { last_answer_id }
+    }
+
+    pub fn last_answer_id(self) -> AnswerId {
+        self.last_answer_id
+    }
+}
+
 #[derive(UnsafeFromRawParts, Serialize, Deserialize, Getters, Clone, PartialEq, Debug)]
 pub struct AnswerEntry {
     id: AnswerId,

--- a/server/domain/src/form/answer/mod.rs
+++ b/server/domain/src/form/answer/mod.rs
@@ -9,7 +9,7 @@ mod title;
 
 pub use author::{AnswerAuthor, TemporaryAnswerAuthor, TemporaryAnswerAuthorId};
 pub use content::{FormAnswerContent, FormAnswerContentId, PostedAnswerContents};
-pub use entry::{AnswerEntry, AnswerId};
+pub use entry::{AnswerEntry, AnswerId, AnswerPagePosition};
 pub use label::{AnswerLabel, AnswerLabelId};
 pub use settings::{AnswerAcceptancePeriod, AnswerSettings, AnswerVisibility, DefaultAnswerTitle};
 pub use submitter::AnswerSubmitter;

--- a/server/domain/src/form/models.rs
+++ b/server/domain/src/form/models.rs
@@ -33,6 +33,44 @@ use crate::{
 
 pub type FormId = types::Id<ActiveForm>;
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FormPagePosition {
+    last_form_id: FormId,
+}
+
+impl FormPagePosition {
+    pub fn new(last_form_id: FormId) -> Self {
+        Self { last_form_id }
+    }
+
+    pub fn last_form_id(self) -> FormId {
+        self.last_form_id
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ArchivedFormPagePosition {
+    last_archived_at: DateTime<Utc>,
+    last_form_id: FormId,
+}
+
+impl ArchivedFormPagePosition {
+    pub fn new(last_archived_at: DateTime<Utc>, last_form_id: FormId) -> Self {
+        Self {
+            last_archived_at,
+            last_form_id,
+        }
+    }
+
+    pub fn last_archived_at(self) -> DateTime<Utc> {
+        self.last_archived_at
+    }
+
+    pub fn last_form_id(self) -> FormId {
+        self.last_form_id
+    }
+}
+
 #[cfg_attr(test, derive(Arbitrary))]
 #[derive(Clone, DerivingVia, Debug, PartialOrd, PartialEq)]
 #[deriving(From, Into, IntoInner, Serialize, Deserialize)]

--- a/server/domain/src/repository/form/active_form_repository.rs
+++ b/server/domain/src/repository/form/active_form_repository.rs
@@ -4,7 +4,8 @@ use mockall::automock;
 
 use crate::{
     account::models::AccountUser,
-    form::models::{ActiveForm, FormId},
+    form::models::{ActiveForm, FormId, FormPagePosition},
+    pagination::{Page, PageRequest},
     types::authorization_guard::{Allowed, AuthorizationGuard, Create, Read, Update},
 };
 
@@ -18,9 +19,9 @@ pub trait ActiveFormRepository: Send + Sync + 'static {
     ) -> Result<(), Error>;
     async fn list(
         &self,
-        offset: Option<u32>,
-        limit: Option<u32>,
-    ) -> Result<Vec<AuthorizationGuard<ActiveForm, Read>>, Error>;
+        request: PageRequest<FormPagePosition>,
+    ) -> Result<Page<AuthorizationGuard<ActiveForm, Read>, FormPagePosition>, Error>;
+    async fn list_all(&self) -> Result<Vec<AuthorizationGuard<ActiveForm, Read>>, Error>;
     async fn get(&self, id: FormId) -> Result<Option<AuthorizationGuard<ActiveForm, Read>>, Error>;
     async fn update_form(
         &self,

--- a/server/domain/src/repository/form/answer_entry_repository.rs
+++ b/server/domain/src/repository/form/answer_entry_repository.rs
@@ -4,9 +4,10 @@ use mockall::automock;
 
 use crate::{
     form::{
-        answer::{AnswerEntry, AnswerId},
+        answer::{AnswerEntry, AnswerId, AnswerPagePosition},
         models::ActiveForm,
     },
+    pagination::{Page, PageRequest},
     types::authorization_guard::{Allowed, Create, Read, Update},
 };
 
@@ -21,11 +22,13 @@ pub trait AnswerEntryRepository: Send + Sync + 'static {
     async fn list_by_form(
         &self,
         form: &Allowed<ActiveForm, Read>,
-    ) -> Result<Vec<Allowed<AnswerEntry, Read>>, Error>;
+        request: PageRequest<AnswerPagePosition>,
+    ) -> Result<Page<Allowed<AnswerEntry, Read>, AnswerPagePosition>, Error>;
     async fn list_all(
         &self,
         forms: &[Allowed<ActiveForm, Read>],
-    ) -> Result<Vec<Allowed<AnswerEntry, Read>>, Error>;
+        request: PageRequest<AnswerPagePosition>,
+    ) -> Result<Page<Allowed<AnswerEntry, Read>, AnswerPagePosition>, Error>;
     async fn post(
         &self,
         form: &Allowed<ActiveForm, Read>,

--- a/server/domain/src/repository/form/archived_form_repository.rs
+++ b/server/domain/src/repository/form/archived_form_repository.rs
@@ -3,7 +3,8 @@ use errors::Error;
 use mockall::automock;
 
 use crate::{
-    form::models::{ArchivedForm, FormId},
+    form::models::{ArchivedForm, ArchivedFormPagePosition, FormId},
+    pagination::{Page, PageRequest},
     types::authorization_guard::{Allowed, AuthorizationGuard, Create, Read, Update},
 };
 
@@ -12,10 +13,9 @@ use crate::{
 pub trait ArchivedFormRepository: Send + Sync + 'static {
     async fn list(
         &self,
-        offset: Option<u32>,
-        limit: Option<u32>,
+        request: PageRequest<ArchivedFormPagePosition>,
         query: Option<String>,
-    ) -> Result<Vec<AuthorizationGuard<ArchivedForm, Read>>, Error>;
+    ) -> Result<Page<AuthorizationGuard<ArchivedForm, Read>, ArchivedFormPagePosition>, Error>;
     async fn get(
         &self,
         id: FormId,

--- a/server/infra/resource/src/database/components.rs
+++ b/server/infra/resource/src/database/components.rs
@@ -18,7 +18,10 @@ use domain::{
         answer::{AnswerEntry, AnswerId, AnswerLabel, AnswerLabelId, AnswerSubmitterRestriction},
         comment::{Comment, CommentId},
         message::{Message, MessageId},
-        models::{ActiveForm, ArchivedForm, FormId, FormLabel, FormLabelId, FormLabelName},
+        models::{
+            ActiveForm, ArchivedForm, ArchivedFormPagePosition, FormId, FormLabel, FormLabelId,
+            FormLabelName, FormPagePosition,
+        },
     },
     notification::models::NotificationPreference,
     pagination::{Page, PageRequest},
@@ -65,24 +68,30 @@ pub trait FormDatabase: Send + Sync {
     async fn create(&self, form: &ActiveForm, user: &AccountUser) -> Result<(), InfraError>;
     async fn list(
         &self,
-        offset: Option<u32>,
-        limit: Option<u32>,
-    ) -> Result<Vec<ActiveFormRecord>, InfraError>;
+        request: PageRequest<FormPagePosition>,
+    ) -> Result<Page<ActiveFormRecord, FormPagePosition>, InfraError>;
+    async fn list_all(&self) -> Result<Vec<ActiveFormRecord>, InfraError>;
     async fn get(&self, form_id: FormId) -> Result<Option<ActiveFormRecord>, InfraError>;
     async fn list_archived(
         &self,
-        offset: Option<u32>,
-        limit: Option<u32>,
+        request: PageRequest<ArchivedFormPagePosition>,
         query: Option<String>,
-    ) -> Result<Vec<ArchivedFormRecord>, InfraError>;
+    ) -> Result<Page<ArchivedFormRecord, ArchivedFormPagePosition>, InfraError>;
     async fn get_archived(&self, form_id: FormId)
     -> Result<Option<ArchivedFormRecord>, InfraError>;
     async fn archive(&self, form: &ArchivedForm) -> Result<ArchivedForm, InfraError>;
     async fn restore(&self, form_id: FormId) -> Result<(), InfraError>;
     async fn update(&self, form: &ActiveForm, updated_by: &AccountUser) -> Result<(), InfraError>;
     async fn size(&self) -> Result<u32, InfraError>;
-    async fn list_answer_entries(&self, form_id: FormId) -> Result<Vec<AnswerEntry>, InfraError>;
-    async fn list_all_answer_entries(&self) -> Result<Vec<AnswerEntry>, InfraError>;
+    async fn list_answer_entries(
+        &self,
+        form_id: FormId,
+        request: PageRequest<domain::form::answer::AnswerPagePosition>,
+    ) -> Result<Page<AnswerEntry, domain::form::answer::AnswerPagePosition>, InfraError>;
+    async fn list_all_answer_entries(
+        &self,
+        request: PageRequest<domain::form::answer::AnswerPagePosition>,
+    ) -> Result<Page<AnswerEntry, domain::form::answer::AnswerPagePosition>, InfraError>;
 }
 
 #[automock]

--- a/server/infra/resource/src/database/forms/form.rs
+++ b/server/infra/resource/src/database/forms/form.rs
@@ -2,14 +2,18 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use domain::account::models::UserGroupId;
 use domain::form::{
-    answer::AnswerEntry,
-    models::{AllowedUserGroups, DiscordWebhookUrl, FormLabelId},
+    answer::{AnswerEntry, AnswerPagePosition},
+    models::{
+        AllowedUserGroups, ArchivedFormPagePosition, DiscordWebhookUrl, FormLabelId,
+        FormPagePosition,
+    },
     question::{Choice, Question, QuestionId, QuestionType},
 };
 use domain::{
     account::models::{AccountUser, Role},
     auth::Actor,
     form::models::{ActiveForm, ArchivedForm, FormId},
+    pagination::{Page, PageRequest},
 };
 use errors::{Error, infra::InfraError};
 use futures::{TryStreamExt, stream};
@@ -421,12 +425,11 @@ fn archived_form_row_from_db_row(row: MySqlRow) -> Result<ArchivedFormRow, Infra
     })
 }
 
-/// 回答 ([`AnswerEntry`]) を取得する。`form_id` を指定するとそのフォームの回答だけを、
-/// `None` を指定すると全フォームの回答を取得する。
-async fn fetch_answer_entries(
+async fn fetch_answer_entries_page(
     txn: &mut DatabaseTransaction,
     form_id: Option<FormId>,
-) -> Result<Vec<AnswerEntry>, InfraError> {
+    request: PageRequest<AnswerPagePosition>,
+) -> Result<Page<AnswerEntry, AnswerPagePosition>, InfraError> {
     let base_query = r"SELECT form_id, answers.id AS answer_id, title, author_type, user,
             users.name AS user_name, users.role AS user_role,
             temporary_user_id, temporary_users.name AS temporary_user_name,
@@ -434,16 +437,32 @@ async fn fetch_answer_entries(
             timestamp FROM answers
             LEFT JOIN users ON answers.user = users.id
             LEFT JOIN temporary_users ON answers.temporary_user_id = temporary_users.id";
-    let sql = match form_id {
-        Some(_) => format!("{base_query} WHERE form_id = ? ORDER BY answers.timestamp"),
-        None => format!("{base_query} ORDER BY answers.timestamp"),
+    let sql = match (form_id, request.after_position()) {
+        (Some(_), Some(_)) => {
+            format!(
+                "{base_query} WHERE form_id = ? AND answers.id > ? ORDER BY answers.id ASC LIMIT ?"
+            )
+        }
+        (Some(_), None) => {
+            format!("{base_query} WHERE form_id = ? ORDER BY answers.id ASC LIMIT ?")
+        }
+        (None, Some(_)) => {
+            format!("{base_query} WHERE answers.id > ? ORDER BY answers.id ASC LIMIT ?")
+        }
+        (None, None) => format!("{base_query} ORDER BY answers.id ASC LIMIT ?"),
     };
 
     let mut query = sqlx::query(AssertSqlSafe(&*sql));
     if let Some(form_id) = form_id {
         query = query.bind(form_id.into_inner().to_string());
     }
-    let answers = query.fetch_all(&mut **txn).await?;
+    if let Some(position) = request.after_position() {
+        query = query.bind(position.last_answer_id().into_inner().to_string());
+    }
+    let answers = query
+        .bind(i64::from(request.limit().overfetch_value()))
+        .fetch_all(&mut **txn)
+        .await?;
 
     let form_answer_records = answers
         .into_iter()
@@ -469,13 +488,19 @@ async fn fetch_answer_entries(
     let contents = fetch_real_answers_by_answer_ids(txn, &answer_ids).await?;
     let messages = fetch_messages_by_answer_ids(txn, &answer_ids).await?;
 
-    attach_entry_children(form_answer_records, contents, messages)?
+    let entries = attach_entry_children(form_answer_records, contents, messages)?
         .into_iter()
         .map(TryInto::<AnswerEntry>::try_into)
         .collect::<Result<Vec<_>, _>>()
         .map_err(|error: Error| InfraError::Unexpected {
             cause: error.to_string(),
-        })
+        })?;
+
+    Ok(Page::from_overfetched_items(
+        entries,
+        request.limit(),
+        |entry| AnswerPagePosition::new(*entry.id()),
+    ))
 }
 
 async fn fetch_form_row(
@@ -961,9 +986,97 @@ impl FormDatabase for ConnectionPool {
     #[tracing::instrument]
     async fn list(
         &self,
-        offset: Option<u32>,
-        limit: Option<u32>,
-    ) -> Result<Vec<ActiveFormRecord>, InfraError> {
+        request: PageRequest<FormPagePosition>,
+    ) -> Result<Page<ActiveFormRecord, FormPagePosition>, InfraError> {
+        self.read_only_transaction(|txn| {
+            Box::pin(async move {
+                let rows = if let Some(position) = request.after_position() {
+                    sqlx::query(
+                        r"SELECT f.id, f.title, f.description, f.visibility,
+            f.answer_visibility, f.allow_temporary_answers,
+            f.acceptance_period_start_at, f.acceptance_period_end_at, f.default_answer_title,
+                    f.created_at, f.updated_at, w.url AS discord_webhook_url
+                    FROM form_meta_data f
+                    LEFT JOIN form_discord_webhooks w ON f.id = w.form_id
+                    WHERE f.id > ?
+                    ORDER BY f.id
+                    LIMIT ?",
+                    )
+                    .bind(position.last_form_id().into_inner().to_string())
+                    .bind(i64::from(request.limit().overfetch_value()))
+                    .fetch_all(&mut **txn)
+                    .await?
+                } else {
+                    sqlx::query(
+                        r"SELECT f.id, f.title, f.description, f.visibility,
+            f.answer_visibility, f.allow_temporary_answers,
+            f.acceptance_period_start_at, f.acceptance_period_end_at, f.default_answer_title,
+                    f.created_at, f.updated_at, w.url AS discord_webhook_url
+                    FROM form_meta_data f
+                    LEFT JOIN form_discord_webhooks w ON f.id = w.form_id
+                    ORDER BY f.id
+                    LIMIT ?",
+                    )
+                    .bind(i64::from(request.limit().overfetch_value()))
+                    .fetch_all(&mut **txn)
+                    .await?
+                };
+
+                let form_rows = rows
+                    .into_iter()
+                    .map(form_row_from_db_row)
+                    .collect::<Result<Vec<_>, _>>()?;
+
+                let form_ids = form_rows.iter().map(|r| r.id.clone()).collect_vec();
+                let group_restrictions =
+                    fetch_form_group_restrictions_batch(txn, "form_", &form_ids).await?;
+                let labels_by_form =
+                    fetch_label_ids_batch(txn, "label_settings_for_forms", &form_ids).await?;
+
+                let records = stream::try_unfold(
+                    (
+                        form_rows.into_iter(),
+                        group_restrictions,
+                        labels_by_form,
+                        txn,
+                    ),
+                    |(mut rows, mut restrictions, mut labels, txn)| async move {
+                        let Some(row) = rows.next() else {
+                            return Ok::<_, InfraError>(None);
+                        };
+                        let r = restrictions.remove(&row.id).unwrap_or_default();
+                        let l = labels.remove(&row.id).unwrap_or_default();
+                        let record = build_active_form_record(
+                            txn,
+                            row,
+                            r,
+                            l,
+                            "form_questions",
+                            "form_choices",
+                        )
+                        .await?;
+                        Ok(Some((record, (rows, restrictions, labels, txn))))
+                    },
+                )
+                .try_collect()
+                .await?;
+
+                Ok::<_, InfraError>(Page::from_overfetched_items(
+                    records,
+                    request.limit(),
+                    |record: &ActiveFormRecord| {
+                        FormPagePosition::new(FormId::from(
+                            Uuid::parse_str(&record.id).expect("database form id must be uuid"),
+                        ))
+                    },
+                ))
+            })
+        })
+        .await
+    }
+
+    #[tracing::instrument]
+    async fn list_all(&self) -> Result<Vec<ActiveFormRecord>, InfraError> {
         self.read_only_transaction(|txn| {
             Box::pin(async move {
                 let rows = sqlx::query(
@@ -973,11 +1086,8 @@ impl FormDatabase for ConnectionPool {
                     f.created_at, f.updated_at, w.url AS discord_webhook_url
                     FROM form_meta_data f
                     LEFT JOIN form_discord_webhooks w ON f.id = w.form_id
-                    ORDER BY f.id
-                    LIMIT ? OFFSET ?",
+                    ORDER BY f.id",
                 )
-                .bind(limit.unwrap_or(u32::MAX))
-                .bind(offset.unwrap_or(0))
                 .fetch_all(&mut **txn)
                 .await?;
 
@@ -1040,14 +1150,59 @@ impl FormDatabase for ConnectionPool {
     #[tracing::instrument]
     async fn list_archived(
         &self,
-        offset: Option<u32>,
-        limit: Option<u32>,
+        request: PageRequest<ArchivedFormPagePosition>,
         query_text: Option<String>,
-    ) -> Result<Vec<ArchivedFormRecord>, InfraError> {
+    ) -> Result<Page<ArchivedFormRecord, ArchivedFormPagePosition>, InfraError> {
         self.read_only_transaction(|txn| {
             Box::pin(async move {
                 let rows = if let Some(query_text) = query_text {
                     let like = format!("%{query_text}%");
+                    if let Some(position) = request.after_position() {
+                        sqlx::query(
+                            r"SELECT f.id, f.title, f.description, f.visibility,
+            f.answer_visibility, f.allow_temporary_answers,
+            f.acceptance_period_start_at, f.acceptance_period_end_at, f.default_answer_title,
+                        f.created_at, f.updated_at, w.url AS discord_webhook_url,
+                        f.archived_at, u.name AS archived_by_name,
+                        u.id AS archived_by_id, u.role AS archived_by_role
+                        FROM archived_form_meta_data f
+                        INNER JOIN users u ON f.archived_by = u.id
+                        LEFT JOIN archived_form_discord_webhooks w ON f.id = w.form_id
+                        WHERE (f.archived_at < ? OR (f.archived_at = ? AND f.id > ?))
+                            AND (f.title LIKE ? OR f.description LIKE ?)
+                        ORDER BY f.archived_at DESC, f.id ASC
+                        LIMIT ?",
+                        )
+                        .bind(position.last_archived_at())
+                        .bind(position.last_archived_at())
+                        .bind(position.last_form_id().into_inner().to_string())
+                        .bind(&like)
+                        .bind(&like)
+                        .bind(i64::from(request.limit().overfetch_value()))
+                        .fetch_all(&mut **txn)
+                        .await?
+                    } else {
+                        sqlx::query(
+                            r"SELECT f.id, f.title, f.description, f.visibility,
+            f.answer_visibility, f.allow_temporary_answers,
+            f.acceptance_period_start_at, f.acceptance_period_end_at, f.default_answer_title,
+                        f.created_at, f.updated_at, w.url AS discord_webhook_url,
+                        f.archived_at, u.name AS archived_by_name,
+                        u.id AS archived_by_id, u.role AS archived_by_role
+                        FROM archived_form_meta_data f
+                        INNER JOIN users u ON f.archived_by = u.id
+                        LEFT JOIN archived_form_discord_webhooks w ON f.id = w.form_id
+                        WHERE f.title LIKE ? OR f.description LIKE ?
+                        ORDER BY f.archived_at DESC, f.id ASC
+                        LIMIT ?",
+                        )
+                        .bind(&like)
+                        .bind(&like)
+                        .bind(i64::from(request.limit().overfetch_value()))
+                        .fetch_all(&mut **txn)
+                        .await?
+                    }
+                } else if let Some(position) = request.after_position() {
                     sqlx::query(
                         r"SELECT f.id, f.title, f.description, f.visibility,
             f.answer_visibility, f.allow_temporary_answers,
@@ -1058,14 +1213,14 @@ impl FormDatabase for ConnectionPool {
                         FROM archived_form_meta_data f
                         INNER JOIN users u ON f.archived_by = u.id
                         LEFT JOIN archived_form_discord_webhooks w ON f.id = w.form_id
-                        WHERE f.title LIKE ? OR f.description LIKE ?
-                        ORDER BY f.archived_at DESC, f.id
-                        LIMIT ? OFFSET ?",
+                        WHERE f.archived_at < ? OR (f.archived_at = ? AND f.id > ?)
+                        ORDER BY f.archived_at DESC, f.id ASC
+                        LIMIT ?",
                     )
-                    .bind(&like)
-                    .bind(&like)
-                    .bind(limit.unwrap_or(u32::MAX))
-                    .bind(offset.unwrap_or(0))
+                    .bind(position.last_archived_at())
+                    .bind(position.last_archived_at())
+                    .bind(position.last_form_id().into_inner().to_string())
+                    .bind(i64::from(request.limit().overfetch_value()))
                     .fetch_all(&mut **txn)
                     .await?
                 } else {
@@ -1079,11 +1234,10 @@ impl FormDatabase for ConnectionPool {
                         FROM archived_form_meta_data f
                         INNER JOIN users u ON f.archived_by = u.id
                         LEFT JOIN archived_form_discord_webhooks w ON f.id = w.form_id
-                        ORDER BY f.archived_at DESC, f.id
-                        LIMIT ? OFFSET ?",
+                        ORDER BY f.archived_at DESC, f.id ASC
+                        LIMIT ?",
                     )
-                    .bind(limit.unwrap_or(u32::MAX))
-                    .bind(offset.unwrap_or(0))
+                    .bind(i64::from(request.limit().overfetch_value()))
                     .fetch_all(&mut **txn)
                     .await?
                 };
@@ -1100,7 +1254,7 @@ impl FormDatabase for ConnectionPool {
                     fetch_label_ids_batch(txn, "archived_label_settings_for_forms", &form_ids)
                         .await?;
 
-                stream::try_unfold(
+                let records = stream::try_unfold(
                     (
                         form_rows.into_iter(),
                         group_restrictions,
@@ -1126,7 +1280,21 @@ impl FormDatabase for ConnectionPool {
                     },
                 )
                 .try_collect()
-                .await
+                .await?;
+
+                Ok::<_, InfraError>(Page::from_overfetched_items(
+                    records,
+                    request.limit(),
+                    |record: &ArchivedFormRecord| {
+                        ArchivedFormPagePosition::new(
+                            record.archived_at,
+                            FormId::from(
+                                Uuid::parse_str(&record.form.id)
+                                    .expect("database archived form id must be uuid"),
+                            ),
+                        )
+                    },
+                ))
             })
         })
         .await
@@ -1227,17 +1395,24 @@ impl FormDatabase for ConnectionPool {
     }
 
     #[tracing::instrument]
-    async fn list_answer_entries(&self, form_id: FormId) -> Result<Vec<AnswerEntry>, InfraError> {
+    async fn list_answer_entries(
+        &self,
+        form_id: FormId,
+        request: PageRequest<AnswerPagePosition>,
+    ) -> Result<Page<AnswerEntry, AnswerPagePosition>, InfraError> {
         self.read_only_transaction(|txn| {
-            Box::pin(async move { fetch_answer_entries(txn, Some(form_id)).await })
+            Box::pin(async move { fetch_answer_entries_page(txn, Some(form_id), request).await })
         })
         .await
     }
 
     #[tracing::instrument]
-    async fn list_all_answer_entries(&self) -> Result<Vec<AnswerEntry>, InfraError> {
+    async fn list_all_answer_entries(
+        &self,
+        request: PageRequest<AnswerPagePosition>,
+    ) -> Result<Page<AnswerEntry, AnswerPagePosition>, InfraError> {
         self.read_only_transaction(|txn| {
-            Box::pin(async move { fetch_answer_entries(txn, None).await })
+            Box::pin(async move { fetch_answer_entries_page(txn, None, request).await })
         })
         .await
     }

--- a/server/infra/resource/src/repository/form_repository_impls/answer_entry_repository_impl.rs
+++ b/server/infra/resource/src/repository/form_repository_impls/answer_entry_repository_impl.rs
@@ -3,14 +3,14 @@ use std::collections::HashMap;
 use async_trait::async_trait;
 use domain::{
     form::{
-        answer::{AnswerEntry, AnswerId},
+        answer::{AnswerEntry, AnswerId, AnswerPagePosition},
         models::ActiveForm,
     },
+    pagination::{Page, PageRequest},
     repository::form::answer_entry_repository::AnswerEntryRepository,
     types::authorization_guard::{Allowed, Create, Read, Update},
 };
 use errors::Error;
-use uuid::Uuid;
 
 use crate::{
     database::{
@@ -47,47 +47,44 @@ where
     async fn list_by_form(
         &self,
         form: &Allowed<ActiveForm, Read>,
-    ) -> Result<Vec<Allowed<AnswerEntry, Read>>, Error> {
-        let entries = self.client.form().list_answer_entries(*form.id()).await?;
+        request: PageRequest<AnswerPagePosition>,
+    ) -> Result<Page<Allowed<AnswerEntry, Read>, AnswerPagePosition>, Error> {
+        let page = self
+            .client
+            .form()
+            .list_answer_entries(*form.id(), request)
+            .await?;
+        let (entries, next) = page.into_parts();
 
-        Ok(form.readable_entries(entries))
+        Ok(Page::new(form.readable_entries(entries), next))
     }
 
     #[tracing::instrument(skip(self, forms))]
     async fn list_all(
         &self,
         forms: &[Allowed<ActiveForm, Read>],
-    ) -> Result<Vec<Allowed<AnswerEntry, Read>>, Error> {
+        request: PageRequest<AnswerPagePosition>,
+    ) -> Result<Page<Allowed<AnswerEntry, Read>, AnswerPagePosition>, Error> {
         if forms.is_empty() {
-            return Ok(Vec::new());
+            return Ok(Page::new(Vec::new(), None));
         }
 
-        let mut entries_by_form = self
-            .client
-            .form()
-            .list_all_answer_entries()
-            .await?
-            .into_iter()
-            .fold(
-                HashMap::<Uuid, Vec<AnswerEntry>>::new(),
-                |mut acc, entry| {
-                    acc.entry(entry.form_id().into_inner())
-                        .or_default()
-                        .push(entry);
-                    acc
-                },
-            );
-
-        Ok(forms
+        let page = self.client.form().list_all_answer_entries(request).await?;
+        let (entries, next) = page.into_parts();
+        let forms_by_id = forms
             .iter()
-            .flat_map(|form| {
-                form.readable_entries(
-                    entries_by_form
-                        .remove(&form.id().into_inner())
-                        .unwrap_or_default(),
-                )
+            .map(|form| (form.id().into_inner(), form))
+            .collect::<HashMap<_, _>>();
+        let authorized_entries = entries
+            .into_iter()
+            .filter_map(|entry| {
+                forms_by_id
+                    .get(&entry.form_id().into_inner())
+                    .map(|form| form.read_entry(entry))
             })
-            .collect())
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(Page::new(authorized_entries, next))
     }
 
     #[tracing::instrument(skip(self, _form, answer_entry))]

--- a/server/infra/resource/src/repository/form_repository_impls/form_repository_impl.rs
+++ b/server/infra/resource/src/repository/form_repository_impls/form_repository_impl.rs
@@ -1,7 +1,8 @@
 use async_trait::async_trait;
 use domain::{
     account::models::AccountUser,
-    form::models::{ActiveForm, ArchivedForm, FormId},
+    form::models::{ActiveForm, ArchivedForm, ArchivedFormPagePosition, FormId, FormPagePosition},
+    pagination::{Page, PageRequest},
     repository::form::{
         active_form_repository::ActiveFormRepository,
         archived_form_repository::ArchivedFormRepository,
@@ -36,12 +37,26 @@ where
     #[tracing::instrument(skip(self))]
     async fn list(
         &self,
-        offset: Option<u32>,
-        limit: Option<u32>,
-    ) -> Result<Vec<AuthorizationGuard<ActiveForm, Read>>, Error> {
+        request: PageRequest<FormPagePosition>,
+    ) -> Result<Page<AuthorizationGuard<ActiveForm, Read>, FormPagePosition>, Error> {
+        let page = self.client.form().list(request).await?;
+        let (forms, next) = page.into_parts();
+        let forms = forms
+            .into_iter()
+            .map(TryInto::<ActiveForm>::try_into)
+            .map(|form| {
+                form.map(|form| AuthorizationGuard::<ActiveForm, Create>::from(form).into_read())
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(Page::new(forms, next))
+    }
+
+    #[tracing::instrument(skip(self))]
+    async fn list_all(&self) -> Result<Vec<AuthorizationGuard<ActiveForm, Read>>, Error> {
         self.client
             .form()
-            .list(offset, limit)
+            .list_all()
             .await?
             .into_iter()
             .map(TryInto::<ActiveForm>::try_into)
@@ -91,20 +106,20 @@ where
     #[tracing::instrument(skip(self))]
     async fn list(
         &self,
-        offset: Option<u32>,
-        limit: Option<u32>,
+        request: PageRequest<ArchivedFormPagePosition>,
         query: Option<String>,
-    ) -> Result<Vec<AuthorizationGuard<ArchivedForm, Read>>, Error> {
-        self.client
-            .form()
-            .list_archived(offset, limit, query)
-            .await?
+    ) -> Result<Page<AuthorizationGuard<ArchivedForm, Read>, ArchivedFormPagePosition>, Error> {
+        let page = self.client.form().list_archived(request, query).await?;
+        let (forms, next) = page.into_parts();
+        let forms = forms
             .into_iter()
             .map(TryInto::<ArchivedForm>::try_into)
             .map(|form| {
                 form.map(|form| AuthorizationGuard::<ArchivedForm, Create>::from(form).into_read())
             })
-            .collect()
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(Page::new(forms, next))
     }
 
     #[tracing::instrument(skip(self))]

--- a/server/presentation/src/handlers/form/answer_handler.rs
+++ b/server/presentation/src/handlers/form/answer_handler.rs
@@ -3,18 +3,20 @@ use axum::extract::rejection::{JsonRejection, PathRejection};
 use axum::response::Response;
 use axum::{
     Extension, Json,
-    extract::{Path, State},
+    extract::{Path, Query, State},
     http::StatusCode,
     response::IntoResponse,
 };
-use domain::form::answer::{FormAnswerContent, FormAnswerContentId};
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+use domain::form::answer::{AnswerPagePosition, FormAnswerContent, FormAnswerContentId};
 use domain::{
     account::models::AccountUser,
     form::answer::TemporaryAnswerAuthor,
     form::{answer::AnswerId, models::FormId},
+    pagination::{PageLimit, PageRequest},
     repository::Repositories,
 };
-use errors::ErrorExtra;
+use errors::{Error, ErrorExtra, presentation::PresentationError};
 use itertools::Itertools;
 use resource::{
     outgoing::discord_webhook_sender::{
@@ -22,6 +24,7 @@ use resource::{
     },
     repository::{RealInfrastructureRepository, Repository},
 };
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 use tracing::warn;
 use usecase::forms::{
@@ -34,9 +37,9 @@ use crate::{
     handlers::error_handler::handle_error,
     schemas::form::{
         form_request_schemas::{
-            AnswerCreateSchema, AnswerUpdateSchema, TemporaryAnswerCreateSchema,
+            AnswerCreateSchema, AnswerListQuery, AnswerUpdateSchema, TemporaryAnswerCreateSchema,
         },
-        form_response_schemas::FormAnswer,
+        form_response_schemas::{AnswerListPageResponse, FormAnswer},
     },
 };
 
@@ -110,7 +113,7 @@ impl DiscordAnswerWebhookNotifier for ResourceDiscordAnswerWebhookNotifier {
 #[derive(utoipa::IntoResponses)]
 pub enum GetAllAnswersResponse {
     #[response(status = 200, description = "The request has succeeded.")]
-    Ok(Vec<FormAnswer>),
+    Ok(AnswerListPageResponse),
 }
 
 impl IntoResponse for GetAllAnswersResponse {
@@ -138,7 +141,7 @@ impl IntoResponse for GetAnswerResponse {
 #[derive(utoipa::IntoResponses)]
 pub enum GetAnswersByFormResponse {
     #[response(status = 200, description = "The request has succeeded.")]
-    Ok(Vec<FormAnswer>),
+    Ok(AnswerListPageResponse),
 }
 
 impl IntoResponse for GetAnswersByFormResponse {
@@ -163,10 +166,60 @@ impl IntoResponse for UpdateAnswerResponse {
     }
 }
 
+#[derive(Deserialize, Serialize)]
+struct AnswerListCursor {
+    after_answer_id: uuid::Uuid,
+}
+
+fn bad_query(message: impl Into<String>) -> Error {
+    Error::from(PresentationError::QueryRejection {
+        cause: message.into(),
+    })
+}
+
+fn decode_answer_list_cursor(cursor: &str) -> Result<AnswerPagePosition, Error> {
+    let decoded = URL_SAFE_NO_PAD
+        .decode(cursor)
+        .map_err(|_| bad_query("Invalid cursor."))?;
+    let cursor = serde_json::from_slice::<AnswerListCursor>(&decoded)
+        .map_err(|_| bad_query("Invalid cursor."))?;
+
+    Ok(AnswerPagePosition::new(cursor.after_answer_id.into()))
+}
+
+fn encode_answer_list_cursor(position: AnswerPagePosition) -> Result<String, Error> {
+    let cursor = AnswerListCursor {
+        after_answer_id: position.last_answer_id().into_inner(),
+    };
+    let bytes = serde_json::to_vec(&cursor).map_err(|_| bad_query("Invalid cursor."))?;
+
+    Ok(URL_SAFE_NO_PAD.encode(bytes))
+}
+
+fn answer_list_page_request(
+    query: AnswerListQuery,
+) -> Result<PageRequest<AnswerPagePosition>, Error> {
+    let limit = match query.limit {
+        Some(limit) => PageLimit::try_new(limit)
+            .map_err(|err| bad_query(format!("Invalid limit: {}.", err.value())))?,
+        None => PageLimit::default_limit(),
+    };
+    let after = query
+        .cursor
+        .as_deref()
+        .map(decode_answer_list_cursor)
+        .transpose()?;
+
+    Ok(PageRequest::new(after, limit))
+}
+
 #[utoipa::path(
     get,
     path = "/forms/answers",
     summary = "すべての回答をフォームを横断して取得",
+    params(
+        AnswerListQuery,
+    ),
     responses(
         GetAllAnswersResponse,
         BadRequest,
@@ -180,16 +233,24 @@ impl IntoResponse for UpdateAnswerResponse {
 pub async fn get_all_answers(
     Extension(user): Extension<AccountUser>,
     State(repository): State<RealInfrastructureRepository>,
+    query: Result<Query<AnswerListQuery>, axum::extract::rejection::QueryRejection>,
 ) -> Result<GetAllAnswersResponse, Response> {
     let form_answer_use_case = build_answer_use_case(&repository, None);
+    let Query(query) = query.map_err_to_error().map_err(handle_error)?;
+    let request = answer_list_page_request(query).map_err(handle_error)?;
 
-    let answers = form_answer_use_case
-        .get_all_answers(&user)
+    let page = form_answer_use_case
+        .get_all_answers(&user, request)
         .await
         .map_err(handle_error)?;
+    let (answers, next) = page.into_parts();
+    let next_cursor = next
+        .map(encode_answer_list_cursor)
+        .transpose()
+        .map_err(handle_error)?;
 
-    Ok(GetAllAnswersResponse::Ok(
-        answers
+    Ok(GetAllAnswersResponse::Ok(AnswerListPageResponse {
+        items: answers
             .into_iter()
             .map(|answer_details| {
                 FormAnswer::new(
@@ -200,7 +261,8 @@ pub async fn get_all_answers(
                 )
             })
             .collect_vec(),
-    ))
+        next_cursor,
+    }))
 }
 
 #[utoipa::path(
@@ -251,6 +313,7 @@ pub async fn get_answer_handler(
     summary = "回答の一覧取得",
     params(
         ("id" = String, Path, description = "Form ID"),
+        AnswerListQuery,
     ),
     responses(
         GetAnswersByFormResponse,
@@ -268,18 +331,26 @@ pub async fn get_answer_by_form_id_handler(
     Extension(user): Extension<AccountUser>,
     State(repository): State<RealInfrastructureRepository>,
     path: Result<Path<FormId>, PathRejection>,
+    query: Result<Query<AnswerListQuery>, axum::extract::rejection::QueryRejection>,
 ) -> Result<GetAnswersByFormResponse, Response> {
     let form_answer_use_case = build_answer_use_case(&repository, None);
 
     let Path(form_id) = path.map_err_to_error().map_err(handle_error)?;
+    let Query(query) = query.map_err_to_error().map_err(handle_error)?;
+    let request = answer_list_page_request(query).map_err(handle_error)?;
 
-    let answers = form_answer_use_case
-        .get_answers_by_form_id(form_id, &user)
+    let page = form_answer_use_case
+        .get_answers_by_form_id(form_id, &user, request)
         .await
         .map_err(handle_error)?;
+    let (answers, next) = page.into_parts();
+    let next_cursor = next
+        .map(encode_answer_list_cursor)
+        .transpose()
+        .map_err(handle_error)?;
 
-    Ok(GetAnswersByFormResponse::Ok(
-        answers
+    Ok(GetAnswersByFormResponse::Ok(AnswerListPageResponse {
+        items: answers
             .into_iter()
             .map(|answer_details| {
                 FormAnswer::new(
@@ -290,7 +361,8 @@ pub async fn get_answer_by_form_id_handler(
                 )
             })
             .collect_vec(),
-    ))
+        next_cursor,
+    }))
 }
 
 #[utoipa::path(

--- a/server/presentation/src/handlers/form/form_handler.rs
+++ b/server/presentation/src/handlers/form/form_handler.rs
@@ -7,20 +7,27 @@ use axum::{
     http::{HeaderValue, StatusCode, header},
     response::IntoResponse,
 };
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+use chrono::{DateTime, Utc};
 use domain::{
     account::models::AccountUser,
     auth::Actor,
     form::{
-        models::{ActiveForm, AllowedUserGroups, ArchivedForm, FormDescription, FormId, FormLabel},
+        models::{
+            ActiveForm, AllowedUserGroups, ArchivedForm, ArchivedFormPagePosition, FormDescription,
+            FormId, FormLabel, FormPagePosition,
+        },
         question::{Choice, Question, QuestionSet, QuestionType},
     },
+    pagination::{PageLimit, PageRequest},
     repository::Repositories,
 };
-use errors::{ErrorExtra, domain::DomainError};
+use errors::{Error, ErrorExtra, domain::DomainError, presentation::PresentationError};
 use resource::{
     database::connection::ConnectionPool,
     repository::{RealInfrastructureRepository, Repository},
 };
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 use types::non_empty_vec::NonEmptyVec;
 use usecase::{
@@ -33,14 +40,14 @@ use crate::schemas::{
     error_responses::*,
     form::{
         form_request_schemas::{
-            ChoiceSchema, FormCreateSchema, FormUpdateSchema, OffsetAndLimit, QuestionSchema,
+            ArchivedFormListQuery, ChoiceSchema, FormCreateSchema, FormListQuery, FormUpdateSchema,
+            QuestionSchema,
         },
         form_response_schemas::{
-            ArchivedFormSchema, FormMetaSchema, FormSchema, FormSettingsSchema,
-            QuestionResponseSchema,
+            ArchivedFormListPageResponse, ArchivedFormSchema, FormListPageResponse, FormMetaSchema,
+            FormSchema, FormSettingsSchema, QuestionResponseSchema,
         },
     },
-    search_schemas::SearchQuery,
 };
 
 #[derive(utoipa::IntoResponses)]
@@ -72,7 +79,7 @@ impl IntoResponse for CreateFormResponse {
 #[derive(utoipa::IntoResponses)]
 pub enum FormListResponse {
     #[response(status = 200, description = "The request has succeeded.")]
-    Ok(Vec<FormSchema>),
+    Ok(FormListPageResponse),
 }
 
 impl IntoResponse for FormListResponse {
@@ -114,7 +121,7 @@ impl IntoResponse for UpdateFormResponse {
 #[derive(utoipa::IntoResponses)]
 pub enum ArchivedFormListResponse {
     #[response(status = 200, description = "The request has succeeded.")]
-    Ok(Vec<ArchivedFormSchema>),
+    Ok(ArchivedFormListPageResponse),
 }
 
 impl IntoResponse for ArchivedFormListResponse {
@@ -209,6 +216,97 @@ fn archived_form_schema_from_parts(
             .collect(),
         labels,
     }
+}
+
+#[derive(Deserialize, Serialize)]
+struct FormListCursor {
+    after_form_id: uuid::Uuid,
+}
+
+#[derive(Deserialize, Serialize)]
+struct ArchivedFormListCursor {
+    after_archived_at: DateTime<Utc>,
+    after_form_id: uuid::Uuid,
+}
+
+fn bad_query(message: impl Into<String>) -> Error {
+    Error::from(PresentationError::QueryRejection {
+        cause: message.into(),
+    })
+}
+
+fn decode_form_list_cursor(cursor: &str) -> Result<FormPagePosition, Error> {
+    let decoded = URL_SAFE_NO_PAD
+        .decode(cursor)
+        .map_err(|_| bad_query("Invalid cursor."))?;
+    let cursor = serde_json::from_slice::<FormListCursor>(&decoded)
+        .map_err(|_| bad_query("Invalid cursor."))?;
+
+    Ok(FormPagePosition::new(cursor.after_form_id.into()))
+}
+
+fn encode_form_list_cursor(position: FormPagePosition) -> Result<String, Error> {
+    let cursor = FormListCursor {
+        after_form_id: position.last_form_id().into_inner(),
+    };
+    let bytes = serde_json::to_vec(&cursor).map_err(|_| bad_query("Invalid cursor."))?;
+
+    Ok(URL_SAFE_NO_PAD.encode(bytes))
+}
+
+fn form_list_page_request(query: &FormListQuery) -> Result<PageRequest<FormPagePosition>, Error> {
+    let limit = match query.limit {
+        Some(limit) => PageLimit::try_new(limit)
+            .map_err(|err| bad_query(format!("Invalid limit: {}.", err.value())))?,
+        None => PageLimit::default_limit(),
+    };
+    let after = query
+        .cursor
+        .as_deref()
+        .map(decode_form_list_cursor)
+        .transpose()?;
+
+    Ok(PageRequest::new(after, limit))
+}
+
+fn decode_archived_form_list_cursor(cursor: &str) -> Result<ArchivedFormPagePosition, Error> {
+    let decoded = URL_SAFE_NO_PAD
+        .decode(cursor)
+        .map_err(|_| bad_query("Invalid cursor."))?;
+    let cursor = serde_json::from_slice::<ArchivedFormListCursor>(&decoded)
+        .map_err(|_| bad_query("Invalid cursor."))?;
+
+    Ok(ArchivedFormPagePosition::new(
+        cursor.after_archived_at,
+        cursor.after_form_id.into(),
+    ))
+}
+
+fn encode_archived_form_list_cursor(position: ArchivedFormPagePosition) -> Result<String, Error> {
+    let cursor = ArchivedFormListCursor {
+        after_archived_at: position.last_archived_at(),
+        after_form_id: position.last_form_id().into_inner(),
+    };
+    let bytes = serde_json::to_vec(&cursor).map_err(|_| bad_query("Invalid cursor."))?;
+
+    Ok(URL_SAFE_NO_PAD.encode(bytes))
+}
+
+fn archived_form_list_page_request(
+    query: &ArchivedFormListQuery,
+) -> Result<PageRequest<ArchivedFormPagePosition>, Error> {
+    let limit = match query.limit {
+        Some(limit) => PageLimit::try_new(limit)
+            .map_err(|err| bad_query(format!("Invalid limit: {}.", err.value())))?,
+        None => PageLimit::default_limit(),
+    };
+    let after = query
+        .cursor
+        .as_deref()
+        .map(decode_archived_form_list_cursor)
+        .transpose()?;
+
+    Ok(PageRequest::new(after, limit))
 }
 
 #[utoipa::path(
@@ -315,8 +413,7 @@ pub async fn create_form_handler(
     path = "/forms",
     summary = "フォームの一覧取得",
     params(
-        ("offset" = Option<u32>, Query, description = "Offset for pagination"),
-        ("limit" = Option<u32>, Query, description = "Limit for pagination"),
+        FormListQuery,
     ),
     responses(
         FormListResponse,
@@ -331,13 +428,20 @@ pub async fn create_form_handler(
 pub async fn form_list_handler(
     Extension(actor): Extension<Actor>,
     State(repository): State<RealInfrastructureRepository>,
-    Query(offset_and_limit): Query<OffsetAndLimit>,
+    query: Result<Query<FormListQuery>, axum::extract::rejection::QueryRejection>,
 ) -> Result<FormListResponse, Response> {
     let form_use_case = build_form_use_case(&repository);
+    let Query(query) = query.map_err_to_error().map_err(handle_error)?;
+    let request = form_list_page_request(&query).map_err(handle_error)?;
 
-    let forms = form_use_case
-        .form_list(&actor, offset_and_limit.offset, offset_and_limit.limit)
+    let page = form_use_case
+        .form_list(&actor, request)
         .await
+        .map_err(handle_error)?;
+    let (forms, next) = page.into_parts();
+    let next_cursor = next
+        .map(encode_form_list_cursor)
+        .transpose()
         .map_err(handle_error)?;
 
     let response_schema = forms
@@ -345,7 +449,10 @@ pub async fn form_list_handler(
         .map(|(form, labels)| form_schema(&actor, &form, labels))
         .collect::<Vec<_>>();
 
-    Ok(FormListResponse::Ok(response_schema))
+    Ok(FormListResponse::Ok(FormListPageResponse {
+        items: response_schema,
+        next_cursor,
+    }))
 }
 
 #[utoipa::path(
@@ -541,9 +648,7 @@ pub async fn update_form_handler(
     path = "/archived-forms",
     summary = "アーカイブ済みフォームの一覧取得",
     params(
-        ("offset" = Option<u32>, Query, description = "Offset for pagination"),
-        ("limit" = Option<u32>, Query, description = "Limit for pagination"),
-        ("query" = Option<String>, Query, description = "Search query"),
+        ArchivedFormListQuery,
     ),
     responses(
         ArchivedFormListResponse,
@@ -558,24 +663,20 @@ pub async fn update_form_handler(
 pub async fn archived_form_list_handler(
     Extension(user): Extension<AccountUser>,
     State(repository): State<RealInfrastructureRepository>,
-    Query(offset_and_limit): Query<OffsetAndLimit>,
-    query: Result<Query<SearchQuery>, axum::extract::rejection::QueryRejection>,
+    query: Result<Query<ArchivedFormListQuery>, axum::extract::rejection::QueryRejection>,
 ) -> Result<ArchivedFormListResponse, Response> {
     let form_use_case = build_form_use_case(&repository);
-    let query = query
-        .map_err_to_error()
-        .map_err(handle_error)?
-        .query
-        .clone();
+    let Query(query) = query.map_err_to_error().map_err(handle_error)?;
+    let request = archived_form_list_page_request(&query).map_err(handle_error)?;
 
-    let forms = form_use_case
-        .archived_form_list(
-            &user,
-            offset_and_limit.offset,
-            offset_and_limit.limit,
-            query.map(|q| q.into_inner()),
-        )
+    let page = form_use_case
+        .archived_form_list(&user, request, query.query.clone())
         .await
+        .map_err(handle_error)?;
+    let (forms, next) = page.into_parts();
+    let next_cursor = next
+        .map(encode_archived_form_list_cursor)
+        .transpose()
         .map_err(handle_error)?;
 
     let actor = Actor::from(user);
@@ -591,7 +692,10 @@ pub async fn archived_form_list_handler(
         })
         .collect::<Vec<_>>();
 
-    Ok(ArchivedFormListResponse::Ok(response_schema))
+    Ok(ArchivedFormListResponse::Ok(ArchivedFormListPageResponse {
+        items: response_schema,
+        next_cursor,
+    }))
 }
 
 #[utoipa::path(

--- a/server/presentation/src/schemas/form/form_request_schemas.rs
+++ b/server/presentation/src/schemas/form/form_request_schemas.rs
@@ -11,10 +11,35 @@ use serde::{Deserialize, Deserializer};
 use types::non_empty_string::NonEmptyString;
 use types::non_empty_vec::NonEmptyVec;
 
-#[derive(Deserialize, Debug, utoipa::ToSchema)]
-pub struct OffsetAndLimit {
-    pub offset: Option<u32>,
+#[derive(Deserialize, Debug, utoipa::IntoParams)]
+#[into_params(parameter_in = Query)]
+pub struct FormListQuery {
+    /// Maximum number of forms to return
+    #[param(minimum = 1, maximum = 100)]
     pub limit: Option<u32>,
+    /// Cursor returned by the previous page
+    pub cursor: Option<String>,
+}
+
+#[derive(Deserialize, Debug, utoipa::IntoParams)]
+#[into_params(parameter_in = Query)]
+pub struct ArchivedFormListQuery {
+    /// Maximum number of forms to return
+    #[param(minimum = 1, maximum = 100)]
+    pub limit: Option<u32>,
+    /// Cursor returned by the previous page
+    pub cursor: Option<String>,
+    pub query: Option<String>,
+}
+
+#[derive(Deserialize, Debug, utoipa::IntoParams)]
+#[into_params(parameter_in = Query)]
+pub struct AnswerListQuery {
+    /// Maximum number of answers to return
+    #[param(minimum = 1, maximum = 100)]
+    pub limit: Option<u32>,
+    /// Cursor returned by the previous page
+    pub cursor: Option<String>,
 }
 
 #[derive(Deserialize, Debug, utoipa::ToSchema)]

--- a/server/presentation/src/schemas/form/form_response_schemas.rs
+++ b/server/presentation/src/schemas/form/form_response_schemas.rs
@@ -124,6 +124,12 @@ pub struct FormSchema {
 }
 
 #[derive(Serialize, Debug, utoipa::ToSchema)]
+pub struct FormListPageResponse {
+    pub items: Vec<FormSchema>,
+    pub next_cursor: Option<String>,
+}
+
+#[derive(Serialize, Debug, utoipa::ToSchema)]
 pub struct ArchivedFormSchema {
     #[schema(value_type = String, format = "uuid")]
     pub id: FormId,
@@ -139,6 +145,12 @@ pub struct ArchivedFormSchema {
     pub questions: Vec<QuestionResponseSchema>,
     #[schema(value_type = Vec<FormLabelResponseSchema>)]
     pub labels: Vec<FormLabel>,
+}
+
+#[derive(Serialize, Debug, utoipa::ToSchema)]
+pub struct ArchivedFormListPageResponse {
+    pub items: Vec<ArchivedFormSchema>,
+    pub next_cursor: Option<String>,
 }
 
 #[derive(Serialize, Debug, utoipa::ToSchema)]
@@ -399,6 +411,12 @@ pub struct FormAnswer {
     title: Option<String>,
     answers: Vec<AnswerContent>,
     labels: Vec<AnswerLabels>,
+}
+
+#[derive(Serialize, Debug, utoipa::ToSchema)]
+pub struct AnswerListPageResponse {
+    pub items: Vec<FormAnswer>,
+    pub next_cursor: Option<String>,
 }
 
 impl FormAnswer {

--- a/server/usecase/src/forms/answer.rs
+++ b/server/usecase/src/forms/answer.rs
@@ -5,12 +5,13 @@ use domain::{
     form::answer::TemporaryAnswerAuthor,
     form::{
         answer::{
-            AnswerAuthor, AnswerEntry, AnswerId, AnswerLabel, AnswerSubmitter, AnswerTitle,
-            FormAnswerContent, PostedAnswerContents,
+            AnswerAuthor, AnswerEntry, AnswerId, AnswerLabel, AnswerPagePosition, AnswerSubmitter,
+            AnswerTitle, FormAnswerContent, PostedAnswerContents,
         },
         models::{ActiveForm, FormId},
         service::DefaultAnswerTitleDomainService,
     },
+    pagination::{Page, PageRequest},
     repository::user_repository::UserRepository,
     repository::{
         answer_submitter_restriction_repository::AnswerSubmitterRestrictionRepository,
@@ -309,13 +310,18 @@ impl<
         &self,
         form_id: FormId,
         actor: &AccountUser,
-    ) -> Result<Vec<AnswerDetails>, Error> {
+        request: PageRequest<AnswerPagePosition>,
+    ) -> Result<Page<AnswerDetails, AnswerPagePosition>, Error> {
         let actor_ref = Actor::from(actor.clone());
         let form = self.read_form(form_id, &actor_ref).await?;
 
-        let visible_answers = self.answer_entry_repository.list_by_form(&form).await?;
+        let page = self
+            .answer_entry_repository
+            .list_by_form(&form, request)
+            .await?;
+        let (visible_answers, next) = page.into_parts();
 
-        stream::iter(visible_answers)
+        let answers = stream::iter(visible_answers)
             .then(|form_answer| async {
                 let answer_id = *form_answer.id();
                 let labels = self
@@ -336,28 +342,40 @@ impl<
             .collect::<Vec<Result<AnswerDetails, Error>>>()
             .await
             .into_iter()
-            .collect()
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(Page::new(answers, next))
     }
 
-    pub async fn get_all_answers(&self, user: &AccountUser) -> Result<Vec<AnswerDetails>, Error> {
-        let actor_ref = Actor::from(user.clone());
-        let readable_forms = self
+    async fn readable_forms(&self, actor: &Actor) -> Result<Vec<Allowed<ActiveForm, Read>>, Error> {
+        Ok(self
             .active_form_repository
-            .list(None, None)
+            .list_all()
             .await?
             .into_iter()
-            .filter_map(|form| form.try_read(actor_ref.clone()).ok())
-            .collect::<Vec<_>>();
+            .filter_map(|form| form.try_read(actor.clone()).ok())
+            .collect())
+    }
 
-        let visible_answers: Vec<(FormId, Allowed<AnswerEntry, Read>)> = self
+    pub async fn get_all_answers(
+        &self,
+        user: &AccountUser,
+        request: PageRequest<AnswerPagePosition>,
+    ) -> Result<Page<AnswerDetails, AnswerPagePosition>, Error> {
+        let actor_ref = Actor::from(user.clone());
+        let readable_forms = self.readable_forms(&actor_ref).await?;
+
+        let page = self
             .answer_entry_repository
-            .list_all(&readable_forms)
-            .await?
+            .list_all(&readable_forms, request)
+            .await?;
+        let (visible_answers, next) = page.into_parts();
+        let visible_answers: Vec<(FormId, Allowed<AnswerEntry, Read>)> = visible_answers
             .into_iter()
             .map(|entry| (*entry.value().form_id(), entry))
             .collect();
 
-        stream::iter(visible_answers)
+        let answers = stream::iter(visible_answers)
             .then(|(form_id, form_answer)| {
                 let user = user.clone();
                 async move {
@@ -391,7 +409,9 @@ impl<
                     })
                 )
             })
-            .collect()
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(Page::new(answers, next))
     }
 
     pub async fn update_answer_meta(

--- a/server/usecase/src/forms/form.rs
+++ b/server/usecase/src/forms/form.rs
@@ -4,10 +4,11 @@ use domain::{
     auth::Actor,
     form::models::{
         ActiveForm, AllowedUserGroups, AnswerAcceptancePeriod, AnswerSettings, AnswerVisibility,
-        ArchivedForm, DefaultAnswerTitle, DiscordWebhookUrl, FormDescription, FormId, FormLabel,
-        FormLabelAssignment, FormLabelId, FormSettings, FormTitle, Question, QuestionSet,
-        Visibility,
+        ArchivedForm, ArchivedFormPagePosition, DefaultAnswerTitle, DiscordWebhookUrl,
+        FormDescription, FormId, FormLabel, FormLabelAssignment, FormLabelId, FormPagePosition,
+        FormSettings, FormTitle, Question, QuestionSet, Visibility,
     },
+    pagination::{Page, PageLimit, PageRequest},
     repository::{
         form::{
             active_form_repository::ActiveFormRepository,
@@ -169,13 +170,11 @@ impl<
     pub async fn form_list(
         &self,
         actor: &Actor,
-        offset: Option<u32>,
-        limit: Option<u32>,
-    ) -> Result<Vec<(ActiveForm, Vec<FormLabel>)>, Error> {
-        let forms = self
-            .active_form_repository
-            .list(offset, limit)
-            .await?
+        request: PageRequest<FormPagePosition>,
+    ) -> Result<Page<(ActiveForm, Vec<FormLabel>), FormPagePosition>, Error> {
+        let page = self.active_form_repository.list(request).await?;
+        let (forms, next) = page.into_parts();
+        let forms = forms
             .into_iter()
             .flat_map(|form| form.try_read(actor.clone()).map(|form| form.into_inner()))
             .collect::<Vec<_>>();
@@ -203,7 +202,7 @@ impl<
             })
             .collect::<Result<Vec<_>, _>>()?;
 
-        Ok(forms_with_labels)
+        Ok(Page::new(forms_with_labels, next))
     }
 
     pub async fn get_form(
@@ -236,15 +235,13 @@ impl<
     pub async fn archived_form_list(
         &self,
         actor: &AccountUser,
-        offset: Option<u32>,
-        limit: Option<u32>,
+        request: PageRequest<ArchivedFormPagePosition>,
         query: Option<String>,
-    ) -> Result<Vec<ArchivedFormDetails>, Error> {
+    ) -> Result<Page<ArchivedFormDetails, ArchivedFormPagePosition>, Error> {
         let actor_user = Actor::from(actor.clone());
-        let forms = self
-            .archived_form_repository
-            .list(offset, limit, query)
-            .await?
+        let page = self.archived_form_repository.list(request, query).await?;
+        let (forms, next) = page.into_parts();
+        let forms = forms
             .into_iter()
             .flat_map(|form| {
                 form.try_read(actor_user.clone())
@@ -287,7 +284,8 @@ impl<
             })
             .collect::<Vec<_>>();
 
-        futures::future::try_join_all(forms_with_labels).await
+        let forms_with_labels = futures::future::try_join_all(forms_with_labels).await?;
+        Ok(Page::new(forms_with_labels, next))
     }
 
     pub async fn get_archived_form(
@@ -421,8 +419,12 @@ impl<
 
             if !self
                 .answer_entry_repository
-                .list_by_form(&current_form_read)
+                .list_by_form(
+                    &current_form_read,
+                    PageRequest::first(PageLimit::default_limit()),
+                )
                 .await?
+                .items()
                 .is_empty()
             {
                 validate_answered_form_question_update(&current_questions, questions.as_slice())?;

--- a/server/usecase/src/search.rs
+++ b/server/usecase/src/search.rs
@@ -9,12 +9,16 @@ use domain::search::models::{NumberOfRecordsPerAggregate, Operation};
 use domain::{
     account::models::AccountUser,
     auth::Actor,
-    form::answer::{AnswerEntry, AnswerId},
+    form::{
+        answer::{AnswerEntry, AnswerId},
+        models::ActiveForm,
+    },
+    pagination::{PageLimit, PageRequest},
     repository::{
         form::active_form_repository::ActiveFormRepository, search_repository::SearchRepository,
     },
     search::models::SearchableFieldsWithOperation,
-    types::authorization_guard::{Allowed, Read},
+    types::authorization_guard::{Allowed, AuthorizationGuard, Read},
 };
 use errors::Error;
 use futures::{StreamExt, TryStreamExt, stream, try_join};
@@ -63,6 +67,36 @@ impl<
             .iter()
             .find(|entry| *entry.value().id() == answer_id)
             .cloned()
+    }
+
+    async fn list_all_form_guards(
+        &self,
+    ) -> Result<Vec<AuthorizationGuard<ActiveForm, Read>>, Error> {
+        self.active_form_repository.list_all().await
+    }
+
+    async fn list_all_answer_entries(
+        &self,
+        forms: &[Allowed<ActiveForm, Read>],
+    ) -> Result<Vec<Allowed<AnswerEntry, Read>>, Error> {
+        let mut request = PageRequest::first(PageLimit::default_limit());
+        let mut answers = Vec::new();
+
+        loop {
+            let page = self
+                .answer_entry_repository
+                .list_all(forms, request)
+                .await?;
+            let (items, next) = page.into_parts();
+            answers.extend(items);
+
+            let Some(next) = next else {
+                break;
+            };
+            request = PageRequest::after(next, PageLimit::default_limit());
+        }
+
+        Ok(answers)
     }
 
     pub async fn cross_search(
@@ -155,16 +189,12 @@ impl<
             .await?;
 
         let readable_forms = self
-            .active_form_repository
-            .list(None, None)
+            .list_all_form_guards()
             .await?
             .into_iter()
             .filter_map(|form| form.try_read(actor_ref.clone()).ok())
             .collect::<Vec<_>>();
-        let answer_entries = self
-            .answer_entry_repository
-            .list_all(&readable_forms)
-            .await?;
+        let answer_entries = self.list_all_answer_entries(&readable_forms).await?;
 
         let visible_answers = stream::iter(answers)
             .then(|entry| {
@@ -276,8 +306,7 @@ impl<
                         let system = Actor::System;
 
                         let form_guards = self
-                            .active_form_repository
-                            .list(None, None)
+                            .list_all_form_guards()
                             .await?
                             .into_iter()
                             .map(|guard| guard.try_read(system.clone()).map_err(Into::into))
@@ -299,8 +328,7 @@ impl<
                             })
                             .collect::<Result<Vec<_>, errors::Error>>()?;
 
-                        let answer_entries =
-                            self.answer_entry_repository.list_all(&form_guards).await?;
+                        let answer_entries = self.list_all_answer_entries(&form_guards).await?;
 
                         let answers = answer_entries
                             .iter()

--- a/server/usecase/src/test_utils/repositories.rs
+++ b/server/usecase/src/test_utils/repositories.rs
@@ -4,8 +4,11 @@ use domain::{
         AccountUser, DiscordAccountLink, DiscordUser, UserGroup, UserGroupId, UserPagePosition,
     },
     form::{
-        answer::{AnswerEntry, AnswerId, AnswerSubmitterRestriction},
-        models::{ActiveForm, ArchivedForm, FormId, FormLabel, FormLabelId},
+        answer::{AnswerEntry, AnswerId, AnswerPagePosition, AnswerSubmitterRestriction},
+        models::{
+            ActiveForm, ArchivedForm, ArchivedFormPagePosition, FormId, FormLabel, FormLabelId,
+            FormPagePosition,
+        },
     },
     notification::models::NotificationPreference,
     pagination::{Page, PageRequest},
@@ -27,18 +30,6 @@ use std::sync::Mutex;
 use uuid::Uuid;
 
 use crate::forms::form::FormUseCase;
-
-fn paginate<T>(
-    items: impl IntoIterator<Item = T>,
-    offset: Option<u32>,
-    limit: Option<u32>,
-) -> Vec<T> {
-    let items = items.into_iter().skip(offset.unwrap_or(0) as usize);
-    match limit {
-        Some(limit) => items.take(limit as usize).collect(),
-        None => items.collect(),
-    }
-}
 
 fn not_found_error(entity: &str, id: impl std::fmt::Display) -> Error {
     errors::domain::DomainError::InvalidEntity {
@@ -133,21 +124,43 @@ impl ActiveFormRepository for InMemoryActiveFormRepository {
 
     async fn list(
         &self,
-        offset: Option<u32>,
-        limit: Option<u32>,
-    ) -> Result<Vec<AuthorizationGuard<ActiveForm, Read>>, Error> {
-        let forms = self
+        request: PageRequest<FormPagePosition>,
+    ) -> Result<Page<AuthorizationGuard<ActiveForm, Read>, FormPagePosition>, Error> {
+        let mut forms = self
             .forms
             .lock()
             .unwrap()
             .iter()
             .cloned()
             .collect::<Vec<_>>();
+        forms.sort_by_key(|form| form.id().into_inner());
 
-        Ok(paginate(forms, offset, limit)
-            .into_iter()
-            .map(AuthorizationGuard::from)
-            .collect())
+        if let Some(position) = request.after_position() {
+            forms.retain(|form| *form.id() > position.last_form_id());
+        }
+
+        let page = Page::from_overfetched_items(forms, request.limit(), |form| {
+            FormPagePosition::new(*form.id())
+        });
+        let (forms, next) = page.into_parts();
+
+        Ok(Page::new(
+            forms.into_iter().map(AuthorizationGuard::from).collect(),
+            next,
+        ))
+    }
+
+    async fn list_all(&self) -> Result<Vec<AuthorizationGuard<ActiveForm, Read>>, Error> {
+        let mut forms = self
+            .forms
+            .lock()
+            .unwrap()
+            .iter()
+            .cloned()
+            .collect::<Vec<_>>();
+        forms.sort_by_key(|form| form.id().into_inner());
+
+        Ok(forms.into_iter().map(AuthorizationGuard::from).collect())
     }
 
     async fn get(&self, id: FormId) -> Result<Option<AuthorizationGuard<ActiveForm, Read>>, Error> {
@@ -257,24 +270,47 @@ impl AnswerEntryRepository for InMemoryAnswerEntryRepository {
     async fn list_by_form(
         &self,
         form: &Allowed<ActiveForm, Read>,
-    ) -> Result<Vec<Allowed<AnswerEntry, Read>>, Error> {
-        Ok(form.readable_entries(
-            self.answers
-                .lock()
-                .unwrap()
-                .iter()
-                .filter(|answer| answer.form_id() == form.id())
-                .cloned()
-                .collect(),
-        ))
+        request: PageRequest<AnswerPagePosition>,
+    ) -> Result<Page<Allowed<AnswerEntry, Read>, AnswerPagePosition>, Error> {
+        let mut answers = self
+            .answers
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|answer| answer.form_id() == form.id())
+            .cloned()
+            .collect::<Vec<_>>();
+        answers.sort_by_key(|answer| answer.id().into_inner());
+
+        if let Some(position) = request.after_position() {
+            answers.retain(|answer| *answer.id() > position.last_answer_id());
+        }
+
+        let page = Page::from_overfetched_items(answers, request.limit(), |answer| {
+            AnswerPagePosition::new(*answer.id())
+        });
+        let (answers, next) = page.into_parts();
+
+        Ok(Page::new(form.readable_entries(answers), next))
     }
 
     async fn list_all(
         &self,
         forms: &[Allowed<ActiveForm, Read>],
-    ) -> Result<Vec<Allowed<AnswerEntry, Read>>, Error> {
-        let answers = self.answers.lock().unwrap();
-        Ok(forms
+        request: PageRequest<AnswerPagePosition>,
+    ) -> Result<Page<Allowed<AnswerEntry, Read>, AnswerPagePosition>, Error> {
+        let mut answers = self.answers.lock().unwrap().clone();
+        answers.sort_by_key(|answer| answer.id().into_inner());
+
+        if let Some(position) = request.after_position() {
+            answers.retain(|answer| *answer.id() > position.last_answer_id());
+        }
+
+        let page = Page::from_overfetched_items(answers, request.limit(), |answer| {
+            AnswerPagePosition::new(*answer.id())
+        });
+        let (answers, next) = page.into_parts();
+        let readable_answers = forms
             .iter()
             .flat_map(|form| {
                 form.readable_entries(
@@ -285,7 +321,9 @@ impl AnswerEntryRepository for InMemoryAnswerEntryRepository {
                         .collect(),
                 )
             })
-            .collect())
+            .collect::<Vec<_>>();
+
+        Ok(Page::new(readable_answers, next))
     }
 
     async fn post(
@@ -331,10 +369,9 @@ pub(crate) struct InMemoryArchivedFormRepository {
 impl ArchivedFormRepository for InMemoryArchivedFormRepository {
     async fn list(
         &self,
-        offset: Option<u32>,
-        limit: Option<u32>,
+        request: PageRequest<ArchivedFormPagePosition>,
         query: Option<String>,
-    ) -> Result<Vec<AuthorizationGuard<ArchivedForm, Read>>, Error> {
+    ) -> Result<Page<AuthorizationGuard<ArchivedForm, Read>, ArchivedFormPagePosition>, Error> {
         let mut forms = self
             .forms
             .lock()
@@ -359,12 +396,30 @@ impl ArchivedFormRepository for InMemoryArchivedFormRepository {
                 None => true,
             })
             .collect::<Vec<_>>();
-        forms.sort_by(|left, right| right.archived_at().cmp(left.archived_at()));
+        forms.sort_by(|left, right| {
+            right
+                .archived_at()
+                .cmp(left.archived_at())
+                .then_with(|| left.form().id().cmp(right.form().id()))
+        });
 
-        Ok(paginate(forms, offset, limit)
-            .into_iter()
-            .map(AuthorizationGuard::from)
-            .collect())
+        if let Some(position) = request.after_position() {
+            forms.retain(|form| {
+                *form.archived_at() < position.last_archived_at()
+                    || (*form.archived_at() == position.last_archived_at()
+                        && *form.form().id() > position.last_form_id())
+            });
+        }
+
+        let page = Page::from_overfetched_items(forms, request.limit(), |form| {
+            ArchivedFormPagePosition::new(*form.archived_at(), *form.form().id())
+        });
+        let (forms, next) = page.into_parts();
+
+        Ok(Page::new(
+            forms.into_iter().map(AuthorizationGuard::from).collect(),
+            next,
+        ))
     }
 
     async fn get(


### PR DESCRIPTION
## 概要
- フォーム一覧、アーカイブ済みフォーム一覧、全回答一覧、フォーム別回答一覧を `PageRequest` / `Page` ベースの cursor pagination に変更しました。
- cursor には変更されうる日時ではなく、安定した `FormId` / `AnswerId` を使うようにしています。
- API レスポンスを `items` / `next_cursor` 形式に変更し、OpenAPI 定義も更新しました。

## 確認事項
- `makers pretty` で clippy fix、nextest 107 件、doctest、`clippy -D warnings`、rustfmt が通ることを確認しました。
- `cargo build` が通ることを確認しました。
- コミットフックの `check-openapi` が通り、`docs/openapi.json` が生成結果と一致することを確認しました。

🤖 Generated with Codex
