### PR TITLE
回答タイトルを横断検索の対象に追加

### DIFF
--- a/.sqlx/query-13c52e5798886c787b64fc9b40b6462cde741862a0aa08ef4207466ada964167.json
+++ b/.sqlx/query-13c52e5798886c787b64fc9b40b6462cde741862a0aa08ef4207466ada964167.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "MySQL",
+  "query": "SELECT COUNT(*) AS `count!: i64` FROM answers",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count!: i64",
+        "type_info": {
+          "type": "LongLong",
+          "flags": "NOT_NULL | BINARY",
+          "collation": 63,
+          "max_size": 21
+        },
+        "origin": "Expression"
+      }
+    ],
+    "parameters": {
+      "Right": 0
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "13c52e5798886c787b64fc9b40b6462cde741862a0aa08ef4207466ada964167"
+}

--- a/server/domain/src/repository/form/answer_entry_repository.rs
+++ b/server/domain/src/repository/form/answer_entry_repository.rs
@@ -39,5 +39,8 @@ pub trait AnswerEntryRepository: Send + Sync + 'static {
         form: &Allowed<ActiveForm, Update>,
         answer_entry: &Allowed<AnswerEntry, Update>,
     ) -> Result<(), Error>;
+    /// 回答 (`answers`) の件数を返す。
     async fn size(&self) -> Result<u32, Error>;
+    /// 回答本文 (`real_answers`) の件数を返す。
+    async fn content_size(&self) -> Result<u32, Error>;
 }

--- a/server/domain/src/search/models.rs
+++ b/server/domain/src/search/models.rs
@@ -1,7 +1,7 @@
 use crate::account::models::UserId;
 use crate::form::answer::FormAnswerContentId;
 use crate::form::{
-    answer::{AnswerId, AnswerLabelId},
+    answer::{AnswerId, AnswerLabelId, AnswerTitle},
     comment::CommentId,
     models::{FormDescription, FormId, FormLabelId, FormTitle},
     question::QuestionId,
@@ -22,6 +22,7 @@ pub enum Operation {
 #[derive(Debug)]
 pub enum SearchableFields {
     FormMetaData(FormMetaData),
+    AnswerTitle(AnswerTitleSearchDocument),
     RealAnswers(RealAnswers),
     FormAnswerComments(FormAnswerComments),
     LabelForFormAnswers(LabelForFormAnswers),
@@ -36,6 +37,13 @@ pub struct FormMetaData {
     pub id: FormId,
     pub title: FormTitle,
     pub description: FormDescription,
+}
+
+/// 回答タイトルを回答単位で検索するための検索エンジン向け投影。
+#[derive(Serialize, Deserialize, Debug)]
+pub struct AnswerTitleSearchDocument {
+    pub id: AnswerId,
+    pub title: AnswerTitle,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -105,6 +113,7 @@ pub struct Users {
 #[derive(Getters, Default, Debug)]
 pub struct NumberOfRecordsPerAggregate {
     pub form_meta_data: NumberOfRecords,
+    pub answers: NumberOfRecords,
     pub real_answers: NumberOfRecords,
     pub form_answer_comments: NumberOfRecords,
     pub label_for_form_answers: NumberOfRecords,
@@ -116,6 +125,7 @@ impl NumberOfRecordsPerAggregate {
     pub fn try_into_sync_rate(&self, other: &Self) -> Result<SyncRate, Error> {
         let Self {
             form_meta_data,
+            answers,
             real_answers,
             form_answer_comments,
             label_for_form_answers,
@@ -125,6 +135,7 @@ impl NumberOfRecordsPerAggregate {
 
         let Self {
             form_meta_data: other_form_meta_data,
+            answers: other_answers,
             real_answers: other_real_answers,
             form_answer_comments: other_form_answer_comments,
             label_for_form_answers: other_label_for_form_answers,
@@ -134,6 +145,9 @@ impl NumberOfRecordsPerAggregate {
 
         let form_meta_data_sync_rate = SyncRate::new(NonNegativeF32::try_new(
             form_meta_data.0 as f32 / other_form_meta_data.0 as f32,
+        )?);
+        let answers_sync_rate = SyncRate::new(NonNegativeF32::try_new(
+            answers.0 as f32 / other_answers.0 as f32,
         )?);
         let real_answers_sync_rate = SyncRate::new(NonNegativeF32::try_new(
             real_answers.0 as f32 / other_real_answers.0 as f32,
@@ -154,6 +168,7 @@ impl NumberOfRecordsPerAggregate {
 
         Ok(SyncRate::average(&[
             form_meta_data_sync_rate,
+            answers_sync_rate,
             real_answers_sync_rate,
             form_answer_comments_sync_rate,
             label_for_form_answers_sync_rate,

--- a/server/infra/resource/src/database/components.rs
+++ b/server/infra/resource/src/database/components.rs
@@ -115,7 +115,10 @@ pub trait FormAnswerDatabase: Send + Sync {
         answer_entry: &AnswerEntry,
         form_id: FormId,
     ) -> Result<(), InfraError>;
+    /// 回答 (`answers`) の件数を返す。
     async fn size(&self) -> Result<u32, InfraError>;
+    /// 回答本文 (`real_answers`) の件数を返す。
+    async fn content_size(&self) -> Result<u32, InfraError>;
 }
 
 #[automock]

--- a/server/infra/resource/src/database/forms/answers.rs
+++ b/server/infra/resource/src/database/forms/answers.rs
@@ -450,6 +450,20 @@ impl FormAnswerDatabase for ConnectionPool {
     async fn size(&self) -> Result<u32, InfraError> {
         self.read_only_transaction(|txn| {
             Box::pin(async move {
+                let size = sqlx::query_scalar!("SELECT COUNT(*) AS `count!: i64` FROM answers")
+                    .fetch_one(&mut **txn)
+                    .await?;
+
+                count_as_u32(size, "answers")
+            })
+        })
+        .await
+    }
+
+    #[tracing::instrument]
+    async fn content_size(&self) -> Result<u32, InfraError> {
+        self.read_only_transaction(|txn| {
+            Box::pin(async move {
                 let size =
                     sqlx::query_scalar!("SELECT COUNT(*) AS `count!: i64` FROM real_answers")
                         .fetch_one(&mut **txn)

--- a/server/infra/resource/src/database/meilisearch_schemas.rs
+++ b/server/infra/resource/src/database/meilisearch_schemas.rs
@@ -12,6 +12,8 @@ pub struct MeilisearchIndexSchema {
     #[serde(default)]
     form_meta_data: NumberOfDocuments,
     #[serde(default)]
+    answers: NumberOfDocuments,
+    #[serde(default)]
     real_answers: NumberOfDocuments,
     #[serde(default)]
     form_answer_comments: NumberOfDocuments,
@@ -27,6 +29,7 @@ impl From<MeilisearchIndexSchema> for NumberOfRecordsPerAggregate {
     fn from(value: MeilisearchIndexSchema) -> Self {
         NumberOfRecordsPerAggregate {
             form_meta_data: NumberOfRecords(value.form_meta_data.number_of_documents),
+            answers: NumberOfRecords(value.answers.number_of_documents),
             real_answers: NumberOfRecords(value.real_answers.number_of_documents),
             form_answer_comments: NumberOfRecords(value.form_answer_comments.number_of_documents),
             label_for_form_answers: NumberOfRecords(

--- a/server/infra/resource/src/database/search.rs
+++ b/server/infra/resource/src/database/search.rs
@@ -3,9 +3,9 @@ use crate::database::meilisearch_schemas::MeilisearchStatsSchema;
 use crate::database::{components::SearchDatabase, connection::ConnectionPool};
 use async_trait::async_trait;
 use domain::search::models::{
-    AnswerLabelSearchHit, AnswerSearchHit, CommentSearchHit, FormAnswerComments,
-    FormLabelSearchHit, FormMetaData, FormSearchHit, LabelForFormAnswers, LabelForForms,
-    NumberOfRecordsPerAggregate, RealAnswers, UserSearchHit, Users,
+    AnswerLabelSearchHit, AnswerSearchHit, AnswerTitleSearchDocument, CommentSearchHit,
+    FormAnswerComments, FormLabelSearchHit, FormMetaData, FormSearchHit, LabelForFormAnswers,
+    LabelForForms, NumberOfRecordsPerAggregate, RealAnswers, UserSearchHit, Users,
 };
 use domain::{
     account::models::UserId,
@@ -14,6 +14,18 @@ use domain::{
 use errors::infra::InfraError;
 use itertools::Itertools;
 use meilisearch_sdk::search::Selectors;
+
+fn merge_answer_hits(
+    title_answer_ids: impl IntoIterator<Item = domain::form::answer::AnswerId>,
+    content_answer_ids: impl IntoIterator<Item = domain::form::answer::AnswerId>,
+) -> Vec<AnswerSearchHit> {
+    title_answer_ids
+        .into_iter()
+        .chain(content_answer_ids)
+        .map(|answer_id| AnswerSearchHit { answer_id })
+        .unique_by(|hit| hit.answer_id)
+        .collect()
+}
 
 #[async_trait]
 impl SearchDatabase for ConnectionPool {
@@ -97,21 +109,33 @@ impl SearchDatabase for ConnectionPool {
 
     #[tracing::instrument]
     async fn search_answers(&self, query: &str) -> Result<Vec<AnswerSearchHit>, InfraError> {
-        Ok(self
-            .meilisearch_client
-            .index("real_answers")
-            .search()
-            .with_query(query)
-            .with_attributes_to_highlight(Selectors::All)
-            .execute::<RealAnswers>()
-            .await?
-            .hits
-            .into_iter()
-            .map(|hit| AnswerSearchHit {
-                answer_id: hit.result.answer_id,
-            })
-            .unique_by(|hit| hit.answer_id.to_string())
-            .collect_vec())
+        let title_search = async {
+            self.meilisearch_client
+                .index("answers")
+                .search()
+                .with_query(query)
+                .with_attributes_to_highlight(Selectors::All)
+                .execute::<AnswerTitleSearchDocument>()
+                .await
+        };
+        let content_search = async {
+            self.meilisearch_client
+                .index("real_answers")
+                .search()
+                .with_query(query)
+                .with_attributes_to_highlight(Selectors::All)
+                .execute::<RealAnswers>()
+                .await
+        };
+        let (title_results, content_results) = futures::try_join!(title_search, content_search)?;
+
+        Ok(merge_answer_hits(
+            title_results.hits.into_iter().map(|hit| hit.result.id),
+            content_results
+                .hits
+                .into_iter()
+                .map(|hit| hit.result.answer_id),
+        ))
     }
 
     #[tracing::instrument]
@@ -146,6 +170,12 @@ impl SearchDatabase for ConnectionPool {
                         self.meilisearch_client
                             .index("form_meta_data")
                             .add_or_replace(&[data], Some("id"))
+                            .await
+                    }
+                    SearchableFields::AnswerTitle(answer) => {
+                        self.meilisearch_client
+                            .index("answers")
+                            .add_or_replace(&[answer], Some("id"))
                             .await
                     }
                     SearchableFields::RealAnswers(answers) => {
@@ -184,6 +214,12 @@ impl SearchDatabase for ConnectionPool {
                         self.meilisearch_client
                             .index("form_meta_data")
                             .delete_document(data.id.into_inner().to_string())
+                            .await
+                    }
+                    SearchableFields::AnswerTitle(answer) => {
+                        self.meilisearch_client
+                            .index("answers")
+                            .delete_document(answer.id.to_string())
                             .await
                     }
                     SearchableFields::RealAnswers(answers) => {
@@ -250,6 +286,7 @@ impl SearchDatabase for ConnectionPool {
     async fn initialize_search_engine(&self) -> Result<(), InfraError> {
         let index_with_uid = vec![
             ("form_meta_data", "id"),
+            ("answers", "id"),
             ("real_answers", "id"),
             ("form_answer_comments", "id"),
             ("label_for_form_answers", "id"),
@@ -259,11 +296,55 @@ impl SearchDatabase for ConnectionPool {
 
         let futures = index_with_uid
             .into_iter()
-            .map(|(index, uid)| self.meilisearch_client.create_index(index, Some(uid)))
+            .map(async |(index, uid)| {
+                self.meilisearch_client
+                    .create_index(index, Some(uid))
+                    .await?
+                    .wait_for_completion(&self.meilisearch_client, None, None)
+                    .await?;
+
+                Ok::<_, meilisearch_sdk::errors::Error>(())
+            })
             .collect_vec();
 
         futures::future::try_join_all(futures).await?;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::merge_answer_hits;
+    use domain::form::answer::AnswerId;
+    use uuid::Uuid;
+
+    fn answer_id(value: u128) -> AnswerId {
+        Uuid::from_u128(value).into()
+    }
+
+    #[test]
+    fn answer_search_hits_include_title_and_content_matches_with_title_first() {
+        let title_match = answer_id(1);
+        let content_match = answer_id(2);
+
+        let hits = merge_answer_hits([title_match], [content_match]);
+
+        assert_eq!(
+            hits.into_iter()
+                .map(|hit| hit.answer_id)
+                .collect::<Vec<_>>(),
+            vec![title_match, content_match]
+        );
+    }
+
+    #[test]
+    fn answer_search_hits_are_unique_when_title_and_content_both_match() {
+        let answer_id = answer_id(1);
+
+        let hits = merge_answer_hits([answer_id], [answer_id, answer_id]);
+
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].answer_id, answer_id);
     }
 }

--- a/server/infra/resource/src/messaging/schema.rs
+++ b/server/infra/resource/src/messaging/schema.rs
@@ -46,6 +46,10 @@ impl Payload {
                 let form_meta_data: FormMetaData = serde_json::from_value(value)?;
                 Ok(Some(ActualDataFields::FormMetaData(form_meta_data)))
             }
+            "answers" => {
+                let answer: AnswerTitleSearchDocument = serde_json::from_value(value)?;
+                Ok(Some(ActualDataFields::AnswerTitle(answer)))
+            }
             "real_answers" => {
                 let real_answers: RealAnswers = serde_json::from_value(value)?;
                 Ok(Some(ActualDataFields::RealAnswers(real_answers)))
@@ -122,6 +126,32 @@ impl TryFrom<FormMetaData> for domain::search::models::FormMetaData {
             id: Uuid::from_str(&form_meta_data.id)?.into(),
             title: form_meta_data.title.into(),
             description: form_meta_data.description.into(),
+        })
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct AnswerTitleSearchDocument {
+    pub id: String,
+    pub title: Option<NonEmptyString>,
+}
+
+impl From<domain::search::models::AnswerTitleSearchDocument> for AnswerTitleSearchDocument {
+    fn from(answer: domain::search::models::AnswerTitleSearchDocument) -> Self {
+        Self {
+            id: answer.id.to_string(),
+            title: answer.title.into_inner(),
+        }
+    }
+}
+
+impl TryFrom<AnswerTitleSearchDocument> for domain::search::models::AnswerTitleSearchDocument {
+    type Error = InfraError;
+
+    fn try_from(answer: AnswerTitleSearchDocument) -> Result<Self, Self::Error> {
+        Ok(Self {
+            id: Uuid::from_str(&answer.id)?.into(),
+            title: domain::form::answer::AnswerTitle::new(answer.title),
         })
     }
 }
@@ -268,6 +298,7 @@ impl TryFrom<Users> for domain::search::models::Users {
 #[derive(Serialize, Deserialize, Debug)]
 pub enum ActualDataFields {
     FormMetaData(FormMetaData),
+    AnswerTitle(AnswerTitleSearchDocument),
     RealAnswers(RealAnswers),
     FormAnswerComments(FormAnswerComments),
     LabelForFormAnswers(LabelForFormAnswers),
@@ -279,6 +310,7 @@ impl From<SearchableFields> for ActualDataFields {
     fn from(value: SearchableFields) -> Self {
         match value {
             SearchableFields::FormMetaData(data) => ActualDataFields::FormMetaData(data.into()),
+            SearchableFields::AnswerTitle(data) => ActualDataFields::AnswerTitle(data.into()),
             SearchableFields::RealAnswers(data) => ActualDataFields::RealAnswers(data.into()),
             SearchableFields::FormAnswerComments(data) => {
                 ActualDataFields::FormAnswerComments(data.into())
@@ -300,6 +332,9 @@ impl TryFrom<ActualDataFields> for SearchableFields {
             ActualDataFields::FormMetaData(data) => {
                 Ok(SearchableFields::FormMetaData(data.try_into()?))
             }
+            ActualDataFields::AnswerTitle(data) => {
+                Ok(SearchableFields::AnswerTitle(data.try_into()?))
+            }
             ActualDataFields::RealAnswers(data) => {
                 Ok(SearchableFields::RealAnswers(data.try_into()?))
             }
@@ -314,5 +349,67 @@ impl TryFrom<ActualDataFields> for SearchableFields {
             }
             ActualDataFields::Users(data) => Ok(SearchableFields::Users(data.try_into()?)),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{RabbitMQSchema, SearchableFields};
+    use serde_json::json;
+    use uuid::Uuid;
+
+    #[test]
+    fn answers_create_or_update_payload_uses_after_image() {
+        let answer_id = Uuid::from_u128(1);
+        let schema: RabbitMQSchema = serde_json::from_value(json!({
+            "payload": {
+                "op": "u",
+                "source": { "table": "answers" },
+                "before": null,
+                "after": {
+                    "id": answer_id.to_string(),
+                    "title": "検索できるタイトル"
+                }
+            }
+        }))
+        .unwrap();
+
+        let actual = schema.payload.try_into_after().unwrap().unwrap();
+        let SearchableFields::AnswerTitle(document) = SearchableFields::try_from(actual).unwrap()
+        else {
+            panic!("answers payload must become an answer title search document");
+        };
+
+        assert_eq!(document.id.into_inner(), answer_id);
+        assert_eq!(
+            serde_json::to_value(document.title).unwrap(),
+            json!("検索できるタイトル")
+        );
+    }
+
+    #[test]
+    fn answers_delete_payload_uses_before_image_and_preserves_null_title() {
+        let answer_id = Uuid::from_u128(1);
+        let schema: RabbitMQSchema = serde_json::from_value(json!({
+            "payload": {
+                "op": "d",
+                "source": { "table": "answers" },
+                "before": {
+                    "id": answer_id.to_string(),
+                    "title": null
+                },
+                "after": null
+            }
+        }))
+        .unwrap();
+
+        let actual = schema.payload.try_into_before().unwrap().unwrap();
+        let SearchableFields::AnswerTitle(document) = SearchableFields::try_from(actual).unwrap()
+        else {
+            panic!("answers payload must become an answer title search document");
+        };
+
+        assert_eq!(document.id.into_inner(), answer_id);
+        assert_eq!(serde_json::to_value(document.title).unwrap(), json!(null));
     }
 }

--- a/server/infra/resource/src/repository/form_repository_impls/answer_entry_repository_impl.rs
+++ b/server/infra/resource/src/repository/form_repository_impls/answer_entry_repository_impl.rs
@@ -117,4 +117,13 @@ where
     async fn size(&self) -> Result<u32, Error> {
         self.client.form_answer().size().await.map_err(Into::into)
     }
+
+    #[tracing::instrument(skip(self))]
+    async fn content_size(&self) -> Result<u32, Error> {
+        self.client
+            .form_answer()
+            .content_size()
+            .await
+            .map_err(Into::into)
+    }
 }

--- a/server/usecase/src/search.rs
+++ b/server/usecase/src/search.rs
@@ -421,8 +421,9 @@ impl<
 
                     let repository_records = NumberOfRecordsPerAggregate {
                         form_meta_data: NumberOfRecords(self.active_form_repository.size().await?),
+                        answers: NumberOfRecords(self.answer_entry_repository.size().await?),
                         real_answers: NumberOfRecords(
-                            self.answer_entry_repository.size().await?,
+                            self.answer_entry_repository.content_size().await?,
                         ),
                         form_answer_comments: NumberOfRecords(
                             self.comment_repository.size().await?,
@@ -464,7 +465,23 @@ impl<
 
                         let answer_entries = self.list_all_answer_entries(&form_guards).await?;
 
-                        let answers = answer_entries
+                        let answer_titles = answer_entries
+                            .iter()
+                            .map(|entry| {
+                                let entry = entry.value();
+                                (
+                                    domain::search::models::SearchableFields::AnswerTitle(
+                                        domain::search::models::AnswerTitleSearchDocument {
+                                            id: *entry.id(),
+                                            title: entry.title().clone(),
+                                        },
+                                    ),
+                                    Operation::Update,
+                                )
+                            })
+                            .collect::<Vec<_>>();
+
+                        let answer_contents = answer_entries
                             .iter()
                             .flat_map(|entry| {
                                 let entry = entry.value();
@@ -584,7 +601,8 @@ impl<
 
                         let data = forms
                             .into_iter()
-                            .chain(answers)
+                            .chain(answer_titles)
+                            .chain(answer_contents)
                             .chain(comments)
                             .chain(labels_for_forms)
                             .chain(labels_for_answers)

--- a/server/usecase/src/test_utils/repositories.rs
+++ b/server/usecase/src/test_utils/repositories.rs
@@ -370,6 +370,16 @@ impl AnswerEntryRepository for InMemoryAnswerEntryRepository {
     async fn size(&self) -> Result<u32, Error> {
         Ok(self.answers.lock().unwrap().len() as u32)
     }
+
+    async fn content_size(&self) -> Result<u32, Error> {
+        Ok(self
+            .answers
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|answer| answer.contents().len() as u32)
+            .sum())
+    }
 }
 
 #[derive(Default)]


### PR DESCRIPTION
## 概要
- 回答タイトル専用の検索ドキュメントと `answers` インデックスを追加し、タイトルだけに検索語が含まれる回答も横断検索で返せるようにしました
- `answers` テーブルの変更を CDC と定期再同期から Meilisearch へ反映し、タイトルと本文の検索結果を回答 ID 単位で重複なく統合します
- 回答件数と回答本文件数の契約を分け、sqlx メタデータを更新しました

Closes #1209

## 確認事項
- `cargo test --all-features` で全テストと doctest が成功しました
- `cargo test -p resource` でタイトル・本文の検索結果統合と `answers` CDC payload のテスト 6 件が成功しました
- `cargo build` と `cargo clippy -- -D warnings` が成功しました
- `cargo sqlx prepare --workspace` で typed query のメタデータを更新しました
- rustfmt と `git diff --check` が成功しました
- コミットフックの OpenAPI 再生成・追跡差分確認が成功し、API スキーマに変更がないことを確認しました

## 補足
- 実 Meilisearch・Debezium を起動した E2E は、このリポジトリに既存の infra 統合テスト基盤がないため未実施です。検索結果の統合と CDC の変換は resource の単体テストで確認しています

🤖 Generated with Codex