### PR TITLE
fix: 横断検索 API が返すスキーマを改善

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -5832,32 +5832,6 @@
           }
         }
       },
-      "CommentSchema": {
-        "type": "object",
-        "required": [
-          "answer_id",
-          "id",
-          "content",
-          "commented_by"
-        ],
-        "properties": {
-          "answer_id": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "commented_by": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "content": {
-            "type": "string"
-          },
-          "id": {
-            "type": "string",
-            "format": "uuid"
-          }
-        }
-      },
       "CommentUpdateSchema": {
         "type": "object",
         "properties": {
@@ -5886,29 +5860,39 @@
         "properties": {
           "answers": {
             "type": "array",
-            "items": {}
+            "items": {
+              "$ref": "#/components/schemas/FormAnswer"
+            }
           },
           "comments": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/CommentSchema"
+              "$ref": "#/components/schemas/SearchCommentSchema"
             }
           },
           "forms": {
             "type": "array",
-            "items": {}
+            "items": {
+              "$ref": "#/components/schemas/FormSchema"
+            }
           },
           "label_for_answers": {
             "type": "array",
-            "items": {}
+            "items": {
+              "$ref": "#/components/schemas/AnswerLabelResponseSchema"
+            }
           },
           "label_for_forms": {
             "type": "array",
-            "items": {}
+            "items": {
+              "$ref": "#/components/schemas/FormLabelResponseSchema"
+            }
           },
           "users": {
             "type": "array",
-            "items": {}
+            "items": {
+              "$ref": "#/components/schemas/UserSchema"
+            }
           }
         }
       },
@@ -6651,6 +6635,25 @@
         "enum": [
           "STANDARD_USER",
           "ADMINISTRATOR"
+        ]
+      },
+      "SearchCommentSchema": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/AnswerComment"
+          },
+          {
+            "type": "object",
+            "required": [
+              "answer_id"
+            ],
+            "properties": {
+              "answer_id": {
+                "type": "string",
+                "format": "uuid"
+              }
+            }
+          }
         ]
       },
       "SelectQuestionResponseSchema": {

--- a/server/entrypoint/src/openapi.rs
+++ b/server/entrypoint/src/openapi.rs
@@ -54,7 +54,7 @@ use utoipa_axum::routes;
         presentation::schemas::form::form_response_schemas::SenderSchema,
         presentation::schemas::form::form_response_schemas::User,
         presentation::schemas::notification::notification_response_schemas::NotificationSettingsResponse,
-        presentation::schemas::search_schemas::CommentSchema,
+        presentation::schemas::search_schemas::SearchCommentSchema,
         presentation::schemas::search_schemas::CrossSearchResult,
         presentation::schemas::search_schemas::UserSearchResult,
     )),

--- a/server/presentation/src/handlers/form/form_handler.rs
+++ b/server/presentation/src/handlers/form/form_handler.rs
@@ -14,8 +14,8 @@ use domain::{
     auth::Actor,
     form::{
         models::{
-            ActiveForm, AllowedUserGroups, ArchivedForm, ArchivedFormPagePosition, FormDescription,
-            FormId, FormLabel, FormPagePosition,
+            AllowedUserGroups, ArchivedForm, ArchivedFormPagePosition, FormDescription, FormId,
+            FormLabel, FormPagePosition,
         },
         question::{Choice, Question, QuestionSet, QuestionType},
     },
@@ -165,27 +165,6 @@ fn build_form_use_case(repository: &RealInfrastructureRepository) -> ResourceFor
         form_label_repository: repository.form_label_repository(),
         answer_entry_repository: repository.answer_entry_repository(),
         user_repository: repository.user_repository(),
-    }
-}
-
-fn form_schema(actor: &Actor, form: &ActiveForm, labels: Vec<FormLabel>) -> FormSchema {
-    FormSchema {
-        id: form.id().to_owned(),
-        title: form.title().to_owned(),
-        description: form.description().to_owned(),
-        settings: FormSettingsSchema::from_settings_and_answer_settings(
-            actor,
-            form.settings(),
-            form.answer_settings(),
-        ),
-        metadata: FormMetaSchema::from_meta_ref(form.metadata()),
-        questions: form
-            .questions()
-            .iter()
-            .cloned()
-            .map(QuestionResponseSchema::from)
-            .collect(),
-        labels,
     }
 }
 
@@ -401,7 +380,7 @@ pub async fn create_form_handler(
 
     let actor = Actor::from(user.clone());
 
-    Ok(CreateFormResponse::Created(form_schema(
+    Ok(CreateFormResponse::Created(FormSchema::from_active_form(
         &actor,
         &form,
         vec![],
@@ -446,7 +425,7 @@ pub async fn form_list_handler(
 
     let response_schema = forms
         .into_iter()
-        .map(|(form, labels)| form_schema(&actor, &form, labels))
+        .map(|(form, labels)| FormSchema::from_active_form(&actor, &form, labels))
         .collect::<Vec<_>>();
 
     Ok(FormListResponse::Ok(FormListPageResponse {
@@ -487,7 +466,9 @@ pub async fn get_form_handler(
         .await
         .map_err(handle_error)?;
 
-    Ok(GetFormResponse::Ok(form_schema(&actor, &form, labels)))
+    Ok(GetFormResponse::Ok(FormSchema::from_active_form(
+        &actor, &form, labels,
+    )))
 }
 
 #[utoipa::path(
@@ -636,7 +617,7 @@ pub async fn update_form_handler(
 
     let actor = Actor::from(user.clone());
 
-    Ok(UpdateFormResponse::Ok(form_schema(
+    Ok(UpdateFormResponse::Ok(FormSchema::from_active_form(
         &actor,
         &updated_form,
         labels,

--- a/server/presentation/src/handlers/search_handler.rs
+++ b/server/presentation/src/handlers/search_handler.rs
@@ -9,7 +9,7 @@ use axum::{
     response::IntoResponse,
 };
 use domain::{
-    account::models::AccountUser, repository::Repositories,
+    account::models::AccountUser, auth::Actor, repository::Repositories,
     search::models::SearchableFieldsWithOperation,
 };
 use errors::{Error, ErrorExtra, presentation::PresentationError};
@@ -103,7 +103,10 @@ pub async fn cross_search(
         .cross_search(&user, query)
         .await
         .map_err(handle_error)?;
-    Ok(CrossSearchResponse::Ok(CrossSearchResult::from(result)))
+    Ok(CrossSearchResponse::Ok(CrossSearchResult::from_output(
+        &Actor::from(user),
+        result,
+    )))
 }
 
 #[utoipa::path(

--- a/server/presentation/src/schemas/form/form_response_schemas.rs
+++ b/server/presentation/src/schemas/form/form_response_schemas.rs
@@ -5,8 +5,8 @@ use domain::form::{
     comment::{CommentHistoryAction, CommentHistoryEntry, CommentId},
     message::{MessageHistoryAction, MessageHistoryEntry},
     models::{
-        AnswerSettings, DefaultAnswerTitle, FormDescription, FormId, FormLabel, FormMeta,
-        FormSettings, FormTitle, Visibility,
+        ActiveForm, AnswerSettings, DefaultAnswerTitle, FormDescription, FormId, FormLabel,
+        FormMeta, FormSettings, FormTitle, Visibility,
     },
     question::{Choice, Question, QuestionType},
 };
@@ -123,6 +123,29 @@ pub struct FormSchema {
     pub questions: Vec<QuestionResponseSchema>,
     #[schema(value_type = Vec<FormLabelResponseSchema>)]
     pub labels: Vec<FormLabel>,
+}
+
+impl FormSchema {
+    pub fn from_active_form(actor: &Actor, form: &ActiveForm, labels: Vec<FormLabel>) -> Self {
+        Self {
+            id: *form.id(),
+            title: form.title().clone(),
+            description: form.description().clone(),
+            settings: FormSettingsSchema::from_settings_and_answer_settings(
+                actor,
+                form.settings(),
+                form.answer_settings(),
+            ),
+            metadata: FormMetaSchema::from_meta_ref(form.metadata()),
+            questions: form
+                .questions()
+                .iter()
+                .cloned()
+                .map(QuestionResponseSchema::from)
+                .collect(),
+            labels,
+        }
+    }
 }
 
 #[derive(Serialize, Debug, utoipa::ToSchema)]

--- a/server/presentation/src/schemas/search_schemas.rs
+++ b/server/presentation/src/schemas/search_schemas.rs
@@ -1,19 +1,14 @@
-use domain::form::answer::AnswerEntry;
-use domain::{
-    account::models::AccountUser,
-    form::{
-        answer::{AnswerId, AnswerLabel},
-        comment::{Comment, CommentId},
-        models::{ActiveForm, FormLabel},
-    },
-};
-use itertools::Itertools;
+use domain::{auth::Actor, form::answer::AnswerId};
 use serde::{Deserialize, Serialize};
 use types::non_empty_string::NonEmptyString;
-use usecase::models::CrossSearchOutput;
-use uuid::Uuid;
+use usecase::models::{CommentWithAuthor, CrossSearchOutput};
 
-use crate::schemas::user::UserSchema;
+use crate::schemas::{
+    form::form_response_schemas::{
+        AnswerComment, AnswerLabelResponseSchema, FormAnswer, FormLabelResponseSchema, FormSchema,
+    },
+    user::UserSchema,
+};
 
 #[derive(Deserialize, Debug, PartialEq, utoipa::ToSchema)]
 pub struct SearchQuery {
@@ -21,51 +16,61 @@ pub struct SearchQuery {
     pub query: Option<NonEmptyString>,
 }
 
-#[derive(Serialize, Debug, PartialEq, utoipa::ToSchema)]
-pub struct CommentSchema {
+#[derive(Serialize, Debug, utoipa::ToSchema)]
+pub struct SearchCommentSchema {
     #[schema(value_type = String, format = "uuid")]
     pub answer_id: AnswerId,
-    #[schema(value_type = String, format = "uuid")]
-    pub id: CommentId,
-    pub content: String,
-    pub commented_by: Uuid,
+    #[serde(flatten)]
+    pub comment: AnswerComment,
 }
 
-impl From<Comment> for CommentSchema {
-    fn from(value: Comment) -> Self {
+impl From<CommentWithAuthor> for SearchCommentSchema {
+    fn from(value: CommentWithAuthor) -> Self {
         Self {
-            answer_id: value.answer_id().to_owned(),
-            id: value.comment_id().to_owned(),
-            content: value.content().to_owned().into_inner().into_inner(),
-            commented_by: value.commented_by().into_inner(),
+            answer_id: *value.comment.answer_id(),
+            comment: value.into(),
         }
     }
 }
 
-#[derive(Serialize, Debug, PartialEq, utoipa::ToSchema)]
+#[derive(Serialize, Debug, utoipa::ToSchema)]
 pub struct CrossSearchResult {
-    #[schema(value_type = Vec<serde_json::Value>)]
-    pub forms: Vec<ActiveForm>,
-    #[schema(value_type = Vec<serde_json::Value>)]
-    pub users: Vec<AccountUser>,
-    #[schema(value_type = Vec<serde_json::Value>)]
-    pub answers: Vec<AnswerEntry>,
-    #[schema(value_type = Vec<serde_json::Value>)]
-    pub label_for_forms: Vec<FormLabel>,
-    #[schema(value_type = Vec<serde_json::Value>)]
-    pub label_for_answers: Vec<AnswerLabel>,
-    pub comments: Vec<CommentSchema>,
+    pub forms: Vec<FormSchema>,
+    pub users: Vec<UserSchema>,
+    pub answers: Vec<FormAnswer>,
+    pub label_for_forms: Vec<FormLabelResponseSchema>,
+    pub label_for_answers: Vec<AnswerLabelResponseSchema>,
+    pub comments: Vec<SearchCommentSchema>,
 }
 
-impl From<CrossSearchOutput> for CrossSearchResult {
-    fn from(output: CrossSearchOutput) -> Self {
+impl CrossSearchResult {
+    pub fn from_output(actor: &Actor, output: CrossSearchOutput) -> Self {
         Self {
-            forms: output.forms,
-            users: output.users,
-            answers: output.answers,
-            label_for_forms: output.label_for_forms,
-            label_for_answers: output.label_for_answers,
-            comments: output.comments.into_iter().map(Into::into).collect_vec(),
+            forms: output
+                .forms
+                .into_iter()
+                .map(|details| FormSchema::from_active_form(actor, &details.form, details.labels))
+                .collect(),
+            users: output.users.into_iter().map(Into::into).collect(),
+            answers: output
+                .answers
+                .into_iter()
+                .map(|details| {
+                    FormAnswer::new(
+                        details.form_answer,
+                        details.form_id,
+                        details.author,
+                        details.labels,
+                    )
+                })
+                .collect(),
+            label_for_forms: output.label_for_forms.into_iter().map(Into::into).collect(),
+            label_for_answers: output
+                .label_for_answers
+                .into_iter()
+                .map(Into::into)
+                .collect(),
+            comments: output.comments.into_iter().map(Into::into).collect(),
         }
     }
 }
@@ -73,4 +78,213 @@ impl From<CrossSearchOutput> for CrossSearchResult {
 #[derive(Serialize, Debug, utoipa::ToSchema)]
 pub struct UserSearchResult {
     pub users: Vec<UserSchema>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use domain::{
+        account::models::{AccountUser, Role, UserGroup, UserGroupName},
+        form::{
+            answer::{
+                AnswerAuthor, AnswerEntry, AnswerId, AnswerLabel, AnswerTitle, FormAnswerContent,
+                FormAnswerContentId,
+            },
+            comment::{Comment, CommentContent, CommentId},
+            models::{
+                ActiveForm, DiscordWebhookUrl, FormDescription, FormLabel, FormLabelName,
+                FormSettings, FormTitle,
+            },
+            question::{Question, QuestionSet},
+        },
+    };
+    use types::non_empty_vec::NonEmptyVec;
+    use usecase::models::{ActiveFormWithLabels, AnswerDetails, CommentWithAuthor};
+    use uuid::Uuid;
+
+    fn standard_user(name: &str) -> AccountUser {
+        AccountUser::new(
+            name.to_string(),
+            Uuid::from_u128(1).into(),
+            Role::StandardUser,
+        )
+    }
+
+    fn form_with_webhook() -> ActiveForm {
+        let question = Question::new_text(
+            "body".to_string().try_into().unwrap(),
+            0,
+            "Body".to_string().try_into().unwrap(),
+            Some("Answer body".to_string().try_into().unwrap()),
+            true,
+        )
+        .unwrap();
+        let questions =
+            QuestionSet::try_new(NonEmptyVec::try_new(vec![question]).unwrap()).unwrap();
+        let settings = FormSettings::new().change_discord_webhook_url(
+            DiscordWebhookUrl::try_new(Some(
+                "https://discord.com/api/webhooks/secret"
+                    .to_string()
+                    .try_into()
+                    .unwrap(),
+            ))
+            .unwrap(),
+        );
+
+        ActiveForm::new(
+            FormTitle::new("Detailed form".to_string().try_into().unwrap()),
+            FormDescription::new("Form description".to_string()),
+            questions,
+        )
+        .change_settings(settings)
+    }
+
+    #[test]
+    fn cross_search_result_preserves_detailed_resource_shape_and_comment_parent() {
+        let actor = Actor::from(AccountUser::new(
+            "admin".to_string(),
+            Uuid::from_u128(2).into(),
+            Role::Administrator,
+        ));
+        let form = form_with_webhook();
+        let form_id = *form.id();
+        let answer_id = AnswerId::from(Uuid::from_u128(3));
+        let question_id = form.questions().iter().next().unwrap().id();
+        let answer_author = standard_user("answer author");
+        let answer = unsafe {
+            AnswerEntry::from_raw_parts(
+                answer_id,
+                form_id,
+                AnswerAuthor::AuthenticatedUser(*answer_author.id()),
+                Utc::now(),
+                AnswerTitle::new(Some("Detailed answer".to_string().try_into().unwrap())),
+                vec![FormAnswerContent {
+                    id: FormAnswerContentId::from(Uuid::from_u128(4)),
+                    question_id,
+                    answer: "answer content".to_string(),
+                }],
+            )
+        };
+        let comment_id = CommentId::from(Uuid::from_u128(5));
+        let comment = unsafe {
+            Comment::from_raw_parts(
+                answer_id,
+                comment_id,
+                CommentContent::new("comment content".to_string().try_into().unwrap()),
+                Utc::now(),
+                *answer_author.id(),
+            )
+        };
+        let searched_user = AccountUser::with_groups(
+            "searched user".to_string(),
+            Uuid::from_u128(6).into(),
+            Role::StandardUser,
+            vec![UserGroup::new(UserGroupName::new(
+                "members".to_string().try_into().unwrap(),
+            ))],
+        );
+
+        let result = CrossSearchResult::from_output(
+            &actor,
+            CrossSearchOutput {
+                forms: vec![ActiveFormWithLabels {
+                    form,
+                    labels: vec![FormLabel::new(FormLabelName::new(
+                        "form label".to_string().try_into().unwrap(),
+                    ))],
+                }],
+                users: vec![searched_user],
+                answers: vec![AnswerDetails {
+                    form_id,
+                    form_answer: answer,
+                    author: Actor::from(answer_author.clone()),
+                    labels: vec![AnswerLabel::new(
+                        "answer label".to_string().try_into().unwrap(),
+                    )],
+                }],
+                label_for_forms: vec![FormLabel::new(FormLabelName::new(
+                    "matching form label".to_string().try_into().unwrap(),
+                ))],
+                label_for_answers: vec![AnswerLabel::new(
+                    "matching answer label".to_string().try_into().unwrap(),
+                )],
+                comments: vec![CommentWithAuthor {
+                    comment,
+                    commented_by: answer_author,
+                }],
+            },
+        );
+
+        let serialized = serde_json::to_value(result).unwrap();
+
+        assert_eq!(serialized["forms"][0]["title"], "Detailed form");
+        assert_eq!(serialized["forms"][0]["description"], "Form description");
+        assert_eq!(
+            serialized["forms"][0]["questions"][0]["template_key"],
+            "body"
+        );
+        assert_eq!(serialized["forms"][0]["labels"][0]["name"], "form label");
+        assert_eq!(serialized["users"][0]["name"], "searched user");
+        assert_eq!(serialized["users"][0]["role"], "STANDARD_USER");
+        assert_eq!(serialized["users"][0]["groups"][0]["name"], "members");
+        assert_eq!(serialized["answers"][0]["title"], "Detailed answer");
+        assert_eq!(
+            serialized["answers"][0]["author"]["user"]["name"],
+            "answer author"
+        );
+        assert_eq!(
+            serialized["answers"][0]["answers"][0]["answer"],
+            "answer content"
+        );
+        assert_eq!(
+            serialized["answers"][0]["labels"][0]["name"],
+            "answer label"
+        );
+        assert_eq!(
+            serialized["label_for_forms"][0]["name"],
+            "matching form label"
+        );
+        assert_eq!(
+            serialized["label_for_answers"][0]["name"],
+            "matching answer label"
+        );
+        assert_eq!(
+            serialized["comments"][0]["answer_id"],
+            answer_id.to_string()
+        );
+        assert_eq!(serialized["comments"][0]["id"], comment_id.to_string());
+        assert_eq!(
+            serialized["comments"][0]["commented_by"]["name"],
+            "answer author"
+        );
+    }
+
+    #[test]
+    fn cross_search_result_omits_form_webhook_for_standard_user() {
+        let actor = Actor::from(standard_user("viewer"));
+        let result = CrossSearchResult::from_output(
+            &actor,
+            CrossSearchOutput {
+                forms: vec![ActiveFormWithLabels {
+                    form: form_with_webhook(),
+                    labels: vec![],
+                }],
+                users: vec![],
+                answers: vec![],
+                label_for_forms: vec![],
+                label_for_answers: vec![],
+                comments: vec![],
+            },
+        );
+
+        let serialized = serde_json::to_value(result).unwrap();
+
+        assert_eq!(serialized["forms"][0]["title"], "Detailed form");
+        assert!(
+            serialized["forms"][0]["settings"]
+                .get("discord_webhook_url")
+                .is_none()
+        );
+    }
 }

--- a/server/usecase/src/models.rs
+++ b/server/usecase/src/models.rs
@@ -49,10 +49,10 @@ pub struct UserProfile {
 }
 
 pub struct CrossSearchOutput {
-    pub forms: Vec<ActiveForm>,
+    pub forms: Vec<ActiveFormWithLabels>,
     pub users: Vec<AccountUser>,
-    pub answers: Vec<AnswerEntry>,
+    pub answers: Vec<AnswerDetails>,
     pub label_for_forms: Vec<FormLabel>,
     pub label_for_answers: Vec<AnswerLabel>,
-    pub comments: Vec<Comment>,
+    pub comments: Vec<CommentWithAuthor>,
 }

--- a/server/usecase/src/search.rs
+++ b/server/usecase/src/search.rs
@@ -1,4 +1,7 @@
-use crate::models::CrossSearchOutput;
+use crate::{
+    models::{ActiveFormWithLabels, AnswerDetails, CommentWithAuthor, CrossSearchOutput},
+    user_reference_resolver::resolve_user_references,
+};
 use domain::repository::form::answer_entry_repository::AnswerEntryRepository;
 use domain::repository::form::answer_label_repository::AnswerLabelRepository;
 use domain::repository::form::comment_repository::CommentRepository;
@@ -10,7 +13,8 @@ use domain::{
     account::models::AccountUser,
     auth::Actor,
     form::{
-        answer::{AnswerEntry, AnswerId},
+        answer::{AnswerAuthor, AnswerEntry, AnswerId},
+        comment::Comment,
         models::ActiveForm,
     },
     pagination::{PageLimit, PageRequest},
@@ -21,6 +25,7 @@ use domain::{
     types::authorization_guard::{Allowed, AuthorizationGuard, Read},
 };
 use errors::Error;
+use errors::usecase::UseCaseError::UserNotFound;
 use futures::{StreamExt, TryStreamExt, stream, try_join};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -129,6 +134,114 @@ impl<
             .collect())
     }
 
+    async fn visible_form_with_labels(
+        &self,
+        actor: &Actor,
+        form_id: domain::form::models::FormId,
+    ) -> Result<Option<ActiveFormWithLabels>, Error> {
+        let Some(form) = self.active_form_repository.get(form_id).await? else {
+            return Ok(None);
+        };
+        let Ok(form) = form.try_read(actor.clone()) else {
+            return Ok(None);
+        };
+        let labels = self
+            .form_label_repository
+            .fetch_labels_by_form_id(form_id)
+            .await?
+            .into_iter()
+            .map(|label| {
+                label
+                    .try_read(actor.clone())
+                    .map(|label| label.into_inner())
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(Some(ActiveFormWithLabels {
+            form: form.into_inner(),
+            labels,
+        }))
+    }
+
+    async fn answer_details(
+        &self,
+        account_user: &AccountUser,
+        actor: &Actor,
+        answer: Allowed<AnswerEntry, Read>,
+    ) -> Result<AnswerDetails, Error> {
+        let answer_id = *answer.id();
+        let form_id = *answer.form_id();
+        let labels = self
+            .form_answer_label_repository
+            .get_labels_for_answers_by_answer_id(answer_id)
+            .await?
+            .into_iter()
+            .map(|label| {
+                label
+                    .try_read(actor.clone())
+                    .map(|label| label.into_inner())
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let users = resolve_user_references(
+            self.user_repository,
+            account_user,
+            answer
+                .author()
+                .authenticated_user_id()
+                .into_iter()
+                .collect(),
+        )
+        .await?;
+        let author = match answer.author() {
+            AnswerAuthor::AuthenticatedUser(user_id) => Actor::AccountUser(
+                users
+                    .get(user_id)
+                    .cloned()
+                    .ok_or(Error::from(UserNotFound))?,
+            ),
+            AnswerAuthor::Temporary(temporary_user) => {
+                Actor::TemporaryAnswerAuthor(temporary_user.clone())
+            }
+        };
+
+        Ok(AnswerDetails {
+            form_id,
+            form_answer: answer.into_inner(),
+            author,
+            labels,
+        })
+    }
+
+    async fn comments_with_authors(
+        &self,
+        account_user: &AccountUser,
+        comments: Vec<Comment>,
+    ) -> Result<Vec<CommentWithAuthor>, Error> {
+        let users = resolve_user_references(
+            self.user_repository,
+            account_user,
+            comments
+                .iter()
+                .map(|comment| *comment.commented_by())
+                .collect(),
+        )
+        .await?;
+
+        comments
+            .into_iter()
+            .map(|comment| {
+                let commented_by = users
+                    .get(comment.commented_by())
+                    .cloned()
+                    .ok_or(Error::from(UserNotFound))?;
+                Ok(CommentWithAuthor {
+                    comment,
+                    commented_by,
+                })
+            })
+            .collect()
+    }
+
     pub async fn search_users(
         &self,
         actor: &AccountUser,
@@ -142,10 +255,10 @@ impl<
 
     pub async fn cross_search(
         &self,
-        actor: &AccountUser,
+        account_user: &AccountUser,
         query: String,
     ) -> Result<CrossSearchOutput, Error> {
-        let actor = Actor::from(actor.clone());
+        let actor = Actor::from(account_user.clone());
         let (forms, users, label_for_forms, label_for_answers, answers, comments) = try_join!(
             self.search_repository.search_forms(&query),
             self.search_repository.search_users(&query),
@@ -158,19 +271,9 @@ impl<
         let actor_ref = &actor;
 
         let visible_forms = stream::iter(forms)
-            .then(|form| async move {
-                self.active_form_repository
-                    .get(form.form_id)
-                    .await
-                    .map(|guard| {
-                        guard.and_then(|guard| {
-                            guard
-                                .try_read(actor_ref.clone())
-                                .ok()
-                                .map(|form| form.into_inner())
-                        })
-                    })
-            })
+            .then(
+                |form| async move { self.visible_form_with_labels(actor_ref, form.form_id).await },
+            )
             .try_filter_map(|visible| std::future::ready(Ok(visible)))
             .try_collect()
             .await?;
@@ -231,14 +334,16 @@ impl<
                         return Ok::<_, Error>(None);
                     };
 
-                    Ok::<_, Error>(Some(answer.into_inner()))
+                    self.answer_details(account_user, actor_ref, answer)
+                        .await
+                        .map(Some)
                 }
             })
             .try_filter_map(|visible| std::future::ready(Ok(visible)))
             .try_collect()
             .await?;
 
-        let visible_comments = stream::iter(comments)
+        let visible_comments: Vec<Comment> = stream::iter(comments)
             .then(|comment| {
                 let answer_entries = &answer_entries;
 
@@ -260,6 +365,9 @@ impl<
             })
             .try_filter_map(|visible| std::future::ready(Ok(visible)))
             .try_collect()
+            .await?;
+        let visible_comments = self
+            .comments_with_authors(account_user, visible_comments)
             .await?;
 
         Ok(CrossSearchOutput {
@@ -495,5 +603,125 @@ impl<
 
     pub async fn initialize_search_engine(&self) -> Result<(), Error> {
         self.search_repository.initialize_search_engine().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::repositories::{
+        InMemoryActiveFormRepository, InMemoryAnswerEntryRepository, InMemoryFormLabelRepository,
+        InMemoryUserRepository,
+    };
+    use domain::{
+        account::models::{Role, UserGroup, UserGroupName},
+        form::{
+            models::{AllowedUserGroups, FormDescription, FormSettings, FormTitle},
+            question::{Question, QuestionSet},
+        },
+        repository::{
+            form::{
+                answer_label_repository::MockAnswerLabelRepository,
+                comment_repository::MockCommentRepository,
+            },
+            search_repository::MockSearchRepository,
+        },
+        search::models::FormSearchHit,
+    };
+    use types::non_empty_vec::NonEmptyVec;
+    use uuid::Uuid;
+
+    fn form_restricted_to(title: &str, group: &UserGroup) -> ActiveForm {
+        let question = Question::new_text(
+            "body".to_string().try_into().unwrap(),
+            0,
+            "Body".to_string().try_into().unwrap(),
+            None,
+            true,
+        )
+        .unwrap();
+        let questions =
+            QuestionSet::try_new(NonEmptyVec::try_new(vec![question]).unwrap()).unwrap();
+
+        ActiveForm::new(
+            FormTitle::new(title.to_string().try_into().unwrap()),
+            FormDescription::default(),
+            questions,
+        )
+        .change_settings(
+            FormSettings::new()
+                .change_allowed_user_groups(AllowedUserGroups::new(vec![*group.id()])),
+        )
+    }
+
+    #[tokio::test]
+    async fn cross_search_excludes_only_form_hits_the_actor_cannot_read() {
+        let member_group = UserGroup::new(UserGroupName::new(
+            "members".to_string().try_into().unwrap(),
+        ));
+        let other_group =
+            UserGroup::new(UserGroupName::new("other".to_string().try_into().unwrap()));
+        let actor = AccountUser::with_groups(
+            "viewer".to_string(),
+            Uuid::from_u128(1).into(),
+            Role::StandardUser,
+            vec![member_group.clone()],
+        );
+        let hidden_form = form_restricted_to("hidden", &other_group);
+        let readable_form = form_restricted_to("readable", &member_group);
+        let hidden_form_id = *hidden_form.id();
+        let readable_form_id = *readable_form.id();
+
+        let mut search_repository = MockSearchRepository::new();
+        search_repository.expect_search_forms().returning(move |_| {
+            Ok(vec![
+                FormSearchHit {
+                    form_id: hidden_form_id,
+                },
+                FormSearchHit {
+                    form_id: readable_form_id,
+                },
+            ])
+        });
+        search_repository
+            .expect_search_users()
+            .returning(|_| Ok(vec![]));
+        search_repository
+            .expect_search_labels_for_forms()
+            .returning(|_| Ok(vec![]));
+        search_repository
+            .expect_search_labels_for_answers()
+            .returning(|_| Ok(vec![]));
+        search_repository
+            .expect_search_answers()
+            .returning(|_| Ok(vec![]));
+        search_repository
+            .expect_search_comments()
+            .returning(|_| Ok(vec![]));
+
+        let active_form_repository =
+            InMemoryActiveFormRepository::new(vec![hidden_form, readable_form]);
+        let answer_label_repository = MockAnswerLabelRepository::new();
+        let form_label_repository = InMemoryFormLabelRepository;
+        let user_repository = InMemoryUserRepository::default();
+        let answer_entry_repository = InMemoryAnswerEntryRepository::default();
+        let comment_repository = MockCommentRepository::new();
+        let use_case = SearchUseCase {
+            search_repository: &search_repository,
+            active_form_repository: &active_form_repository,
+            form_answer_label_repository: &answer_label_repository,
+            form_label_repository: &form_label_repository,
+            user_repository: &user_repository,
+            answer_entry_repository: &answer_entry_repository,
+            comment_repository: &comment_repository,
+        };
+
+        let output = use_case
+            .cross_search(&actor, "form".to_string())
+            .await
+            .unwrap();
+
+        assert_eq!(output.forms.len(), 1);
+        assert_eq!(*output.forms[0].form.id(), readable_form_id);
     }
 }

--- a/server/usecase/src/search.rs
+++ b/server/usecase/src/search.rs
@@ -25,13 +25,14 @@ use domain::{
     types::authorization_guard::{Allowed, AuthorizationGuard, Read},
 };
 use errors::Error;
-use errors::usecase::UseCaseError::UserNotFound;
 use futures::{StreamExt, TryStreamExt, stream, try_join};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::{Notify, mpsc::Receiver};
 use tokio::time;
+
+const SEARCH_DETAIL_FETCH_CONCURRENCY: usize = 10;
 
 pub struct SearchUseCase<
     'a,
@@ -168,7 +169,7 @@ impl<
         account_user: &AccountUser,
         actor: &Actor,
         answer: Allowed<AnswerEntry, Read>,
-    ) -> Result<AnswerDetails, Error> {
+    ) -> Result<Option<AnswerDetails>, Error> {
         let answer_id = *answer.id();
         let form_id = *answer.form_id();
         let labels = self
@@ -193,23 +194,23 @@ impl<
         )
         .await?;
         let author = match answer.author() {
-            AnswerAuthor::AuthenticatedUser(user_id) => Actor::AccountUser(
-                users
-                    .get(user_id)
-                    .cloned()
-                    .ok_or(Error::from(UserNotFound))?,
-            ),
+            AnswerAuthor::AuthenticatedUser(user_id) => {
+                let Some(user) = users.get(user_id).cloned() else {
+                    return Ok(None);
+                };
+                Actor::AccountUser(user)
+            }
             AnswerAuthor::Temporary(temporary_user) => {
                 Actor::TemporaryAnswerAuthor(temporary_user.clone())
             }
         };
 
-        Ok(AnswerDetails {
+        Ok(Some(AnswerDetails {
             form_id,
             form_answer: answer.into_inner(),
             author,
             labels,
-        })
+        }))
     }
 
     async fn comments_with_authors(
@@ -227,19 +228,18 @@ impl<
         )
         .await?;
 
-        comments
+        Ok(comments
             .into_iter()
-            .map(|comment| {
-                let commented_by = users
+            .filter_map(|comment| {
+                users
                     .get(comment.commented_by())
                     .cloned()
-                    .ok_or(Error::from(UserNotFound))?;
-                Ok(CommentWithAuthor {
-                    comment,
-                    commented_by,
-                })
+                    .map(|commented_by| CommentWithAuthor {
+                        comment,
+                        commented_by,
+                    })
             })
-            .collect()
+            .collect())
     }
 
     pub async fn search_users(
@@ -271,9 +271,8 @@ impl<
         let actor_ref = &actor;
 
         let visible_forms = stream::iter(forms)
-            .then(
-                |form| async move { self.visible_form_with_labels(actor_ref, form.form_id).await },
-            )
+            .map(|form| async move { self.visible_form_with_labels(actor_ref, form.form_id).await })
+            .buffered(SEARCH_DETAIL_FETCH_CONCURRENCY)
             .try_filter_map(|visible| std::future::ready(Ok(visible)))
             .try_collect()
             .await?;
@@ -281,7 +280,7 @@ impl<
         let visible_users = self.visible_users(actor_ref, users).await?;
 
         let visible_label_for_forms = stream::iter(label_for_forms)
-            .then(|label| async move {
+            .map(|label| async move {
                 self.form_label_repository
                     .fetch_label(label.label_id)
                     .await
@@ -294,12 +293,13 @@ impl<
                         })
                     })
             })
+            .buffered(SEARCH_DETAIL_FETCH_CONCURRENCY)
             .try_filter_map(|visible| std::future::ready(Ok(visible)))
             .try_collect()
             .await?;
 
         let visible_label_for_answers = stream::iter(label_for_answers)
-            .then(|label| async move {
+            .map(|label| async move {
                 self.form_answer_label_repository
                     .get_label_for_answers(label.label_id)
                     .await
@@ -312,6 +312,7 @@ impl<
                         })
                     })
             })
+            .buffered(SEARCH_DETAIL_FETCH_CONCURRENCY)
             .try_filter_map(|visible| std::future::ready(Ok(visible)))
             .try_collect()
             .await?;
@@ -325,7 +326,7 @@ impl<
         let answer_entries = self.list_all_answer_entries(&readable_forms).await?;
 
         let visible_answers = stream::iter(answers)
-            .then(|entry| {
+            .map(|entry| {
                 let answer_entries = &answer_entries;
 
                 async move {
@@ -334,17 +335,16 @@ impl<
                         return Ok::<_, Error>(None);
                     };
 
-                    self.answer_details(account_user, actor_ref, answer)
-                        .await
-                        .map(Some)
+                    self.answer_details(account_user, actor_ref, answer).await
                 }
             })
+            .buffered(SEARCH_DETAIL_FETCH_CONCURRENCY)
             .try_filter_map(|visible| std::future::ready(Ok(visible)))
             .try_collect()
             .await?;
 
         let visible_comments: Vec<Comment> = stream::iter(comments)
-            .then(|comment| {
+            .map(|comment| {
                 let answer_entries = &answer_entries;
 
                 async move {
@@ -363,6 +363,7 @@ impl<
                     )
                 }
             })
+            .buffered(SEARCH_DETAIL_FETCH_CONCURRENCY)
             .try_filter_map(|visible| std::future::ready(Ok(visible)))
             .try_collect()
             .await?;
@@ -613,9 +614,15 @@ mod tests {
         InMemoryActiveFormRepository, InMemoryAnswerEntryRepository, InMemoryFormLabelRepository,
         InMemoryUserRepository,
     };
+    use chrono::Utc;
     use domain::{
         account::models::{Role, UserGroup, UserGroupName},
         form::{
+            answer::{
+                AnswerAuthor, AnswerEntry, AnswerSettings, AnswerTitle, AnswerVisibility,
+                FormAnswerContent, FormAnswerContentId, PostedAnswerContents,
+            },
+            comment::{Comment, CommentContent, CommentId},
             models::{AllowedUserGroups, FormDescription, FormSettings, FormTitle},
             question::{Question, QuestionSet},
         },
@@ -626,7 +633,7 @@ mod tests {
             },
             search_repository::MockSearchRepository,
         },
-        search::models::FormSearchHit,
+        search::models::{AnswerSearchHit, CommentSearchHit, FormSearchHit},
     };
     use types::non_empty_vec::NonEmptyVec;
     use uuid::Uuid;
@@ -723,5 +730,231 @@ mod tests {
 
         assert_eq!(output.forms.len(), 1);
         assert_eq!(*output.forms[0].form.id(), readable_form_id);
+    }
+
+    #[tokio::test]
+    async fn cross_search_excludes_only_answer_hits_whose_author_is_missing() {
+        let member_group = UserGroup::new(UserGroupName::new(
+            "members".to_string().try_into().unwrap(),
+        ));
+        let actor = AccountUser::with_groups(
+            "viewer".to_string(),
+            Uuid::from_u128(1).into(),
+            Role::StandardUser,
+            vec![member_group.clone()],
+        );
+        let form = form_restricted_to("answers", &member_group).change_answer_settings(
+            AnswerSettings::default().change_visibility(AnswerVisibility::PUBLIC),
+        );
+        let form_id = *form.id();
+        let question_id = *form.questions().as_slice()[0].id();
+        let answer_contents = || {
+            PostedAnswerContents::try_new(
+                form.questions().as_slice(),
+                vec![FormAnswerContent {
+                    id: FormAnswerContentId::from(Uuid::new_v4()),
+                    question_id: question_id.into(),
+                    answer: "body".to_string(),
+                }],
+            )
+            .unwrap()
+        };
+        let missing_author_answer = AnswerEntry::new(
+            form_id,
+            AnswerAuthor::AuthenticatedUser(Uuid::from_u128(4).into()),
+            AnswerTitle::default(),
+            answer_contents(),
+        );
+        let visible_answer = AnswerEntry::new(
+            form_id,
+            AnswerAuthor::AuthenticatedUser(*actor.id()),
+            AnswerTitle::default(),
+            answer_contents(),
+        );
+        let missing_author_answer_id = *missing_author_answer.id();
+        let visible_answer_id = *visible_answer.id();
+
+        let mut search_repository = MockSearchRepository::new();
+        search_repository
+            .expect_search_forms()
+            .returning(|_| Ok(vec![]));
+        search_repository
+            .expect_search_users()
+            .returning(|_| Ok(vec![]));
+        search_repository
+            .expect_search_labels_for_forms()
+            .returning(|_| Ok(vec![]));
+        search_repository
+            .expect_search_labels_for_answers()
+            .returning(|_| Ok(vec![]));
+        search_repository
+            .expect_search_answers()
+            .returning(move |_| {
+                Ok(vec![
+                    AnswerSearchHit {
+                        answer_id: missing_author_answer_id,
+                    },
+                    AnswerSearchHit {
+                        answer_id: visible_answer_id,
+                    },
+                ])
+            });
+        search_repository
+            .expect_search_comments()
+            .returning(|_| Ok(vec![]));
+
+        let active_form_repository = InMemoryActiveFormRepository::new(vec![form]);
+        let mut answer_label_repository = MockAnswerLabelRepository::new();
+        answer_label_repository
+            .expect_get_labels_for_answers_by_answer_id()
+            .returning(|_| Ok(vec![]));
+        let form_label_repository = InMemoryFormLabelRepository;
+        let user_repository = InMemoryUserRepository::default();
+        user_repository.save_user(actor.clone());
+        let answer_entry_repository =
+            InMemoryAnswerEntryRepository::new(vec![missing_author_answer, visible_answer]);
+        let comment_repository = MockCommentRepository::new();
+        let use_case = SearchUseCase {
+            search_repository: &search_repository,
+            active_form_repository: &active_form_repository,
+            form_answer_label_repository: &answer_label_repository,
+            form_label_repository: &form_label_repository,
+            user_repository: &user_repository,
+            answer_entry_repository: &answer_entry_repository,
+            comment_repository: &comment_repository,
+        };
+
+        let output = use_case
+            .cross_search(&actor, "answer".to_string())
+            .await
+            .unwrap();
+
+        assert_eq!(output.answers.len(), 1);
+        assert_eq!(*output.answers[0].form_answer.id(), visible_answer_id);
+    }
+
+    #[tokio::test]
+    async fn cross_search_excludes_only_comment_hits_whose_author_is_missing() {
+        let member_group = UserGroup::new(UserGroupName::new(
+            "members".to_string().try_into().unwrap(),
+        ));
+        let actor = AccountUser::with_groups(
+            "viewer".to_string(),
+            Uuid::from_u128(10).into(),
+            Role::StandardUser,
+            vec![member_group.clone()],
+        );
+        let form = form_restricted_to("comments", &member_group).change_answer_settings(
+            AnswerSettings::default().change_visibility(AnswerVisibility::PUBLIC),
+        );
+        let question_id = *form.questions().as_slice()[0].id();
+        let answer = AnswerEntry::new(
+            *form.id(),
+            AnswerAuthor::AuthenticatedUser(*actor.id()),
+            AnswerTitle::default(),
+            PostedAnswerContents::try_new(
+                form.questions().as_slice(),
+                vec![FormAnswerContent {
+                    id: FormAnswerContentId::from(Uuid::new_v4()),
+                    question_id: question_id.into(),
+                    answer: "body".to_string(),
+                }],
+            )
+            .unwrap(),
+        );
+        let answer_id = *answer.id();
+        let first_comment_id = CommentId::from(Uuid::from_u128(11));
+        let missing_author_comment_id = CommentId::from(Uuid::from_u128(12));
+        let second_comment_id = CommentId::from(Uuid::from_u128(13));
+        let comment = |comment_id, commented_by, content: &str| unsafe {
+            Comment::from_raw_parts(
+                answer_id,
+                comment_id,
+                CommentContent::new(content.to_string().try_into().unwrap()),
+                Utc::now(),
+                commented_by,
+            )
+        };
+        let first_comment = comment(first_comment_id, *actor.id(), "first");
+        let missing_author_comment = comment(
+            missing_author_comment_id,
+            Uuid::from_u128(14).into(),
+            "missing author",
+        );
+        let second_comment = comment(second_comment_id, *actor.id(), "second");
+
+        let mut search_repository = MockSearchRepository::new();
+        search_repository
+            .expect_search_forms()
+            .returning(|_| Ok(vec![]));
+        search_repository
+            .expect_search_users()
+            .returning(|_| Ok(vec![]));
+        search_repository
+            .expect_search_labels_for_forms()
+            .returning(|_| Ok(vec![]));
+        search_repository
+            .expect_search_labels_for_answers()
+            .returning(|_| Ok(vec![]));
+        search_repository
+            .expect_search_answers()
+            .returning(|_| Ok(vec![]));
+        search_repository
+            .expect_search_comments()
+            .returning(move |_| {
+                Ok(vec![
+                    CommentSearchHit {
+                        comment_id: second_comment_id,
+                        answer_id,
+                    },
+                    CommentSearchHit {
+                        comment_id: missing_author_comment_id,
+                        answer_id,
+                    },
+                    CommentSearchHit {
+                        comment_id: first_comment_id,
+                        answer_id,
+                    },
+                ])
+            });
+
+        let active_form_repository = InMemoryActiveFormRepository::new(vec![form]);
+        let answer_label_repository = MockAnswerLabelRepository::new();
+        let form_label_repository = InMemoryFormLabelRepository;
+        let user_repository = InMemoryUserRepository::default();
+        user_repository.save_user(actor.clone());
+        let answer_entry_repository = InMemoryAnswerEntryRepository::new(vec![answer]);
+        let stored_comments = vec![first_comment, missing_author_comment, second_comment];
+        let mut comment_repository = MockCommentRepository::new();
+        comment_repository
+            .expect_find_by_answer()
+            .returning(move |answer| {
+                stored_comments
+                    .iter()
+                    .cloned()
+                    .map(|comment| answer.authorize_comment(comment).map_err(Error::from))
+                    .collect()
+            });
+        let use_case = SearchUseCase {
+            search_repository: &search_repository,
+            active_form_repository: &active_form_repository,
+            form_answer_label_repository: &answer_label_repository,
+            form_label_repository: &form_label_repository,
+            user_repository: &user_repository,
+            answer_entry_repository: &answer_entry_repository,
+            comment_repository: &comment_repository,
+        };
+
+        let output = use_case
+            .cross_search(&actor, "comment".to_string())
+            .await
+            .unwrap();
+
+        let comment_ids = output
+            .comments
+            .iter()
+            .map(|comment| *comment.comment.comment_id())
+            .collect::<Vec<_>>();
+        assert_eq!(comment_ids, vec![second_comment_id, first_comment_id]);
     }
 }

--- a/server/usecase/src/test_utils/repositories.rs
+++ b/server/usecase/src/test_utils/repositories.rs
@@ -253,6 +253,14 @@ pub(crate) struct InMemoryAnswerEntryRepository {
     answers: Mutex<Vec<AnswerEntry>>,
 }
 
+impl InMemoryAnswerEntryRepository {
+    pub(crate) fn new(answers: Vec<AnswerEntry>) -> Self {
+        Self {
+            answers: Mutex::new(answers),
+        }
+    }
+}
+
 #[async_trait]
 impl AnswerEntryRepository for InMemoryAnswerEntryRepository {
     async fn get(


### PR DESCRIPTION
ID 等が含まれていなく、本当にヒットしたそのものだけを返していたので使いどころがなかった
