### PR TITLE
ユーザー検索APIを追加する

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3407,7 +3407,7 @@
             "name": "query",
             "in": "query",
             "description": "Search query",
-            "required": false,
+            "required": true,
             "schema": {
               "type": "string"
             }
@@ -3420,6 +3420,83 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/CrossSearchResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The server could not understand the request due to invalid syntax.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access is unauthorized.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access is forbidden.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/search/users": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "summary": "ユーザー検索を行う",
+        "operationId": "search_users",
+        "parameters": [
+          {
+            "name": "query",
+            "in": "query",
+            "description": "Search query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserSearchResult"
                 }
               }
             }
@@ -6225,6 +6302,20 @@
           },
           "role": {
             "type": "string"
+          }
+        }
+      },
+      "UserSearchResult": {
+        "type": "object",
+        "required": [
+          "users"
+        ],
+        "properties": {
+          "users": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/UserSchema"
+            }
           }
         }
       },

--- a/server/entrypoint/src/openapi.rs
+++ b/server/entrypoint/src/openapi.rs
@@ -55,6 +55,7 @@ use utoipa_axum::routes;
         presentation::schemas::notification::notification_response_schemas::NotificationSettingsResponse,
         presentation::schemas::search_schemas::CommentSchema,
         presentation::schemas::search_schemas::CrossSearchResult,
+        presentation::schemas::search_schemas::UserSearchResult,
     )),
     modifiers(&SecurityAddon),
     tags(
@@ -181,6 +182,7 @@ pub fn authenticated_api_router() -> OpenApiRouter<RealInfrastructureRepository>
             user_handler::delete_answer_submitter_restriction
         ))
         .routes(routes!(search_handler::cross_search))
+        .routes(routes!(search_handler::search_users))
         .routes(routes!(message_handler::get_messages_handler))
         .routes(routes!(
             message_handler::update_message_handler,

--- a/server/presentation/src/handlers/search_handler.rs
+++ b/server/presentation/src/handlers/search_handler.rs
@@ -12,7 +12,7 @@ use domain::{
     account::models::AccountUser, repository::Repositories,
     search::models::SearchableFieldsWithOperation,
 };
-use errors::{Error, ErrorExtra};
+use errors::{Error, ErrorExtra, presentation::PresentationError};
 use resource::repository::RealInfrastructureRepository;
 use serde_json::json;
 use tokio::sync::{Notify, mpsc::Receiver};
@@ -21,13 +21,19 @@ use usecase::search::SearchUseCase;
 use crate::schemas::error_responses::*;
 use crate::{
     handlers::error_handler::handle_error,
-    schemas::search_schemas::{CrossSearchResult, SearchQuery},
+    schemas::search_schemas::{CrossSearchResult, SearchQuery, UserSearchResult},
 };
 
 #[derive(utoipa::IntoResponses)]
 pub enum CrossSearchResponse {
     #[response(status = 200, description = "The request has succeeded.")]
     Ok(CrossSearchResult),
+}
+
+#[derive(utoipa::IntoResponses)]
+pub enum UserSearchResponse {
+    #[response(status = 200, description = "The request has succeeded.")]
+    Ok(UserSearchResult),
 }
 
 impl IntoResponse for CrossSearchResponse {
@@ -38,12 +44,30 @@ impl IntoResponse for CrossSearchResponse {
     }
 }
 
+impl IntoResponse for UserSearchResponse {
+    fn into_response(self) -> Response {
+        match self {
+            Self::Ok(body) => (StatusCode::OK, Json(json!(body))).into_response(),
+        }
+    }
+}
+
+fn query_string(search_query: SearchQuery) -> Option<String> {
+    search_query.query.map(|query| query.into_inner())
+}
+
+fn missing_query_response() -> Response {
+    handle_error(Error::from(PresentationError::QueryRejection {
+        cause: "query is required".to_string(),
+    }))
+}
+
 #[utoipa::path(
     get,
     path = "/search",
     summary = "横断検索を行う",
     params(
-        ("query" = Option<String>, Query, description = "Search query"),
+        ("query" = String, Query, description = "Search query"),
     ),
     responses(
         CrossSearchResponse,
@@ -71,24 +95,62 @@ pub async fn cross_search(
     };
 
     let Query(search_query) = query.map_err_to_error().map_err(handle_error)?;
+    let Some(query) = query_string(search_query) else {
+        return Err(missing_query_response());
+    };
 
-    match search_query {
-        SearchQuery { query: None } => Err((
-            StatusCode::BAD_REQUEST,
-            Json(json!({
-                "errorCode": "BAD_REQUEST",
-                "reason": "query is required"
-            })),
-        )
-            .into_response()),
-        SearchQuery { query: Some(query) } => {
-            let result = search_use_case
-                .cross_search(&user, query.into_inner())
-                .await
-                .map_err(handle_error)?;
-            Ok(CrossSearchResponse::Ok(CrossSearchResult::from(result)))
-        }
-    }
+    let result = search_use_case
+        .cross_search(&user, query)
+        .await
+        .map_err(handle_error)?;
+    Ok(CrossSearchResponse::Ok(CrossSearchResult::from(result)))
+}
+
+#[utoipa::path(
+    get,
+    path = "/search/users",
+    summary = "ユーザー検索を行う",
+    params(
+        ("query" = String, Query, description = "Search query"),
+    ),
+    responses(
+        UserSearchResponse,
+        BadRequest,
+        Unauthorized,
+        Forbidden,
+        InternalServerError,
+    ),
+    security(("bearer" = [])),
+    tag = "Search"
+)]
+pub async fn search_users(
+    Extension(user): Extension<AccountUser>,
+    State(repository): State<RealInfrastructureRepository>,
+    query: Result<Query<SearchQuery>, QueryRejection>,
+) -> Result<UserSearchResponse, Response> {
+    let search_use_case = SearchUseCase {
+        search_repository: repository.search_repository(),
+        active_form_repository: repository.active_form_repository(),
+        form_answer_label_repository: repository.answer_label_repository(),
+        form_label_repository: repository.form_label_repository(),
+        user_repository: repository.user_repository(),
+        answer_entry_repository: repository.answer_entry_repository(),
+        comment_repository: repository.comment_repository(),
+    };
+
+    let Query(search_query) = query.map_err_to_error().map_err(handle_error)?;
+    let Some(query) = query_string(search_query) else {
+        return Err(missing_query_response());
+    };
+
+    let users = search_use_case
+        .search_users(&user, query)
+        .await
+        .map_err(handle_error)?;
+
+    Ok(UserSearchResponse::Ok(UserSearchResult {
+        users: users.into_iter().map(Into::into).collect(),
+    }))
 }
 
 pub async fn start_sync(

--- a/server/presentation/src/schemas/search_schemas.rs
+++ b/server/presentation/src/schemas/search_schemas.rs
@@ -13,6 +13,8 @@ use types::non_empty_string::NonEmptyString;
 use usecase::models::CrossSearchOutput;
 use uuid::Uuid;
 
+use crate::schemas::user::UserSchema;
+
 #[derive(Deserialize, Debug, PartialEq, utoipa::ToSchema)]
 pub struct SearchQuery {
     #[serde(default)]
@@ -66,4 +68,9 @@ impl From<CrossSearchOutput> for CrossSearchResult {
             comments: output.comments.into_iter().map(Into::into).collect_vec(),
         }
     }
+}
+
+#[derive(Serialize, Debug, utoipa::ToSchema)]
+pub struct UserSearchResult {
+    pub users: Vec<UserSchema>,
 }

--- a/server/usecase/src/search.rs
+++ b/server/usecase/src/search.rs
@@ -5,7 +5,7 @@ use domain::repository::form::comment_repository::CommentRepository;
 use domain::repository::form::form_label_repository::FormLabelRepository;
 use domain::repository::user_repository::UserRepository;
 use domain::search::models::NumberOfRecords;
-use domain::search::models::{NumberOfRecordsPerAggregate, Operation};
+use domain::search::models::{NumberOfRecordsPerAggregate, Operation, UserSearchHit};
 use domain::{
     account::models::AccountUser,
     auth::Actor,
@@ -22,6 +22,7 @@ use domain::{
 };
 use errors::Error;
 use futures::{StreamExt, TryStreamExt, stream, try_join};
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::{Notify, mpsc::Receiver};
@@ -99,6 +100,46 @@ impl<
         Ok(answers)
     }
 
+    async fn visible_users(
+        &self,
+        actor: &Actor,
+        users: Vec<UserSearchHit>,
+    ) -> Result<Vec<AccountUser>, Error> {
+        let user_ids = users
+            .iter()
+            .map(|user| user.user_id.into_inner())
+            .collect::<Vec<_>>();
+
+        let visible_users_by_id = self
+            .user_repository
+            .find_by_ids(user_ids)
+            .await?
+            .into_iter()
+            .filter_map(|guard| {
+                guard.try_read(actor.clone()).ok().map(|user| {
+                    let user = user.into_inner();
+                    (*user.id(), user)
+                })
+            })
+            .collect::<HashMap<_, _>>();
+
+        Ok(users
+            .into_iter()
+            .filter_map(|user| visible_users_by_id.get(&user.user_id).cloned())
+            .collect())
+    }
+
+    pub async fn search_users(
+        &self,
+        actor: &AccountUser,
+        query: String,
+    ) -> Result<Vec<AccountUser>, Error> {
+        let actor = Actor::from(actor.clone());
+        let users = self.search_repository.search_users(&query).await?;
+
+        self.visible_users(&actor, users).await
+    }
+
     pub async fn cross_search(
         &self,
         actor: &AccountUser,
@@ -134,23 +175,7 @@ impl<
             .try_collect()
             .await?;
 
-        let visible_users = stream::iter(users)
-            .then(|user| async move {
-                self.user_repository
-                    .find_by(user.user_id.into_inner())
-                    .await
-                    .map(|guard| {
-                        guard.and_then(|guard| {
-                            guard
-                                .try_read(actor_ref.clone())
-                                .ok()
-                                .map(|user| user.into_inner())
-                        })
-                    })
-            })
-            .try_filter_map(|visible| std::future::ready(Ok(visible)))
-            .try_collect()
-            .await?;
+        let visible_users = self.visible_users(actor_ref, users).await?;
 
         let visible_label_for_forms = stream::iter(label_for_forms)
             .then(|label| async move {


### PR DESCRIPTION
## 概要
- 横断検索とは別に、ユーザーだけを検索できる `GET /api/v1/search/users` を追加しました。
- 既存の Meilisearch ユーザー検索とユーザー Repository の読み取り認可を再利用し、返却形式は `UserSchema` ベースの `UserSearchResult` にしました。
- 新しい経路と schema を OpenAPI に登録し、`docs/openapi.json` を再生成しました。

## 確認事項
- `cargo build` で workspace がコンパイルできることを確認しました。
- `cargo run --package entrypoint --bin generate-openapi` で OpenAPI を再生成でき、`/api/v1/search/users` が含まれることを確認しました。
- `makers pretty` を実行し、clippy、nextest、doc test、rustfmt が通ることを確認しました。

🤖 Generated with Codex
