### PR TITLE
回答タイトルにフォーム名を埋め込めるようにする

### DIFF
--- a/server/domain/src/form/models.rs
+++ b/server/domain/src/form/models.rs
@@ -80,6 +80,10 @@ impl FormTitle {
     pub fn new(title: NonEmptyString) -> Self {
         Self(title)
     }
+
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
 }
 
 #[cfg_attr(test, derive(Arbitrary))]

--- a/server/domain/src/form/question.rs
+++ b/server/domain/src/form/question.rs
@@ -22,16 +22,20 @@ pub type ChoiceId = types::IntegerId<Choice>;
 pub struct TemplateKey(String);
 
 impl TemplateKey {
+    fn is_reserved(value: &str) -> bool {
+        matches!(value, "username" | "form_name")
+    }
+
     fn validate(value: &str) -> Result<(), DomainError> {
         if value.is_empty()
             || value.len() > 255
             || !value
                 .bytes()
                 .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-'))
-            || value == "username"
+            || Self::is_reserved(value)
         {
             return Err(DomainError::InvalidEntity {
-                message: "question.template_key must be 1 to 255 ASCII alphanumeric, underscore, or hyphen characters and must not be \"username\"".to_string(),
+                message: "question.template_key must be 1 to 255 ASCII alphanumeric, underscore, or hyphen characters and must not be \"username\" or \"form_name\"".to_string(),
             });
         }
 
@@ -100,7 +104,9 @@ impl proptest::arbitrary::Arbitrary for TemplateKey {
 
         proptest::string::string_regex("[A-Za-z0-9_-]{1,255}")
             .expect("valid TemplateKey regex")
-            .prop_filter("username is reserved", |value| value != "username")
+            .prop_filter("reserved template keys are excluded", |value| {
+                !Self::is_reserved(value)
+            })
             .prop_map(|value| Self::try_from(value).expect("strategy only generates valid keys"))
             .boxed()
     }
@@ -541,6 +547,8 @@ mod test {
             "question_key-1",
             "Username",
             "USERNAME",
+            "Form_name",
+            "FORM_NAME",
             "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         ] {
             assert!(
@@ -558,6 +566,7 @@ mod test {
             "question.key",
             "質問",
             "username",
+            "form_name",
             "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         ] {
             assert!(

--- a/server/domain/src/form/service.rs
+++ b/server/domain/src/form/service.rs
@@ -5,7 +5,7 @@ use std::sync::OnceLock;
 
 use crate::form::{
     answer::{AnswerTitle, PostedAnswerContents},
-    models::{DefaultAnswerTitle, Question},
+    models::{DefaultAnswerTitle, FormTitle, Question},
 };
 
 pub struct DefaultAnswerTitleDomainService;
@@ -13,6 +13,7 @@ pub struct DefaultAnswerTitleDomainService;
 impl DefaultAnswerTitleDomainService {
     pub fn to_answer_title_from_questions(
         default_answer_title: DefaultAnswerTitle,
+        form_title: &FormTitle,
         questions: &[Question],
         answers: &PostedAnswerContents,
         author_name: &str,
@@ -35,16 +36,17 @@ impl DefaultAnswerTitleDomainService {
                     .collect::<HashMap<_, _>>();
 
                 let replaced_title = template_placeholder_regex()
-                    .replace_all(default_answer_title.as_str(), |caps: &regex::Captures| {
-                        if &caps[1] == "username" {
-                            author_name
-                        } else {
-                            answers_by_template_key
-                                .get(&caps[1])
+                    .replace_all(
+                        default_answer_title.as_str(),
+                        |caps: &regex::Captures| match &caps[1] {
+                            "form_name" => form_title.as_str(),
+                            "username" => author_name,
+                            template_key => answers_by_template_key
+                                .get(template_key)
                                 .copied()
-                                .unwrap_or_default()
-                        }
-                    })
+                                .unwrap_or_default(),
+                        },
+                    )
                     .into_owned();
 
                 Ok(AnswerTitle::new(Some(replaced_title.try_into()?)))
@@ -154,6 +156,7 @@ mod tests {
 
         let result = DefaultAnswerTitleDomainService::to_answer_title_from_questions(
             default_answer_title,
+            &FormTitle::new("Form".to_string().try_into().unwrap()),
             questions.as_slice(),
             &answers,
             match &actor {
@@ -174,6 +177,7 @@ mod tests {
     fn title_from(title: &str, questions: &[Question], answers: &PostedAnswerContents) -> String {
         DefaultAnswerTitleDomainService::to_answer_title_from_questions(
             DefaultAnswerTitle::new(Some(title.to_string().try_into().unwrap())),
+            &FormTitle::new("Form".to_string().try_into().unwrap()),
             questions,
             answers,
             "respondent",
@@ -228,6 +232,49 @@ mod tests {
         assert_eq!(
             title_from("$first$second", &questions, &answers),
             "$usernamesecond answer"
+        );
+    }
+
+    #[test]
+    fn replaces_reserved_and_question_placeholders_once_in_the_same_template() {
+        let question_id = question_id("00000000-0000-7000-8000-000000000013");
+        let questions = vec![question(question_id, "body", 0)];
+        let answers = PostedAnswerContents::try_new(
+            &questions,
+            vec![FormAnswerContent {
+                id: FormAnswerContentId::new(),
+                question_id,
+                answer: "$form_name from $username".to_string(),
+            }],
+        )
+        .unwrap();
+        let form_title = FormTitle::new(
+            "Support for $username and $body"
+                .to_string()
+                .try_into()
+                .unwrap(),
+        );
+
+        let title = DefaultAnswerTitleDomainService::to_answer_title_from_questions(
+            DefaultAnswerTitle::new(Some(
+                "$form_name by $username: $body"
+                    .to_string()
+                    .try_into()
+                    .unwrap(),
+            )),
+            &form_title,
+            &questions,
+            &answers,
+            "respondent",
+        )
+        .unwrap()
+        .into_inner()
+        .unwrap()
+        .into_inner();
+
+        assert_eq!(
+            title,
+            "Support for $username and $body by respondent: $form_name from $username"
         );
     }
 

--- a/server/presentation/src/handlers/form/form_handler.rs
+++ b/server/presentation/src/handlers/form/form_handler.rs
@@ -919,7 +919,7 @@ mod tests {
 
     #[test]
     fn invalid_template_keys_are_rejected_during_deserialization() {
-        for template_key in ["", "question key", "username"] {
+        for template_key in ["", "question key", "username", "form_name"] {
             let result = serde_json::from_value::<QuestionSchema>(json!({
                 "question_type": "Text",
                 "template_key": template_key,

--- a/server/usecase/src/forms/answer.rs
+++ b/server/usecase/src/forms/answer.rs
@@ -213,6 +213,7 @@ impl<
                 .answer_settings()
                 .default_answer_title()
                 .to_owned(),
+            form.value().title(),
             &questions,
             &posted_answers,
             user.name(),
@@ -252,6 +253,7 @@ impl<
                 .answer_settings()
                 .default_answer_title()
                 .to_owned(),
+            form.value().title(),
             &questions,
             &posted_answers,
             temporary_user.name(),
@@ -484,9 +486,10 @@ mod tests {
                 AnswerLabelId, AnswerSubmitterRestriction, AnswerSubmitterRestrictionReason,
                 FormAnswerContentId,
             },
-            models::{FormDescription, FormTitle, QuestionSet},
+            models::{AnswerSettings, DefaultAnswerTitle, FormDescription, FormTitle, QuestionSet},
             question::Question,
         },
+        pagination::PageLimit,
         repository::form::answer_label_repository::AnswerLabelRepository,
         types::authorization_guard::{AuthorizationGuard, Create, Delete, Update},
     };
@@ -581,6 +584,112 @@ mod tests {
             FormDescription::new("description".to_string()),
             QuestionSet::try_new(NonEmptyVec::try_new(vec![question]).unwrap()).unwrap(),
         )
+    }
+
+    fn form_with_default_answer_title(allow_temporary_answers: bool) -> ActiveForm {
+        sample_form().change_answer_settings(
+            AnswerSettings::default()
+                .change_default_answer_title(DefaultAnswerTitle::new(Some(
+                    "$form_name".to_string().try_into().unwrap(),
+                )))
+                .change_allow_temporary_answers(allow_temporary_answers),
+        )
+    }
+
+    fn answer_to(form: &ActiveForm) -> FormAnswerContent {
+        FormAnswerContent {
+            id: FormAnswerContentId::new(),
+            question_id: (*form.questions().as_slice()[0].id()).into(),
+            answer: "answer".to_string(),
+        }
+    }
+
+    async fn only_posted_answer_title(
+        repositories: &FormUseCaseTestRepositories,
+        form_id: FormId,
+    ) -> String {
+        let administrator = active_user("admin", Role::Administrator);
+        let form = repositories
+            .active_form_repository
+            .get(form_id)
+            .await
+            .unwrap()
+            .unwrap()
+            .try_read(Actor::from(administrator))
+            .unwrap();
+        let answers = repositories
+            .answer_entry_repository
+            .list_by_form(&form, PageRequest::first(PageLimit::default_limit()))
+            .await
+            .unwrap();
+
+        answers.items()[0]
+            .title()
+            .to_owned()
+            .into_inner()
+            .unwrap()
+            .into_inner()
+    }
+
+    #[tokio::test]
+    async fn post_answers_uses_current_form_title_for_generated_title() {
+        let form = form_with_default_answer_title(false);
+        let form_id = *form.id();
+        let answer = answer_to(&form);
+        let user = active_user("user", Role::StandardUser);
+        let repositories = FormUseCaseTestRepositories::with_active_forms(vec![form]);
+        let empty_answer_label_repository = EmptyAnswerLabelRepository;
+        let usecase = AnswerUseCase {
+            active_form_repository: &repositories.active_form_repository,
+            answer_label_repository: &empty_answer_label_repository,
+            user_repository: &repositories.user_repository,
+            answer_submitter_restriction_repository: &repositories
+                .answer_submitter_restriction_repository,
+            answer_entry_repository: &repositories.answer_entry_repository,
+            discord_answer_webhook_notifier: None,
+        };
+
+        usecase
+            .post_answers(user, form_id, vec![answer])
+            .await
+            .unwrap();
+
+        assert_eq!(
+            only_posted_answer_title(&repositories, form_id).await,
+            "Form"
+        );
+    }
+
+    #[tokio::test]
+    async fn post_temporary_answers_uses_current_form_title_for_generated_title() {
+        let form = form_with_default_answer_title(true);
+        let form_id = *form.id();
+        let answer = answer_to(&form);
+        let repositories = FormUseCaseTestRepositories::with_active_forms(vec![form]);
+        let empty_answer_label_repository = EmptyAnswerLabelRepository;
+        let usecase = AnswerUseCase {
+            active_form_repository: &repositories.active_form_repository,
+            answer_label_repository: &empty_answer_label_repository,
+            user_repository: &repositories.user_repository,
+            answer_submitter_restriction_repository: &repositories
+                .answer_submitter_restriction_repository,
+            answer_entry_repository: &repositories.answer_entry_repository,
+            discord_answer_webhook_notifier: None,
+        };
+
+        usecase
+            .post_temporary_answers(
+                TemporaryAnswerAuthor::new("temporary user".to_string(), "contact".to_string()),
+                form_id,
+                vec![answer],
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            only_posted_answer_title(&repositories, form_id).await,
+            "Form"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## 概要
- 回答の自動タイトルで `$form_name` を現在のフォームタイトルへ置換できるように変更
- `form_name` を `username` と同じ予約語として扱い、質問の `template_key` には指定できないように制限
- 認証済み回答と一時回答の両投稿経路、およびドメイン・HTTP 入力の境界にテストを追加

## 確認事項
- `cargo test -p domain -p usecase -p presentation` を実行し、対象3 crate のテストと doc test がすべて成功
- `cargo build` を実行し、workspace 全体のビルドが成功
- `makers pretty` を実行し、nextest 127件、doc test、clippy（warnings deny）、rustfmt がすべて成功
- commit hook の OpenAPI 再生成チェックが成功し、`docs/openapi.json` に差分がないことを確認
- SQL クエリは変更していないため、`cargo sqlx prepare --workspace` は未実行

## 補足
- 既存 DB に `template_key = form_name` がある場合はフォーム復元時に新しい予約語検証へ抵触するため、デプロイ前に既存値を確認し、必要に応じて修正してください。

Closes #1195

🤖 Generated with Codex
