### PR TITLE
回答投稿制限の履歴取得APIを追加する

### DIFF
--- a/.sqlx/query-0259cc6587db947df1a818d3a48cee3e2e0827185b84985b5c54a85439980cc4.json
+++ b/.sqlx/query-0259cc6587db947df1a818d3a48cee3e2e0827185b84985b5c54a85439980cc4.json
@@ -1,0 +1,150 @@
+{
+  "db_name": "MySQL",
+  "query": "\n                    SELECT id, submitter_id, reason, restricted_by, restricted_at, expires_at, lifted_at, lifted_by\n                    FROM answer_submitter_restrictions\n                    WHERE submitter_id = ?\n                    ORDER BY restricted_at DESC\n                    ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": {
+          "type": "String",
+          "flags": "NOT_NULL | PRIMARY_KEY | NO_DEFAULT_VALUE",
+          "collation": 224,
+          "max_size": 144
+        },
+        "origin": {
+          "Table": {
+            "table": "seichi_portal.answer_submitter_restrictions",
+            "name": "id"
+          }
+        }
+      },
+      {
+        "ordinal": 1,
+        "name": "submitter_id",
+        "type_info": {
+          "type": "String",
+          "flags": "NOT_NULL | MULTIPLE_KEY | NO_DEFAULT_VALUE",
+          "collation": 224,
+          "max_size": 144
+        },
+        "origin": {
+          "Table": {
+            "table": "seichi_portal.answer_submitter_restrictions",
+            "name": "submitter_id"
+          }
+        }
+      },
+      {
+        "ordinal": 2,
+        "name": "reason",
+        "type_info": {
+          "type": "Blob",
+          "flags": "NOT_NULL | BLOB | NO_DEFAULT_VALUE",
+          "collation": 224,
+          "max_size": 262140
+        },
+        "origin": {
+          "Table": {
+            "table": "seichi_portal.answer_submitter_restrictions",
+            "name": "reason"
+          }
+        }
+      },
+      {
+        "ordinal": 3,
+        "name": "restricted_by",
+        "type_info": {
+          "type": "String",
+          "flags": "NOT_NULL | MULTIPLE_KEY | NO_DEFAULT_VALUE",
+          "collation": 224,
+          "max_size": 144
+        },
+        "origin": {
+          "Table": {
+            "table": "seichi_portal.answer_submitter_restrictions",
+            "name": "restricted_by"
+          }
+        }
+      },
+      {
+        "ordinal": 4,
+        "name": "restricted_at",
+        "type_info": {
+          "type": "Datetime",
+          "flags": "NOT_NULL | BINARY | NO_DEFAULT_VALUE",
+          "collation": 63,
+          "max_size": 26
+        },
+        "origin": {
+          "Table": {
+            "table": "seichi_portal.answer_submitter_restrictions",
+            "name": "restricted_at"
+          }
+        }
+      },
+      {
+        "ordinal": 5,
+        "name": "expires_at",
+        "type_info": {
+          "type": "Datetime",
+          "flags": "BINARY",
+          "collation": 63,
+          "max_size": 26
+        },
+        "origin": {
+          "Table": {
+            "table": "seichi_portal.answer_submitter_restrictions",
+            "name": "expires_at"
+          }
+        }
+      },
+      {
+        "ordinal": 6,
+        "name": "lifted_at",
+        "type_info": {
+          "type": "Datetime",
+          "flags": "BINARY",
+          "collation": 63,
+          "max_size": 26
+        },
+        "origin": {
+          "Table": {
+            "table": "seichi_portal.answer_submitter_restrictions",
+            "name": "lifted_at"
+          }
+        }
+      },
+      {
+        "ordinal": 7,
+        "name": "lifted_by",
+        "type_info": {
+          "type": "String",
+          "flags": "MULTIPLE_KEY",
+          "collation": 224,
+          "max_size": 144
+        },
+        "origin": {
+          "Table": {
+            "table": "seichi_portal.answer_submitter_restrictions",
+            "name": "lifted_by"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true
+    ]
+  },
+  "hash": "0259cc6587db947df1a818d3a48cee3e2e0827185b84985b5c54a85439980cc4"
+}

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -4946,6 +4946,96 @@
           }
         ]
       }
+    },
+    "/api/v1/users/{uuid}/answer-submitter-restriction/history": {
+      "get": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "回答投稿者の回答投稿制限履歴の取得",
+        "operationId": "get_answer_submitter_restriction_history",
+        "parameters": [
+          {
+            "name": "uuid",
+            "in": "path",
+            "description": "User UUID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AnswerSubmitterRestrictionHistoryResponse"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The server could not understand the request due to invalid syntax.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access is unauthorized.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access is forbidden.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The server cannot find the requested resource.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
     }
   },
   "components": {
@@ -5194,6 +5284,54 @@
           },
           "visibility": {
             "$ref": "#/components/schemas/AnswerVisibility"
+          }
+        }
+      },
+      "AnswerSubmitterRestrictionHistoryResponse": {
+        "type": "object",
+        "required": [
+          "id",
+          "submitter_id",
+          "reason",
+          "restricted_by",
+          "restricted_at"
+        ],
+        "properties": {
+          "expires_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "id": {
+            "type": "string"
+          },
+          "lifted_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "lifted_by": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "reason": {
+            "type": "string"
+          },
+          "restricted_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "restricted_by": {
+            "type": "string"
+          },
+          "submitter_id": {
+            "type": "string"
           }
         }
       },

--- a/server/domain/src/form/answer/mod.rs
+++ b/server/domain/src/form/answer/mod.rs
@@ -14,6 +14,7 @@ pub use label::{AnswerLabel, AnswerLabelId};
 pub use settings::{AnswerAcceptancePeriod, AnswerSettings, AnswerVisibility, DefaultAnswerTitle};
 pub use submitter::AnswerSubmitter;
 pub use submitter_restriction::{
-    AnswerSubmitterRestriction, AnswerSubmitterRestrictionId, AnswerSubmitterRestrictionReason,
+    AnswerSubmitterRestriction, AnswerSubmitterRestrictionHistory, AnswerSubmitterRestrictionId,
+    AnswerSubmitterRestrictionReason,
 };
 pub use title::AnswerTitle;

--- a/server/domain/src/form/answer/submitter_restriction.rs
+++ b/server/domain/src/form/answer/submitter_restriction.rs
@@ -32,6 +32,8 @@ pub struct AnswerSubmitterRestriction {
     restricted_by: UserId,
     restricted_at: DateTime<Utc>,
     expires_at: Option<DateTime<Utc>>,
+    lifted_at: Option<DateTime<Utc>>,
+    lifted_by: Option<UserId>,
 }
 
 impl AnswerSubmitterRestriction {
@@ -56,11 +58,13 @@ impl AnswerSubmitterRestriction {
             restricted_by,
             restricted_at,
             expires_at,
+            lifted_at: None,
+            lifted_by: None,
         })
     }
 
     pub fn is_active_at(&self, now: DateTime<Utc>) -> bool {
-        self.expires_at.is_none_or(|expires_at| now < expires_at)
+        self.lifted_at.is_none() && self.expires_at.is_none_or(|expires_at| now < expires_at)
     }
 }
 

--- a/server/domain/src/form/answer/submitter_restriction.rs
+++ b/server/domain/src/form/answer/submitter_restriction.rs
@@ -68,6 +68,59 @@ impl AnswerSubmitterRestriction {
     }
 }
 
+#[derive(Debug, PartialEq)]
+pub struct AnswerSubmitterRestrictionHistory {
+    submitter_id: UserId,
+    restrictions: Vec<AnswerSubmitterRestriction>,
+}
+
+impl AnswerSubmitterRestrictionHistory {
+    pub fn new(
+        submitter_id: UserId,
+        restrictions: Vec<AnswerSubmitterRestriction>,
+    ) -> Result<Self, DomainError> {
+        if restrictions
+            .iter()
+            .any(|restriction| restriction.submitter_id != submitter_id)
+        {
+            return Err(DomainError::InvalidEntity {
+                message: "answer submitter restriction history must contain only restrictions for the submitter".to_string(),
+            });
+        }
+
+        Ok(Self {
+            submitter_id,
+            restrictions,
+        })
+    }
+
+    pub fn into_restrictions(self) -> Vec<AnswerSubmitterRestriction> {
+        self.restrictions
+    }
+}
+
+impl AuthorizationRole for AnswerSubmitterRestrictionHistory {
+    type Role = SelfGuarded;
+}
+
+impl AuthorizationGuardDefinitions for AnswerSubmitterRestrictionHistory {
+    fn can_create(&self, _actor: &Actor) -> bool {
+        false
+    }
+
+    fn can_read(&self, actor: &Actor) -> bool {
+        matches!(actor, Actor::AccountUser(user) if self.submitter_id == *user.id() || user.role() == &Role::Administrator)
+    }
+
+    fn can_update(&self, _actor: &Actor) -> bool {
+        false
+    }
+
+    fn can_delete(&self, _actor: &Actor) -> bool {
+        false
+    }
+}
+
 impl AuthorizationRole for AnswerSubmitterRestriction {
     type Role = SelfGuarded;
 }

--- a/server/domain/src/repository/answer_submitter_restriction_repository.rs
+++ b/server/domain/src/repository/answer_submitter_restriction_repository.rs
@@ -16,6 +16,11 @@ pub trait AnswerSubmitterRestrictionRepository: Send + Sync + 'static {
         submitter_id: Uuid,
     ) -> Result<Option<AuthorizationGuard<AnswerSubmitterRestriction, Read>>, Error>;
 
+    async fn list_by_submitter_id(
+        &self,
+        submitter_id: Uuid,
+    ) -> Result<Vec<AuthorizationGuard<AnswerSubmitterRestriction, Read>>, Error>;
+
     async fn restrict(
         &self,
         restriction: Allowed<AnswerSubmitterRestriction, Create>,

--- a/server/domain/src/repository/answer_submitter_restriction_repository.rs
+++ b/server/domain/src/repository/answer_submitter_restriction_repository.rs
@@ -4,7 +4,7 @@ use mockall::automock;
 use uuid::Uuid;
 
 use crate::{
-    form::answer::AnswerSubmitterRestriction,
+    form::answer::{AnswerSubmitterRestriction, AnswerSubmitterRestrictionHistory},
     types::authorization_guard::{Allowed, AuthorizationGuard, Create, Delete, Read},
 };
 
@@ -19,7 +19,7 @@ pub trait AnswerSubmitterRestrictionRepository: Send + Sync + 'static {
     async fn list_by_submitter_id(
         &self,
         submitter_id: Uuid,
-    ) -> Result<Vec<AuthorizationGuard<AnswerSubmitterRestriction, Read>>, Error>;
+    ) -> Result<AuthorizationGuard<AnswerSubmitterRestrictionHistory, Read>, Error>;
 
     async fn restrict(
         &self,

--- a/server/entrypoint/src/openapi.rs
+++ b/server/entrypoint/src/openapi.rs
@@ -18,6 +18,7 @@ use utoipa_axum::routes;
         presentation::schemas::user::UserGroupSchema,
         presentation::schemas::user::AnswerSubmitterRestrictionRequest,
         presentation::schemas::user::AnswerSubmitterRestrictionResponse,
+        presentation::schemas::user::AnswerSubmitterRestrictionHistoryResponse,
         presentation::schemas::form::form_response_schemas::AnswerComment,
         presentation::schemas::form::form_response_schemas::AnswerContent,
         presentation::schemas::form::form_response_schemas::AnswerLabels,
@@ -181,6 +182,9 @@ pub fn authenticated_api_router() -> OpenApiRouter<RealInfrastructureRepository>
             user_handler::get_answer_submitter_restriction,
             user_handler::put_answer_submitter_restriction,
             user_handler::delete_answer_submitter_restriction
+        ))
+        .routes(routes!(
+            user_handler::get_answer_submitter_restriction_history
         ))
         .routes(routes!(search_handler::cross_search))
         .routes(routes!(search_handler::search_users))

--- a/server/infra/resource/src/database/components.rs
+++ b/server/infra/resource/src/database/components.rs
@@ -276,6 +276,10 @@ pub trait AnswerSubmitterRestrictionDatabase: Send + Sync {
         &self,
         submitter_id: Uuid,
     ) -> Result<Option<AnswerSubmitterRestriction>, InfraError>;
+    async fn list_by_submitter_id(
+        &self,
+        submitter_id: Uuid,
+    ) -> Result<Vec<AnswerSubmitterRestriction>, InfraError>;
     async fn restrict(&self, restriction: &AnswerSubmitterRestriction) -> Result<(), InfraError>;
     async fn lift(&self, submitter_id: Uuid, lifted_by: Uuid) -> Result<(), InfraError>;
 }

--- a/server/infra/resource/src/database/user.rs
+++ b/server/infra/resource/src/database/user.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::str::FromStr;
 
 use async_trait::async_trait;
-use chrono::Utc;
+use chrono::{NaiveDateTime, Utc};
 use domain::{
     account::models::{
         AccountUser, DiscordAccountLink, Role, UserGroup, UserGroupId, UserGroupName,
@@ -638,22 +638,55 @@ impl AnswerSubmitterRestrictionDatabase for ConnectionPool {
                 .await?;
 
                 row.map(|row| {
-                    Ok::<_, InfraError>(unsafe {
-                        AnswerSubmitterRestriction::from_raw_parts(
-                            AnswerSubmitterRestrictionId::from(Uuid::parse_str(&row.id)?),
-                            Uuid::parse_str(&row.submitter_id)?.into(),
-                            AnswerSubmitterRestrictionReason::new(row.reason.try_into().map_err(
-                                |err: errors::validation::ValidationError| InfraError::Unexpected {
-                                    cause: err.to_string(),
-                                },
-                            )?),
-                            Uuid::parse_str(&row.restricted_by)?.into(),
-                            row.restricted_at.and_utc(),
-                            row.expires_at.map(|expires_at| expires_at.and_utc()),
-                        )
+                    answer_submitter_restriction_from_row(AnswerSubmitterRestrictionRowData {
+                        id: row.id,
+                        submitter_id: row.submitter_id,
+                        reason: row.reason,
+                        restricted_by: row.restricted_by,
+                        restricted_at: row.restricted_at,
+                        expires_at: row.expires_at,
+                        lifted_at: None,
+                        lifted_by: None,
                     })
                 })
                 .transpose()
+            })
+        })
+        .await
+    }
+
+    async fn list_by_submitter_id(
+        &self,
+        submitter_id: Uuid,
+    ) -> Result<Vec<AnswerSubmitterRestriction>, InfraError> {
+        self.read_only_transaction(|txn| {
+            Box::pin(async move {
+                let rows = sqlx::query!(
+                    r#"
+                    SELECT id, submitter_id, reason, restricted_by, restricted_at, expires_at, lifted_at, lifted_by
+                    FROM answer_submitter_restrictions
+                    WHERE submitter_id = ?
+                    ORDER BY restricted_at DESC
+                    "#,
+                    submitter_id.to_string(),
+                )
+                .fetch_all(&mut **txn)
+                .await?;
+
+                rows.into_iter()
+                    .map(|row| {
+                        answer_submitter_restriction_from_row(AnswerSubmitterRestrictionRowData {
+                            id: row.id,
+                            submitter_id: row.submitter_id,
+                            reason: row.reason,
+                            restricted_by: row.restricted_by,
+                            restricted_at: row.restricted_at,
+                            expires_at: row.expires_at,
+                            lifted_at: row.lifted_at,
+                            lifted_by: row.lifted_by,
+                        })
+                    })
+                    .collect()
             })
         })
         .await
@@ -727,4 +760,38 @@ impl AnswerSubmitterRestrictionDatabase for ConnectionPool {
         })
         .await
     }
+}
+
+struct AnswerSubmitterRestrictionRowData {
+    id: String,
+    submitter_id: String,
+    reason: String,
+    restricted_by: String,
+    restricted_at: NaiveDateTime,
+    expires_at: Option<NaiveDateTime>,
+    lifted_at: Option<NaiveDateTime>,
+    lifted_by: Option<String>,
+}
+
+fn answer_submitter_restriction_from_row(
+    row: AnswerSubmitterRestrictionRowData,
+) -> Result<AnswerSubmitterRestriction, InfraError> {
+    Ok(unsafe {
+        AnswerSubmitterRestriction::from_raw_parts(
+            AnswerSubmitterRestrictionId::from(Uuid::parse_str(&row.id)?),
+            Uuid::parse_str(&row.submitter_id)?.into(),
+            AnswerSubmitterRestrictionReason::new(row.reason.try_into().map_err(
+                |err: errors::validation::ValidationError| InfraError::Unexpected {
+                    cause: err.to_string(),
+                },
+            )?),
+            Uuid::parse_str(&row.restricted_by)?.into(),
+            row.restricted_at.and_utc(),
+            row.expires_at.map(|expires_at| expires_at.and_utc()),
+            row.lifted_at.map(|lifted_at| lifted_at.and_utc()),
+            row.lifted_by
+                .map(|lifted_by| Uuid::parse_str(&lifted_by).map(Into::into))
+                .transpose()?,
+        )
+    })
 }

--- a/server/infra/resource/src/repository/answer_submitter_restriction_repository_impl.rs
+++ b/server/infra/resource/src/repository/answer_submitter_restriction_repository_impl.rs
@@ -29,6 +29,20 @@ impl<Client: DatabaseComponents + 'static> AnswerSubmitterRestrictionRepository
             .map(Into::into))
     }
 
+    async fn list_by_submitter_id(
+        &self,
+        submitter_id: Uuid,
+    ) -> Result<Vec<AuthorizationGuard<AnswerSubmitterRestriction, Read>>, Error> {
+        Ok(self
+            .client
+            .answer_submitter_restriction()
+            .list_by_submitter_id(submitter_id)
+            .await?
+            .into_iter()
+            .map(Into::into)
+            .collect())
+    }
+
     async fn restrict(
         &self,
         restriction: Allowed<AnswerSubmitterRestriction, Create>,

--- a/server/infra/resource/src/repository/answer_submitter_restriction_repository_impl.rs
+++ b/server/infra/resource/src/repository/answer_submitter_restriction_repository_impl.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use domain::{
     auth::Actor,
-    form::answer::AnswerSubmitterRestriction,
+    form::answer::{AnswerSubmitterRestriction, AnswerSubmitterRestrictionHistory},
     repository::answer_submitter_restriction_repository::AnswerSubmitterRestrictionRepository,
     types::authorization_guard::{Allowed, AuthorizationGuard, Create, Delete, Read},
 };
@@ -32,15 +32,15 @@ impl<Client: DatabaseComponents + 'static> AnswerSubmitterRestrictionRepository
     async fn list_by_submitter_id(
         &self,
         submitter_id: Uuid,
-    ) -> Result<Vec<AuthorizationGuard<AnswerSubmitterRestriction, Read>>, Error> {
-        Ok(self
-            .client
-            .answer_submitter_restriction()
-            .list_by_submitter_id(submitter_id)
-            .await?
-            .into_iter()
-            .map(Into::into)
-            .collect())
+    ) -> Result<AuthorizationGuard<AnswerSubmitterRestrictionHistory, Read>, Error> {
+        Ok(AnswerSubmitterRestrictionHistory::new(
+            submitter_id.into(),
+            self.client
+                .answer_submitter_restriction()
+                .list_by_submitter_id(submitter_id)
+                .await?,
+        )?
+        .into())
     }
 
     async fn restrict(

--- a/server/presentation/src/handlers/user_handler.rs
+++ b/server/presentation/src/handlers/user_handler.rs
@@ -24,9 +24,9 @@ use uuid::Uuid;
 
 use crate::schemas::error_responses::*;
 use crate::schemas::user::{
-    AnswerSubmitterRestrictionRequest, AnswerSubmitterRestrictionResponse, UserGroupRequest,
-    UserGroupSchema, UserInfoResponse, UserListPageResponse, UserListQuery, UserSchema,
-    UserUpdateSchema,
+    AnswerSubmitterRestrictionHistoryResponse, AnswerSubmitterRestrictionRequest,
+    AnswerSubmitterRestrictionResponse, UserGroupRequest, UserGroupSchema, UserInfoResponse,
+    UserListPageResponse, UserListQuery, UserSchema, UserUpdateSchema,
 };
 use crate::{handlers::error_handler::handle_error, schemas::user::DiscordOAuthToken};
 use axum::response::Response;
@@ -148,6 +148,20 @@ pub enum GetAnswerSubmitterRestrictionResponse {
 }
 
 impl IntoResponse for GetAnswerSubmitterRestrictionResponse {
+    fn into_response(self) -> Response {
+        match self {
+            Self::Ok(body) => (StatusCode::OK, Json(body)).into_response(),
+        }
+    }
+}
+
+#[derive(utoipa::IntoResponses)]
+pub enum GetAnswerSubmitterRestrictionHistoryResponse {
+    #[response(status = 200, description = "The request has succeeded.")]
+    Ok(Vec<AnswerSubmitterRestrictionHistoryResponse>),
+}
+
+impl IntoResponse for GetAnswerSubmitterRestrictionHistoryResponse {
     fn into_response(self) -> Response {
         match self {
             Self::Ok(body) => (StatusCode::OK, Json(body)).into_response(),
@@ -701,6 +715,45 @@ pub async fn get_answer_submitter_restriction(
 
     Ok(GetAnswerSubmitterRestrictionResponse::Ok(
         restriction.map(Into::into),
+    ))
+}
+
+#[utoipa::path(
+    get,
+    path = "/users/{uuid}/answer-submitter-restriction/history",
+    summary = "回答投稿者の回答投稿制限履歴の取得",
+    params(
+        ("uuid" = String, Path, description = "User UUID"),
+    ),
+    responses(
+        GetAnswerSubmitterRestrictionHistoryResponse,
+        BadRequest,
+        Unauthorized,
+        Forbidden,
+        NotFound,
+        InternalServerError,
+    ),
+    security(("bearer" = [])),
+    tag = "Users"
+)]
+pub async fn get_answer_submitter_restriction_history(
+    Extension(actor): Extension<AccountUser>,
+    State(repository): State<RealInfrastructureRepository>,
+    path: Result<Path<Uuid>, PathRejection>,
+) -> Result<GetAnswerSubmitterRestrictionHistoryResponse, Response> {
+    let restriction_use_case = AnswerSubmitterRestrictionUseCase {
+        user_repository: repository.user_repository(),
+        restriction_repository: repository.answer_submitter_restriction_repository(),
+    };
+
+    let Path(uuid) = path.map_err_to_error().map_err(handle_error)?;
+    let restrictions = restriction_use_case
+        .list_history(&actor, uuid)
+        .await
+        .map_err(handle_error)?;
+
+    Ok(GetAnswerSubmitterRestrictionHistoryResponse::Ok(
+        restrictions.into_iter().map(Into::into).collect(),
     ))
 }
 

--- a/server/presentation/src/schemas/user.rs
+++ b/server/presentation/src/schemas/user.rs
@@ -67,6 +67,18 @@ pub struct AnswerSubmitterRestrictionResponse {
     pub expires_at: Option<DateTime<Utc>>,
 }
 
+#[derive(Serialize, Debug, utoipa::ToSchema)]
+pub struct AnswerSubmitterRestrictionHistoryResponse {
+    pub id: String,
+    pub submitter_id: String,
+    pub reason: String,
+    pub restricted_by: String,
+    pub restricted_at: DateTime<Utc>,
+    pub expires_at: Option<DateTime<Utc>>,
+    pub lifted_at: Option<DateTime<Utc>>,
+    pub lifted_by: Option<String>,
+}
+
 impl From<domain::form::answer::AnswerSubmitterRestriction> for AnswerSubmitterRestrictionResponse {
     fn from(value: domain::form::answer::AnswerSubmitterRestriction) -> Self {
         Self {
@@ -76,6 +88,23 @@ impl From<domain::form::answer::AnswerSubmitterRestriction> for AnswerSubmitterR
             restricted_by: value.restricted_by().to_string(),
             restricted_at: *value.restricted_at(),
             expires_at: *value.expires_at(),
+        }
+    }
+}
+
+impl From<domain::form::answer::AnswerSubmitterRestriction>
+    for AnswerSubmitterRestrictionHistoryResponse
+{
+    fn from(value: domain::form::answer::AnswerSubmitterRestriction) -> Self {
+        Self {
+            id: value.id().to_string(),
+            submitter_id: value.submitter_id().to_string(),
+            reason: value.reason().to_owned().into_inner().into_inner(),
+            restricted_by: value.restricted_by().to_string(),
+            restricted_at: *value.restricted_at(),
+            expires_at: *value.expires_at(),
+            lifted_at: *value.lifted_at(),
+            lifted_by: value.lifted_by().map(|lifted_by| lifted_by.to_string()),
         }
     }
 }

--- a/server/usecase/src/answer_submitter_restriction.rs
+++ b/server/usecase/src/answer_submitter_restriction.rs
@@ -113,13 +113,56 @@ impl<R1: UserRepository, R2: AnswerSubmitterRestrictionRepository>
         self.restriction_repository
             .list_by_submitter_id(submitter_id)
             .await?
-            .into_iter()
-            .map(|restriction| {
-                restriction
-                    .try_read(actor_ref.clone())
-                    .map(|restriction| restriction.into_inner())
-            })
-            .collect::<Result<Vec<_>, _>>()
+            .try_read(actor_ref)
+            .map(|history| history.into_inner().into_restrictions())
             .map_err(Into::into)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use domain::account::models::{Role, UserId};
+    use errors::domain::DomainError;
+
+    use super::*;
+    use crate::test_utils::repositories::FormUseCaseTestRepositories;
+
+    fn user(seed: u128, name: &str, role: Role) -> AccountUser {
+        AccountUser::new(name.to_string(), UserId::from(Uuid::from_u128(seed)), role)
+    }
+
+    #[tokio::test]
+    async fn list_history_rejects_other_standard_user_even_when_history_is_empty() {
+        let actor = user(1, "actor", Role::StandardUser);
+        let submitter = user(2, "submitter", Role::StandardUser);
+        let repositories = FormUseCaseTestRepositories::default();
+        repositories.user_repository.save_user(submitter.clone());
+        let usecase = AnswerSubmitterRestrictionUseCase {
+            user_repository: &repositories.user_repository,
+            restriction_repository: &repositories.answer_submitter_restriction_repository,
+        };
+
+        let result = usecase
+            .list_history(&actor, submitter.id().into_inner())
+            .await;
+
+        assert_eq!(result, Err(Error::from(DomainError::Forbidden)));
+    }
+
+    #[tokio::test]
+    async fn list_history_allows_submitter_to_read_empty_history() {
+        let submitter = user(1, "submitter", Role::StandardUser);
+        let repositories = FormUseCaseTestRepositories::default();
+        repositories.user_repository.save_user(submitter.clone());
+        let usecase = AnswerSubmitterRestrictionUseCase {
+            user_repository: &repositories.user_repository,
+            restriction_repository: &repositories.answer_submitter_restriction_repository,
+        };
+
+        let result = usecase
+            .list_history(&submitter, submitter.id().into_inner())
+            .await;
+
+        assert_eq!(result, Ok(vec![]));
     }
 }

--- a/server/usecase/src/answer_submitter_restriction.rs
+++ b/server/usecase/src/answer_submitter_restriction.rs
@@ -98,4 +98,28 @@ impl<R1: UserRepository, R2: AnswerSubmitterRestrictionRepository>
             .transpose()
             .map_err(Into::into)
     }
+
+    pub async fn list_history(
+        &self,
+        actor: &AccountUser,
+        submitter_id: Uuid,
+    ) -> Result<Vec<AnswerSubmitterRestriction>, Error> {
+        let actor_ref = Actor::from(actor.clone());
+        self.user_repository
+            .find_by(submitter_id)
+            .await?
+            .ok_or(Error::from(UseCaseError::UserNotFound))?;
+
+        self.restriction_repository
+            .list_by_submitter_id(submitter_id)
+            .await?
+            .into_iter()
+            .map(|restriction| {
+                restriction
+                    .try_read(actor_ref.clone())
+                    .map(|restriction| restriction.into_inner())
+            })
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(Into::into)
+    }
 }

--- a/server/usecase/src/test_utils/repositories.rs
+++ b/server/usecase/src/test_utils/repositories.rs
@@ -3,8 +3,12 @@ use domain::{
     account::models::{
         AccountUser, DiscordAccountLink, DiscordUser, UserGroup, UserGroupId, UserPagePosition,
     },
+    auth::Actor,
     form::{
-        answer::{AnswerEntry, AnswerId, AnswerPagePosition, AnswerSubmitterRestriction},
+        answer::{
+            AnswerEntry, AnswerId, AnswerPagePosition, AnswerSubmitterRestriction,
+            AnswerSubmitterRestrictionId,
+        },
         models::{
             ActiveForm, ArchivedForm, ArchivedFormPagePosition, FormId, FormLabel, FormLabelId,
             FormPagePosition,
@@ -812,6 +816,7 @@ impl AnswerSubmitterRestrictionRepository for InMemoryAnswerSubmitterRestriction
             .lock()
             .unwrap()
             .iter()
+            .rev()
             .find(|restriction| {
                 restriction.submitter_id().into_inner() == submitter_id
                     && restriction.is_active_at(chrono::Utc::now())
@@ -820,13 +825,41 @@ impl AnswerSubmitterRestrictionRepository for InMemoryAnswerSubmitterRestriction
             .map(Into::into))
     }
 
+    async fn list_by_submitter_id(
+        &self,
+        submitter_id: Uuid,
+    ) -> Result<Vec<AuthorizationGuard<AnswerSubmitterRestriction, Read>>, Error> {
+        Ok(self
+            .restrictions
+            .lock()
+            .unwrap()
+            .iter()
+            .rev()
+            .filter(|restriction| restriction.submitter_id().into_inner() == submitter_id)
+            .cloned()
+            .map(Into::into)
+            .collect())
+    }
+
     async fn restrict(
         &self,
         restriction: Allowed<AnswerSubmitterRestriction, Create>,
     ) -> Result<(), Error> {
         let restriction = restriction.into_inner();
         let mut restrictions = self.restrictions.lock().unwrap();
-        restrictions.retain(|stored| stored.submitter_id() != restriction.submitter_id());
+        restrictions
+            .iter_mut()
+            .filter(|stored| {
+                stored.submitter_id() == restriction.submitter_id()
+                    && stored.is_active_at(chrono::Utc::now())
+            })
+            .for_each(|stored| {
+                *stored = lifted_answer_submitter_restriction(
+                    stored,
+                    chrono::Utc::now(),
+                    *restriction.restricted_by(),
+                );
+            });
         restrictions.push(restriction);
         Ok(())
     }
@@ -835,10 +868,42 @@ impl AnswerSubmitterRestrictionRepository for InMemoryAnswerSubmitterRestriction
         &self,
         restriction: Allowed<AnswerSubmitterRestriction, Delete>,
     ) -> Result<(), Error> {
+        let lifted_by = match restriction.actor() {
+            Actor::AccountUser(user) => *user.id(),
+            _ => return Ok(()),
+        };
+
         self.restrictions
             .lock()
             .unwrap()
-            .retain(|stored| stored.submitter_id() != restriction.submitter_id());
+            .iter_mut()
+            .filter(|stored| {
+                stored.submitter_id() == restriction.submitter_id()
+                    && stored.is_active_at(chrono::Utc::now())
+            })
+            .for_each(|stored| {
+                *stored =
+                    lifted_answer_submitter_restriction(stored, chrono::Utc::now(), lifted_by);
+            });
         Ok(())
+    }
+}
+
+fn lifted_answer_submitter_restriction(
+    restriction: &AnswerSubmitterRestriction,
+    lifted_at: chrono::DateTime<chrono::Utc>,
+    lifted_by: domain::account::models::UserId,
+) -> AnswerSubmitterRestriction {
+    unsafe {
+        AnswerSubmitterRestriction::from_raw_parts(
+            AnswerSubmitterRestrictionId::from(restriction.id().into_inner()),
+            *restriction.submitter_id(),
+            restriction.reason().clone(),
+            *restriction.restricted_by(),
+            *restriction.restricted_at(),
+            *restriction.expires_at(),
+            Some(lifted_at),
+            Some(lifted_by),
+        )
     }
 }

--- a/server/usecase/src/test_utils/repositories.rs
+++ b/server/usecase/src/test_utils/repositories.rs
@@ -7,7 +7,7 @@ use domain::{
     form::{
         answer::{
             AnswerEntry, AnswerId, AnswerPagePosition, AnswerSubmitterRestriction,
-            AnswerSubmitterRestrictionId,
+            AnswerSubmitterRestrictionHistory, AnswerSubmitterRestrictionId,
         },
         models::{
             ActiveForm, ArchivedForm, ArchivedFormPagePosition, FormId, FormLabel, FormLabelId,
@@ -517,6 +517,12 @@ pub(crate) struct InMemoryUserRepository {
     sessions: Mutex<Vec<(String, AccountUser)>>,
 }
 
+impl InMemoryUserRepository {
+    pub(crate) fn save_user(&self, user: AccountUser) {
+        self.users.lock().unwrap().push(user);
+    }
+}
+
 #[async_trait]
 impl UserRepository for InMemoryUserRepository {
     async fn find_by(
@@ -828,17 +834,19 @@ impl AnswerSubmitterRestrictionRepository for InMemoryAnswerSubmitterRestriction
     async fn list_by_submitter_id(
         &self,
         submitter_id: Uuid,
-    ) -> Result<Vec<AuthorizationGuard<AnswerSubmitterRestriction, Read>>, Error> {
-        Ok(self
-            .restrictions
-            .lock()
-            .unwrap()
-            .iter()
-            .rev()
-            .filter(|restriction| restriction.submitter_id().into_inner() == submitter_id)
-            .cloned()
-            .map(Into::into)
-            .collect())
+    ) -> Result<AuthorizationGuard<AnswerSubmitterRestrictionHistory, Read>, Error> {
+        Ok(AnswerSubmitterRestrictionHistory::new(
+            submitter_id.into(),
+            self.restrictions
+                .lock()
+                .unwrap()
+                .iter()
+                .rev()
+                .filter(|restriction| restriction.submitter_id().into_inner() == submitter_id)
+                .cloned()
+                .collect(),
+        )?
+        .into())
     }
 
     async fn restrict(


### PR DESCRIPTION
## 概要
- 回答投稿制限の履歴を確認できる `GET /api/v1/users/{uuid}/answer-submitter-restriction/history` を追加しました。
- 履歴レスポンスに制限理由、制限者、制限日時、期限、解除日時、解除者を含めるようにしました。
- 履歴取得用の sqlx メタデータと OpenAPI 定義を更新しました。

## 確認事項
- `cargo sqlx prepare --workspace` を実行し、新しい履歴取得クエリの `.sqlx` メタデータが生成されることを確認しました。
- `cargo run --bin generate-openapi` を実行し、OpenAPI 定義に新しい履歴 API が反映されることを確認しました。
- `makers pretty` を実行し、clippy、nextest 109 件、doctest、fmt が通ることを確認しました。
- usecase の回帰テストは、実 DB や HTTP 経路ではなく test double の挙動を固定するだけだったため追加していません。

🤖 Generated with Codex