### PR TITLE
回答タイトルの埋め込み記法を $ 形式に統一する

### DIFF
--- a/server/domain/src/form/question.rs
+++ b/server/domain/src/form/question.rs
@@ -3,7 +3,7 @@ use errors::domain::DomainError;
 #[cfg(test)]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeSet;
+use std::{collections::BTreeSet, fmt, str::FromStr};
 use strum_macros::EnumString;
 use types::non_empty_string::NonEmptyString;
 use types::non_empty_vec::NonEmptyVec;
@@ -16,6 +16,81 @@ use crate::{
 
 pub type QuestionId = types::Id<Question>;
 pub type ChoiceId = types::IntegerId<Choice>;
+
+#[derive(Serialize, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[serde(transparent)]
+pub struct TemplateKey(String);
+
+impl TemplateKey {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn into_inner(self) -> String {
+        self.0
+    }
+}
+
+impl TryFrom<String> for TemplateKey {
+    type Error = DomainError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        if value.is_empty()
+            || value.len() > 255
+            || !value
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-'))
+            || value == "username"
+        {
+            return Err(DomainError::InvalidEntity {
+                message: "question.template_key must be 1 to 255 ASCII alphanumeric, underscore, or hyphen characters and must not be \"username\"".to_string(),
+            });
+        }
+
+        Ok(Self(value))
+    }
+}
+
+impl FromStr for TemplateKey {
+    type Err = DomainError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        value.to_owned().try_into()
+    }
+}
+
+impl<'de> Deserialize<'de> for TemplateKey {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        String::deserialize(deserializer)?
+            .try_into()
+            .map_err(serde::de::Error::custom)
+    }
+}
+
+impl fmt::Display for TemplateKey {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+#[cfg(test)]
+impl proptest::arbitrary::Arbitrary for TemplateKey {
+    type Parameters = ();
+    type Strategy = proptest::strategy::BoxedStrategy<Self>;
+
+    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+        use proptest::strategy::Strategy;
+
+        proptest::string::string_regex("[A-Za-z0-9_-]{1,255}")
+            .expect("valid TemplateKey regex")
+            .prop_filter("username is reserved", |value| value != "username")
+            .prop_map(|value| Self::try_from(value).expect("strategy only generates valid keys"))
+            .boxed()
+    }
+}
 
 #[cfg_attr(test, derive(Arbitrary))]
 #[derive(Serialize, Deserialize, Clone, Getters, Debug, PartialEq)]
@@ -52,7 +127,7 @@ impl Choice {
 #[derive(Serialize, Deserialize, Clone, Getters, Debug, PartialEq)]
 pub struct QuestionDefinition {
     id: QuestionId,
-    template_key: NonEmptyString,
+    template_key: TemplateKey,
     position: u16,
     title: NonEmptyString,
     description: Option<NonEmptyString>,
@@ -62,7 +137,7 @@ pub struct QuestionDefinition {
 impl QuestionDefinition {
     pub fn new(
         id: QuestionId,
-        template_key: NonEmptyString,
+        template_key: TemplateKey,
         position: u16,
         title: NonEmptyString,
         description: Option<NonEmptyString>,
@@ -188,7 +263,7 @@ impl QuestionSet {
 
 impl Question {
     pub fn new_text(
-        template_key: NonEmptyString,
+        template_key: TemplateKey,
         position: u16,
         title: NonEmptyString,
         description: Option<NonEmptyString>,
@@ -206,7 +281,7 @@ impl Question {
 
     #[allow(clippy::too_many_arguments)]
     pub fn new_single_choice(
-        template_key: NonEmptyString,
+        template_key: TemplateKey,
         position: u16,
         title: NonEmptyString,
         description: Option<NonEmptyString>,
@@ -228,7 +303,7 @@ impl Question {
 
     #[allow(clippy::too_many_arguments)]
     pub fn new_multiple_choice(
-        template_key: NonEmptyString,
+        template_key: TemplateKey,
         position: u16,
         title: NonEmptyString,
         description: Option<NonEmptyString>,
@@ -255,7 +330,7 @@ impl Question {
     #[allow(clippy::too_many_arguments)]
     pub unsafe fn from_raw_parts(
         id: QuestionId,
-        template_key: NonEmptyString,
+        template_key: TemplateKey,
         position: u16,
         title: NonEmptyString,
         description: Option<NonEmptyString>,
@@ -309,7 +384,7 @@ impl Question {
         *self.definition().id()
     }
 
-    pub fn template_key(&self) -> &NonEmptyString {
+    pub fn template_key(&self) -> &TemplateKey {
         self.definition().template_key()
     }
 
@@ -440,6 +515,46 @@ mod test {
 
     use super::*;
     use crate::form::question::QuestionType;
+
+    #[test]
+    fn template_key_accepts_valid_values() {
+        for value in [
+            "a",
+            "A",
+            "0",
+            "_",
+            "-",
+            "question_key-1",
+            "Username",
+            "USERNAME",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        ] {
+            assert!(
+                TemplateKey::from_str(value).is_ok(),
+                "template key {value:?} must be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn template_key_rejects_invalid_values() {
+        for value in [
+            "",
+            "question key",
+            "question.key",
+            "質問",
+            "username",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        ] {
+            assert!(
+                matches!(
+                    TemplateKey::from_str(value),
+                    Err(DomainError::InvalidEntity { .. })
+                ),
+                "template key {value:?} must be rejected"
+            );
+        }
+    }
 
     #[test_case("TEXT" => Ok(QuestionType::Text); "legacy upper text")]
     #[test_case("text" => Ok(QuestionType::Text); "legacy lower text")]

--- a/server/domain/src/form/question.rs
+++ b/server/domain/src/form/question.rs
@@ -22,6 +22,22 @@ pub type ChoiceId = types::IntegerId<Choice>;
 pub struct TemplateKey(String);
 
 impl TemplateKey {
+    fn validate(value: &str) -> Result<(), DomainError> {
+        if value.is_empty()
+            || value.len() > 255
+            || !value
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-'))
+            || value == "username"
+        {
+            return Err(DomainError::InvalidEntity {
+                message: "question.template_key must be 1 to 255 ASCII alphanumeric, underscore, or hyphen characters and must not be \"username\"".to_string(),
+            });
+        }
+
+        Ok(())
+    }
+
     pub fn as_str(&self) -> &str {
         &self.0
     }
@@ -35,19 +51,17 @@ impl TryFrom<String> for TemplateKey {
     type Error = DomainError;
 
     fn try_from(value: String) -> Result<Self, Self::Error> {
-        if value.is_empty()
-            || value.len() > 255
-            || !value
-                .bytes()
-                .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-'))
-            || value == "username"
-        {
-            return Err(DomainError::InvalidEntity {
-                message: "question.template_key must be 1 to 255 ASCII alphanumeric, underscore, or hyphen characters and must not be \"username\"".to_string(),
-            });
-        }
-
+        Self::validate(&value)?;
         Ok(Self(value))
+    }
+}
+
+impl TryFrom<&str> for TemplateKey {
+    type Error = DomainError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::validate(value)?;
+        Ok(Self(value.to_owned()))
     }
 }
 
@@ -55,7 +69,7 @@ impl FromStr for TemplateKey {
     type Err = DomainError;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
-        value.to_owned().try_into()
+        Self::try_from(value)
     }
 }
 

--- a/server/domain/src/form/service.rs
+++ b/server/domain/src/form/service.rs
@@ -34,28 +34,29 @@ impl DefaultAnswerTitleDomainService {
                     })
                     .collect::<HashMap<_, _>>();
 
-                let answer_replaced_title: String = question_placeholder_regex()
+                let replaced_title = template_placeholder_regex()
                     .replace_all(default_answer_title.as_str(), |caps: &regex::Captures| {
-                        answers_by_template_key
-                            .get(&caps[1])
-                            .copied()
-                            .unwrap_or_default()
+                        if &caps[1] == "username" {
+                            author_name
+                        } else {
+                            answers_by_template_key
+                                .get(&caps[1])
+                                .copied()
+                                .unwrap_or_default()
+                        }
                     })
                     .into_owned();
 
-                let username_replaced_title =
-                    answer_replaced_title.replace("$username", author_name);
-
-                Ok(AnswerTitle::new(Some(username_replaced_title.try_into()?)))
+                Ok(AnswerTitle::new(Some(replaced_title.try_into()?)))
             }
             None => Ok(AnswerTitle::new(None)),
         }
     }
 }
 
-fn question_placeholder_regex() -> &'static Regex {
+fn template_placeholder_regex() -> &'static Regex {
     static REGEX: OnceLock<Regex> = OnceLock::new();
-    REGEX.get_or_init(|| Regex::new(r"\{\{question\.([A-Za-z0-9_-]+)\}\}").unwrap())
+    REGEX.get_or_init(|| Regex::new(r"\$([A-Za-z0-9_-]+)").unwrap())
 }
 
 #[cfg(test)]
@@ -82,8 +83,7 @@ mod tests {
 
         let default_answer_title = DefaultAnswerTitle::new(Some(
             NonEmptyString::try_new(
-                "Answer to {{question.first}}, {{question.second}}, {{question.third}} by $username($username)"
-                    .to_string(),
+                "Answer to $first, $second, $third by $username($username)".to_string(),
             )
             .unwrap(),
         ));
@@ -168,6 +168,110 @@ mod tests {
         assert_eq!(
             result.into_inner().unwrap().into_inner(),
             "Answer to Answer1, Answer2, Answer3 by respondent_name(respondent_name)"
+        );
+    }
+
+    fn title_from(title: &str, questions: &[Question], answers: &PostedAnswerContents) -> String {
+        DefaultAnswerTitleDomainService::to_answer_title_from_questions(
+            DefaultAnswerTitle::new(Some(title.to_string().try_into().unwrap())),
+            questions,
+            answers,
+            "respondent",
+        )
+        .unwrap()
+        .into_inner()
+        .unwrap()
+        .into_inner()
+    }
+
+    fn question(id: QuestionId, template_key: &str, position: u16) -> Question {
+        unsafe {
+            Question::from_raw_parts(
+                id,
+                template_key.parse().unwrap(),
+                position,
+                template_key.to_string().try_into().unwrap(),
+                None,
+                QuestionType::Text,
+                None,
+                false,
+            )
+            .unwrap()
+        }
+    }
+
+    #[test]
+    fn replaces_consecutive_placeholders_in_one_pass() {
+        let first_id = question_id("00000000-0000-7000-8000-000000000011");
+        let second_id = question_id("00000000-0000-7000-8000-000000000012");
+        let questions = vec![
+            question(first_id, "first", 0),
+            question(second_id, "second", 1),
+        ];
+        let answers = PostedAnswerContents::try_new(
+            &questions,
+            vec![
+                FormAnswerContent {
+                    id: FormAnswerContentId::new(),
+                    question_id: first_id,
+                    answer: "$username".to_string(),
+                },
+                FormAnswerContent {
+                    id: FormAnswerContentId::new(),
+                    question_id: second_id,
+                    answer: "second answer".to_string(),
+                },
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(
+            title_from("$first$second", &questions, &answers),
+            "$usernamesecond answer"
+        );
+    }
+
+    #[test]
+    fn leaves_legacy_question_placeholders_literal() {
+        let question_id = question_id("00000000-0000-7000-8000-000000000021");
+        let questions = vec![question(question_id, "body", 0)];
+        let answers = PostedAnswerContents::try_new(
+            &questions,
+            vec![FormAnswerContent {
+                id: FormAnswerContentId::new(),
+                question_id,
+                answer: "answer".to_string(),
+            }],
+        )
+        .unwrap();
+
+        assert_eq!(
+            title_from("{{question.body}}", &questions, &answers),
+            "{{question.body}}"
+        );
+    }
+
+    #[test]
+    fn replaces_unknown_and_unanswered_placeholders_with_empty_strings() {
+        let answered_id = question_id("00000000-0000-7000-8000-000000000031");
+        let unanswered_id = question_id("00000000-0000-7000-8000-000000000032");
+        let questions = vec![
+            question(answered_id, "answered", 0),
+            question(unanswered_id, "unanswered", 1),
+        ];
+        let answers = PostedAnswerContents::try_new(
+            &questions,
+            vec![FormAnswerContent {
+                id: FormAnswerContentId::new(),
+                question_id: answered_id,
+                answer: "answer".to_string(),
+            }],
+        )
+        .unwrap();
+
+        assert_eq!(
+            title_from("$answered/$unanswered/$unknown", &questions, &answers),
+            "answer//"
         );
     }
 }

--- a/server/infra/resource/src/records.rs
+++ b/server/infra/resource/src/records.rs
@@ -515,4 +515,22 @@ mod tests {
 
         assert!(result.is_err());
     }
+
+    #[test]
+    fn question_record_rejects_invalid_template_key() {
+        let result: Result<Question, _> = QuestionRecord {
+            id: Uuid::nil().to_string(),
+            form_id: Uuid::nil().to_string(),
+            template_key: "invalid key".to_string(),
+            position: 0,
+            title: "Question".to_string(),
+            description: None,
+            question_type: "Text".to_string(),
+            choices: vec![],
+            is_required: true,
+        }
+        .try_into();
+
+        assert!(result.is_err());
+    }
 }

--- a/server/presentation/src/handlers/form/form_handler.rs
+++ b/server/presentation/src/handlers/form/form_handler.rs
@@ -918,6 +918,24 @@ mod tests {
     }
 
     #[test]
+    fn invalid_template_keys_are_rejected_during_deserialization() {
+        for template_key in ["", "question key", "username"] {
+            let result = serde_json::from_value::<QuestionSchema>(json!({
+                "question_type": "Text",
+                "template_key": template_key,
+                "position": 0,
+                "title": "Body",
+                "is_required": true
+            }));
+
+            assert!(
+                result.is_err(),
+                "template_key {template_key:?} must be rejected"
+            );
+        }
+    }
+
+    #[test]
     fn choice_question_without_choices_is_rejected() {
         let question: QuestionSchema = serde_json::from_value(json!({
             "question_type": "SingleChoice",

--- a/server/presentation/src/schemas/form/form_request_schemas.rs
+++ b/server/presentation/src/schemas/form/form_request_schemas.rs
@@ -1,5 +1,5 @@
 use domain::account::models::UserGroupId;
-use domain::form::question::{ChoiceId, QuestionId, QuestionType};
+use domain::form::question::{ChoiceId, QuestionId, QuestionType, TemplateKey};
 use domain::form::{
     answer::{AnswerLabelId, AnswerTitle},
     models::{
@@ -196,7 +196,7 @@ pub struct QuestionDefinitionSchema {
     #[schema(value_type = Option<String>, format = "uuid")]
     pub id: Option<QuestionId>,
     #[schema(value_type = String)]
-    pub template_key: NonEmptyString,
+    pub template_key: TemplateKey,
     pub position: u16,
     #[schema(value_type = String)]
     pub title: NonEmptyString,


### PR DESCRIPTION
## 概要
- 回答タイトルの質問回答埋め込みを `{{question.<template_key>}}` から `$<template_key>` へ変更し、既存の `$username` と記法を統一
- `template_key` を専用の値オブジェクトに変更し、1〜255 文字の ASCII 英数字・`_`・`-` のみに制限するとともに、予約語 `username` を禁止
- API 入力と DB からの復元でも同じ制約を適用し、回答タイトルの置換規則と各境界のテストを追加

## 確認事項
- `makers pretty` を実行し、clippy、nextest、doc test、rustfmt が成功
- `cargo build` が成功
- `cargo test --all-features` が成功
- OpenAPI を再生成し、`docs/openapi.json` に差分がないことを確認
- SQL クエリは変更していないため、`cargo sqlx prepare --workspace` は未実行

## 補足
- 旧 `{{question.<template_key>}}` 記法は置換されなくなるため、保存済みのデフォルト回答タイトルは新記法へ更新が必要です。
- 既存 DB に新しい制約を満たさない `template_key`（空白・非 ASCII 文字・予約語 `username` など）がある場合、その質問を含むフォームを復元できなくなります。デプロイ前に既存値を確認し、必要に応じて修正してください。

🤖 Generated with Codex