### PR TITLE
ユーザーグループの所属ユーザー取得APIを追加する

### DIFF
--- a/.sqlx/query-6c925ef89400627587d4f70fd1ec89d2090b6faa2a4d5f207a07ab0a0bc52326.json
+++ b/.sqlx/query-6c925ef89400627587d4f70fd1ec89d2090b6faa2a4d5f207a07ab0a0bc52326.json
@@ -1,0 +1,65 @@
+{
+  "db_name": "MySQL",
+  "query": "SELECT u.id, u.name, u.role\n                    FROM users u\n                    INNER JOIN user_group_memberships m ON u.id = m.user_id\n                    WHERE m.group_id = ?\n                    ORDER BY u.id ASC",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": {
+          "type": "String",
+          "flags": "NOT_NULL | PRIMARY_KEY | NO_DEFAULT_VALUE",
+          "collation": 224,
+          "max_size": 144
+        },
+        "origin": {
+          "Table": {
+            "table": "seichi_portal.users",
+            "name": "id"
+          }
+        }
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": {
+          "type": "VarString",
+          "flags": "NOT_NULL | NO_DEFAULT_VALUE",
+          "collation": 224,
+          "max_size": 64
+        },
+        "origin": {
+          "Table": {
+            "table": "seichi_portal.users",
+            "name": "name"
+          }
+        }
+      },
+      {
+        "ordinal": 2,
+        "name": "role",
+        "type_info": {
+          "type": "String",
+          "flags": "NOT_NULL | ENUM | NO_DEFAULT_VALUE",
+          "collation": 224,
+          "max_size": 52
+        },
+        "origin": {
+          "Table": {
+            "table": "seichi_portal.users",
+            "name": "role"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "6c925ef89400627587d4f70fd1ec89d2090b6faa2a4d5f207a07ab0a0bc52326"
+}

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -4053,6 +4053,96 @@
         ]
       }
     },
+    "/api/v1/user-groups/{group_id}/users": {
+      "get": {
+        "tags": [
+          "User Groups"
+        ],
+        "summary": "ユーザーグループに所属するユーザーの一覧取得",
+        "operationId": "user_group_user_list",
+        "parameters": [
+          {
+            "name": "group_id",
+            "in": "path",
+            "description": "User group UUID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/UserSchema"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The server could not understand the request due to invalid syntax.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access is unauthorized.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access is forbidden.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The server cannot find the requested resource.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
     "/api/v1/user-groups/{group_id}/users/{user_id}": {
       "put": {
         "tags": [

--- a/server/domain/src/repository/user_repository.rs
+++ b/server/domain/src/repository/user_repository.rs
@@ -32,6 +32,10 @@ pub trait UserRepository: Send + Sync + 'static {
         group_id: UserGroupId,
     ) -> Result<Option<AuthorizationGuard<UserGroup, Read>>, Error>;
     async fn fetch_user_groups(&self) -> Result<Vec<AuthorizationGuard<UserGroup, Read>>, Error>;
+    async fn fetch_users_by_group(
+        &self,
+        group: Allowed<UserGroup, Read>,
+    ) -> Result<Vec<AuthorizationGuard<AccountUser, Read>>, Error>;
     async fn add_user_to_group(
         &self,
         group: Allowed<UserGroup, Update>,

--- a/server/entrypoint/src/openapi.rs
+++ b/server/entrypoint/src/openapi.rs
@@ -172,6 +172,7 @@ pub fn authenticated_api_router() -> OpenApiRouter<RealInfrastructureRepository>
             user_handler::update_user_group,
             user_handler::delete_user_group
         ))
+        .routes(routes!(user_handler::user_group_user_list))
         .routes(routes!(
             user_handler::add_user_to_group,
             user_handler::remove_user_from_group

--- a/server/infra/resource/src/database/components.rs
+++ b/server/infra/resource/src/database/components.rs
@@ -230,6 +230,10 @@ pub trait UserDatabase: Send + Sync {
     async fn find_user_group(&self, group_id: UserGroupId)
     -> Result<Option<UserGroup>, InfraError>;
     async fn fetch_user_groups(&self) -> Result<Vec<UserGroup>, InfraError>;
+    async fn fetch_users_by_group(
+        &self,
+        group_id: UserGroupId,
+    ) -> Result<Vec<AccountUser>, InfraError>;
     async fn add_user_to_group(
         &self,
         group_id: UserGroupId,

--- a/server/infra/resource/src/database/user.rs
+++ b/server/infra/resource/src/database/user.rs
@@ -304,6 +304,46 @@ impl UserDatabase for ConnectionPool {
         .await
     }
 
+    async fn fetch_users_by_group(
+        &self,
+        group_id: UserGroupId,
+    ) -> Result<Vec<AccountUser>, InfraError> {
+        let group_id = group_id.to_string();
+
+        self.read_only_transaction(|txn| {
+            Box::pin(async move {
+                let rows = sqlx::query_as!(
+                    UserRow,
+                    r#"SELECT u.id, u.name, u.role
+                    FROM users u
+                    INNER JOIN user_group_memberships m ON u.id = m.user_id
+                    WHERE m.group_id = ?
+                    ORDER BY u.id ASC"#,
+                    group_id,
+                )
+                .fetch_all(&mut **txn)
+                .await?;
+
+                let user_ids = rows.iter().map(|row| row.id.clone()).collect_vec();
+                let mut groups_by_user = fetch_groups_by_user_ids(txn, &user_ids).await?;
+
+                rows.into_iter()
+                    .map(|row| {
+                        let user_id = Uuid::parse_str(&row.id)?;
+                        let groups = groups_by_user.remove(&row.id).unwrap_or_default();
+                        Ok::<_, InfraError>(AccountUser::with_groups(
+                            row.name,
+                            user_id.into(),
+                            Role::from_str(&row.role)?,
+                            groups,
+                        ))
+                    })
+                    .collect()
+            })
+        })
+        .await
+    }
+
     async fn add_user_to_group(
         &self,
         group_id: UserGroupId,

--- a/server/infra/resource/src/repository/user_repository_impl.rs
+++ b/server/infra/resource/src/repository/user_repository_impl.rs
@@ -108,6 +108,20 @@ impl<Client: DatabaseComponents + 'static> UserRepository for Repository<Client>
             .collect_vec())
     }
 
+    async fn fetch_users_by_group(
+        &self,
+        group: Allowed<UserGroup, Read>,
+    ) -> Result<Vec<AuthorizationGuard<AccountUser, Read>>, Error> {
+        Ok(self
+            .client
+            .user()
+            .fetch_users_by_group(*group.id())
+            .await?
+            .into_iter()
+            .map(Into::into)
+            .collect_vec())
+    }
+
     async fn add_user_to_group(
         &self,
         group: Allowed<UserGroup, Update>,

--- a/server/presentation/src/handlers/user_handler.rs
+++ b/server/presentation/src/handlers/user_handler.rs
@@ -83,6 +83,20 @@ impl IntoResponse for UserGroupListResponse {
 }
 
 #[derive(utoipa::IntoResponses)]
+pub enum UserGroupUserListResponse {
+    #[response(status = 200, description = "The request has succeeded.")]
+    Ok(Vec<UserSchema>),
+}
+
+impl IntoResponse for UserGroupUserListResponse {
+    fn into_response(self) -> Response {
+        match self {
+            Self::Ok(body) => (StatusCode::OK, Json(body)).into_response(),
+        }
+    }
+}
+
+#[derive(utoipa::IntoResponses)]
 pub enum UserGroupResponse {
     #[response(status = 200, description = "The request has succeeded.")]
     Ok(UserGroupSchema),
@@ -460,6 +474,44 @@ pub async fn user_group_list(
 
     Ok(UserGroupListResponse::Ok(
         groups.into_iter().map(Into::into).collect(),
+    ))
+}
+
+#[utoipa::path(
+    get,
+    path = "/user-groups/{group_id}/users",
+    summary = "ユーザーグループに所属するユーザーの一覧取得",
+    params(
+        ("group_id" = String, Path, description = "User group UUID"),
+    ),
+    responses(
+        UserGroupUserListResponse,
+        BadRequest,
+        Unauthorized,
+        Forbidden,
+        NotFound,
+        InternalServerError,
+    ),
+    security(("bearer" = [])),
+    tag = "User Groups"
+)]
+pub async fn user_group_user_list(
+    Extension(actor): Extension<AccountUser>,
+    State(repository): State<RealInfrastructureRepository>,
+    path: Result<Path<Uuid>, PathRejection>,
+) -> Result<UserGroupUserListResponse, Response> {
+    let user_use_case = UserUseCase {
+        repository: repository.user_repository(),
+    };
+    let Path(group_id) = path.map_err_to_error().map_err(handle_error)?;
+
+    let users = user_use_case
+        .fetch_users_by_group(&actor, group_id.into())
+        .await
+        .map_err(handle_error)?;
+
+    Ok(UserGroupUserListResponse::Ok(
+        users.into_iter().map(Into::into).collect(),
     ))
 }
 

--- a/server/usecase/src/test_utils/repositories.rs
+++ b/server/usecase/src/test_utils/repositories.rs
@@ -615,6 +615,24 @@ impl UserRepository for InMemoryUserRepository {
             .collect())
     }
 
+    async fn fetch_users_by_group(
+        &self,
+        group: Allowed<UserGroup, Read>,
+    ) -> Result<Vec<AuthorizationGuard<AccountUser, Read>>, Error> {
+        let group_id = *group.id();
+        let mut users = self
+            .users
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|user| user.groups().iter().any(|group| *group.id() == group_id))
+            .cloned()
+            .collect::<Vec<_>>();
+        users.sort_by_key(|user| user.id().into_inner());
+
+        Ok(users.into_iter().map(AuthorizationGuard::from).collect())
+    }
+
     async fn add_user_to_group(
         &self,
         group: Allowed<UserGroup, Update>,

--- a/server/usecase/src/user.rs
+++ b/server/usecase/src/user.rs
@@ -173,6 +173,32 @@ impl<R: UserRepository> UserUseCase<'_, R> {
             .map_err(Into::into)
     }
 
+    pub async fn fetch_users_by_group(
+        &self,
+        actor: &AccountUser,
+        group_id: UserGroupId,
+    ) -> Result<Vec<AccountUser>, Error> {
+        let actor_ref = Actor::from(actor.clone());
+        let group = self
+            .repository
+            .find_user_group(group_id)
+            .await?
+            .ok_or(Error::from(UseCaseError::UserGroupNotFound))?
+            .try_read(actor_ref.clone())?;
+
+        self.repository
+            .fetch_users_by_group(group)
+            .await?
+            .into_iter()
+            .map(|guard| {
+                guard
+                    .try_read(actor_ref.clone())
+                    .map(|user| user.into_inner())
+            })
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(Into::into)
+    }
+
     pub async fn add_user_to_group(
         &self,
         actor: &AccountUser,
@@ -372,5 +398,74 @@ impl<R: UserRepository> UserUseCase<'_, R> {
         let user = allowed.into_inner();
 
         Ok(UserProfile { user, discord_user })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use domain::account::models::{Role, UserId};
+    use errors::usecase::UseCaseError;
+    use types::non_empty_string::NonEmptyString;
+
+    use super::*;
+    use crate::test_utils::repositories::FormUseCaseTestRepositories;
+
+    fn user(seed: u128, name: &str, role: Role) -> AccountUser {
+        AccountUser::new(name.to_string(), UserId::from(Uuid::from_u128(seed)), role)
+    }
+
+    fn group_name(name: &str) -> UserGroupName {
+        UserGroupName::new(NonEmptyString::try_new(name.to_string()).unwrap())
+    }
+
+    #[tokio::test]
+    async fn fetch_users_by_group_returns_only_group_members() {
+        let admin = user(1, "admin", Role::Administrator);
+        let member = user(2, "member", Role::StandardUser);
+        let outsider = user(3, "outsider", Role::StandardUser);
+        let repositories = FormUseCaseTestRepositories::default();
+        let usecase = UserUseCase {
+            repository: &repositories.user_repository,
+        };
+
+        usecase.upsert_user(&admin, admin.clone()).await.unwrap();
+        usecase.upsert_user(&member, member.clone()).await.unwrap();
+        usecase
+            .upsert_user(&outsider, outsider.clone())
+            .await
+            .unwrap();
+        let group = usecase
+            .create_user_group(&admin, group_name("members"))
+            .await
+            .unwrap();
+        usecase
+            .add_user_to_group(&admin, *group.id(), member.id().into_inner())
+            .await
+            .unwrap();
+
+        let users = usecase
+            .fetch_users_by_group(&admin, *group.id())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            users.into_iter().map(|user| *user.id()).collect::<Vec<_>>(),
+            vec![*member.id()]
+        );
+    }
+
+    #[tokio::test]
+    async fn fetch_users_by_group_returns_not_found_for_unknown_group() {
+        let admin = user(1, "admin", Role::Administrator);
+        let repositories = FormUseCaseTestRepositories::default();
+        let usecase = UserUseCase {
+            repository: &repositories.user_repository,
+        };
+
+        let result = usecase
+            .fetch_users_by_group(&admin, Uuid::from_u128(100).into())
+            .await;
+
+        assert_eq!(result, Err(Error::from(UseCaseError::UserGroupNotFound)));
     }
 }


### PR DESCRIPTION
## 概要
- ユーザーグループから所属ユーザー一覧を取得する `GET /api/v1/user-groups/{group_id}/users` を追加しました。
- UseCase と Repository に、認可済みのユーザーグループを起点にメンバーを取得する読み取り経路を追加しました。
- OpenAPI 定義と sqlx metadata を更新し、UseCase レベルでメンバー取得と存在しないグループの挙動をテストしました。

## 確認事項
- `cargo sqlx prepare --workspace` をローカル MySQL 接続で実行し、新規 typed query の metadata が生成されることを確認しました。
- `cargo build` が成功し、追加した API 経路を含むワークスペースがコンパイルできることを確認しました。
- `makers pretty` が成功し、109 件の nextest、doctest、`cargo clippy -- -D warnings`、rustfmt が通ることを確認しました。

🤖 Generated with Codex