### PR TITLE
feat: 回答のみを検索できる API を追加

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3702,6 +3702,83 @@
         ]
       }
     },
+    "/api/v1/search/answers": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "summary": "回答検索を行う",
+        "operationId": "search_answers",
+        "parameters": [
+          {
+            "name": "query",
+            "in": "query",
+            "description": "Search query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AnswerSearchResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The server could not understand the request due to invalid syntax.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access is unauthorized.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access is forbidden.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
     "/api/v1/search/users": {
       "get": {
         "tags": [
@@ -5491,6 +5568,20 @@
               "string",
               "null"
             ]
+          }
+        }
+      },
+      "AnswerSearchResult": {
+        "type": "object",
+        "required": [
+          "answers"
+        ],
+        "properties": {
+          "answers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FormAnswer"
+            }
           }
         }
       },

--- a/server/domain/src/repository/form/answer_entry_repository.rs
+++ b/server/domain/src/repository/form/answer_entry_repository.rs
@@ -19,6 +19,16 @@ pub trait AnswerEntryRepository: Send + Sync + 'static {
         form: &Allowed<ActiveForm, Read>,
         answer_id: AnswerId,
     ) -> Result<Option<Allowed<AnswerEntry, Read>>, Error>;
+    /// 指定された ID に一致する回答のうち、`forms` に含まれる親フォームから
+    /// 閲覧を認可できるものだけを返す。
+    ///
+    /// 指定されていない ID、親フォームが `forms` にない回答、または閲覧できない回答は
+    /// 返さない。返却順は規定しない。`answer_ids` が空の場合は空のリストを返す。
+    async fn find_by_ids(
+        &self,
+        forms: &[Allowed<ActiveForm, Read>],
+        answer_ids: Vec<AnswerId>,
+    ) -> Result<Vec<Allowed<AnswerEntry, Read>>, Error>;
     async fn list_by_form(
         &self,
         form: &Allowed<ActiveForm, Read>,

--- a/server/entrypoint/src/openapi.rs
+++ b/server/entrypoint/src/openapi.rs
@@ -57,6 +57,7 @@ use utoipa_axum::routes;
         presentation::schemas::search_schemas::SearchCommentSchema,
         presentation::schemas::search_schemas::CrossSearchResult,
         presentation::schemas::search_schemas::UserSearchResult,
+        presentation::schemas::search_schemas::AnswerSearchResult,
     )),
     modifiers(&SecurityAddon),
     tags(
@@ -189,6 +190,7 @@ pub fn authenticated_api_router() -> OpenApiRouter<RealInfrastructureRepository>
         ))
         .routes(routes!(search_handler::cross_search))
         .routes(routes!(search_handler::search_users))
+        .routes(routes!(search_handler::search_answers))
         .routes(routes!(message_handler::get_messages_handler))
         .routes(routes!(message_handler::get_message_history))
         .routes(routes!(

--- a/server/infra/resource/src/repository/form_repository_impls/answer_entry_repository_impl.rs
+++ b/server/infra/resource/src/repository/form_repository_impls/answer_entry_repository_impl.rs
@@ -43,6 +43,39 @@ where
             .map_err(Into::into)
     }
 
+    #[tracing::instrument(skip(self, forms))]
+    async fn find_by_ids(
+        &self,
+        forms: &[Allowed<ActiveForm, Read>],
+        answer_ids: Vec<AnswerId>,
+    ) -> Result<Vec<Allowed<AnswerEntry, Read>>, Error> {
+        if forms.is_empty() || answer_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let entries = self
+            .client
+            .form_answer()
+            .get_answers_by_answer_ids(answer_ids)
+            .await?
+            .into_iter()
+            .map(TryInto::<AnswerEntry>::try_into)
+            .collect::<Result<Vec<_>, _>>()?;
+        let forms_by_id = forms
+            .iter()
+            .map(|form| (form.id().into_inner(), form))
+            .collect::<HashMap<_, _>>();
+
+        Ok(entries
+            .into_iter()
+            .filter_map(|entry| {
+                forms_by_id
+                    .get(&entry.form_id().into_inner())
+                    .and_then(|form| form.read_entry(entry).ok())
+            })
+            .collect())
+    }
+
     #[tracing::instrument(skip(self, form))]
     async fn list_by_form(
         &self,

--- a/server/presentation/src/handlers/search_handler.rs
+++ b/server/presentation/src/handlers/search_handler.rs
@@ -21,7 +21,9 @@ use usecase::search::SearchUseCase;
 use crate::schemas::error_responses::*;
 use crate::{
     handlers::error_handler::handle_error,
-    schemas::search_schemas::{CrossSearchResult, SearchQuery, UserSearchResult},
+    schemas::search_schemas::{
+        AnswerSearchResult, CrossSearchResult, SearchQuery, UserSearchResult,
+    },
 };
 
 #[derive(utoipa::IntoResponses)]
@@ -34,6 +36,12 @@ pub enum CrossSearchResponse {
 pub enum UserSearchResponse {
     #[response(status = 200, description = "The request has succeeded.")]
     Ok(UserSearchResult),
+}
+
+#[derive(utoipa::IntoResponses)]
+pub enum AnswerSearchResponse {
+    #[response(status = 200, description = "The request has succeeded.")]
+    Ok(AnswerSearchResult),
 }
 
 impl IntoResponse for CrossSearchResponse {
@@ -52,14 +60,24 @@ impl IntoResponse for UserSearchResponse {
     }
 }
 
-fn query_string(search_query: SearchQuery) -> Option<String> {
-    search_query.query.map(|query| query.into_inner())
+impl IntoResponse for AnswerSearchResponse {
+    fn into_response(self) -> Response {
+        match self {
+            Self::Ok(body) => (StatusCode::OK, Json(json!(body))).into_response(),
+        }
+    }
 }
 
-fn missing_query_response() -> Response {
-    handle_error(Error::from(PresentationError::QueryRejection {
-        cause: "query is required".to_string(),
-    }))
+fn required_query(query: Result<Query<SearchQuery>, QueryRejection>) -> Result<String, Error> {
+    let Query(search_query) = query.map_err_to_error()?;
+    search_query
+        .query
+        .map(|query| query.into_inner())
+        .ok_or_else(|| {
+            Error::from(PresentationError::QueryRejection {
+                cause: "query is required".to_string(),
+            })
+        })
 }
 
 #[utoipa::path(
@@ -94,10 +112,7 @@ pub async fn cross_search(
         comment_repository: repository.comment_repository(),
     };
 
-    let Query(search_query) = query.map_err_to_error().map_err(handle_error)?;
-    let Some(query) = query_string(search_query) else {
-        return Err(missing_query_response());
-    };
+    let query = required_query(query).map_err(handle_error)?;
 
     let result = search_use_case
         .cross_search(&user, query)
@@ -141,10 +156,7 @@ pub async fn search_users(
         comment_repository: repository.comment_repository(),
     };
 
-    let Query(search_query) = query.map_err_to_error().map_err(handle_error)?;
-    let Some(query) = query_string(search_query) else {
-        return Err(missing_query_response());
-    };
+    let query = required_query(query).map_err(handle_error)?;
 
     let users = search_use_case
         .search_users(&user, query)
@@ -154,6 +166,48 @@ pub async fn search_users(
     Ok(UserSearchResponse::Ok(UserSearchResult {
         users: users.into_iter().map(Into::into).collect(),
     }))
+}
+
+#[utoipa::path(
+    get,
+    path = "/search/answers",
+    summary = "回答検索を行う",
+    params(
+        ("query" = String, Query, description = "Search query"),
+    ),
+    responses(
+        AnswerSearchResponse,
+        BadRequest,
+        Unauthorized,
+        Forbidden,
+        InternalServerError,
+    ),
+    security(("bearer" = [])),
+    tag = "Search"
+)]
+pub async fn search_answers(
+    Extension(user): Extension<AccountUser>,
+    State(repository): State<RealInfrastructureRepository>,
+    query: Result<Query<SearchQuery>, QueryRejection>,
+) -> Result<AnswerSearchResponse, Response> {
+    let search_use_case = SearchUseCase {
+        search_repository: repository.search_repository(),
+        active_form_repository: repository.active_form_repository(),
+        form_answer_label_repository: repository.answer_label_repository(),
+        form_label_repository: repository.form_label_repository(),
+        user_repository: repository.user_repository(),
+        answer_entry_repository: repository.answer_entry_repository(),
+        comment_repository: repository.comment_repository(),
+    };
+
+    let query = required_query(query).map_err(handle_error)?;
+
+    let answers = search_use_case
+        .search_answers(&user, query)
+        .await
+        .map_err(handle_error)?;
+
+    Ok(AnswerSearchResponse::Ok(answers.into()))
 }
 
 pub async fn start_sync(

--- a/server/presentation/src/schemas/search_schemas.rs
+++ b/server/presentation/src/schemas/search_schemas.rs
@@ -1,7 +1,7 @@
 use domain::{auth::Actor, form::answer::AnswerId};
 use serde::{Deserialize, Serialize};
 use types::non_empty_string::NonEmptyString;
-use usecase::models::{CommentWithAuthor, CrossSearchOutput};
+use usecase::models::{AnswerDetails, CommentWithAuthor, CrossSearchOutput};
 
 use crate::schemas::{
     form::form_response_schemas::{
@@ -9,6 +9,17 @@ use crate::schemas::{
     },
     user::UserSchema,
 };
+
+impl From<AnswerDetails> for FormAnswer {
+    fn from(details: AnswerDetails) -> Self {
+        Self::new(
+            details.form_answer,
+            details.form_id,
+            details.author,
+            details.labels,
+        )
+    }
+}
 
 #[derive(Deserialize, Debug, PartialEq, utoipa::ToSchema)]
 pub struct SearchQuery {
@@ -52,18 +63,7 @@ impl CrossSearchResult {
                 .map(|details| FormSchema::from_active_form(actor, &details.form, details.labels))
                 .collect(),
             users: output.users.into_iter().map(Into::into).collect(),
-            answers: output
-                .answers
-                .into_iter()
-                .map(|details| {
-                    FormAnswer::new(
-                        details.form_answer,
-                        details.form_id,
-                        details.author,
-                        details.labels,
-                    )
-                })
-                .collect(),
+            answers: output.answers.into_iter().map(Into::into).collect(),
             label_for_forms: output.label_for_forms.into_iter().map(Into::into).collect(),
             label_for_answers: output
                 .label_for_answers
@@ -78,6 +78,19 @@ impl CrossSearchResult {
 #[derive(Serialize, Debug, utoipa::ToSchema)]
 pub struct UserSearchResult {
     pub users: Vec<UserSchema>,
+}
+
+#[derive(Serialize, Debug, utoipa::ToSchema)]
+pub struct AnswerSearchResult {
+    pub answers: Vec<FormAnswer>,
+}
+
+impl From<Vec<AnswerDetails>> for AnswerSearchResult {
+    fn from(answers: Vec<AnswerDetails>) -> Self {
+        Self {
+            answers: answers.into_iter().map(Into::into).collect(),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/server/usecase/src/search.rs
+++ b/server/usecase/src/search.rs
@@ -28,7 +28,7 @@ use domain::{
 };
 use errors::Error;
 use futures::{StreamExt, TryStreamExt, stream, try_join};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::{Notify, mpsc::Receiver};
@@ -98,7 +98,12 @@ impl<
     async fn visible_answer_entries_by_id(
         &self,
         actor: &Actor,
+        answer_ids: Vec<AnswerId>,
     ) -> Result<HashMap<AnswerId, Allowed<AnswerEntry, Read>>, Error> {
+        if answer_ids.is_empty() {
+            return Ok(HashMap::new());
+        }
+
         let readable_forms = self
             .list_all_form_guards()
             .await?
@@ -107,7 +112,8 @@ impl<
             .collect::<Vec<_>>();
 
         Ok(self
-            .list_all_answer_entries(&readable_forms)
+            .answer_entry_repository
+            .find_by_ids(&readable_forms, answer_ids)
             .await?
             .into_iter()
             .map(|answer| (*answer.id(), answer))
@@ -289,7 +295,10 @@ impl<
     ) -> Result<Vec<AnswerDetails>, Error> {
         let actor = Actor::from(account_user.clone());
         let hits = self.search_repository.search_answers(&query).await?;
-        let visible_answers_by_id = self.visible_answer_entries_by_id(&actor).await?;
+        let answer_ids = unique_answer_ids(hits.iter().map(|hit| hit.answer_id));
+        let visible_answers_by_id = self
+            .visible_answer_entries_by_id(&actor, answer_ids)
+            .await?;
 
         self.visible_answer_details(account_user, &actor, hits, &visible_answers_by_id)
             .await
@@ -311,6 +320,12 @@ impl<
         )?;
 
         let actor_ref = &actor;
+        let answer_ids = unique_answer_ids(
+            answers
+                .iter()
+                .map(|hit| hit.answer_id)
+                .chain(comments.iter().map(|hit| hit.answer_id)),
+        );
 
         let visible_forms = stream::iter(forms)
             .map(|form| async move { self.visible_form_with_labels(actor_ref, form.form_id).await })
@@ -359,7 +374,9 @@ impl<
             .try_collect()
             .await?;
 
-        let visible_answers_by_id = self.visible_answer_entries_by_id(actor_ref).await?;
+        let visible_answers_by_id = self
+            .visible_answer_entries_by_id(actor_ref, answer_ids)
+            .await?;
         let visible_answers = self
             .visible_answer_details(account_user, actor_ref, answers, &visible_answers_by_id)
             .await?;
@@ -646,6 +663,15 @@ impl<
     }
 }
 
+fn unique_answer_ids(answer_ids: impl IntoIterator<Item = AnswerId>) -> Vec<AnswerId> {
+    let mut seen = HashSet::new();
+
+    answer_ids
+        .into_iter()
+        .filter(|answer_id| seen.insert(*answer_id))
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -667,6 +693,7 @@ mod tests {
         },
         repository::{
             form::{
+                answer_entry_repository::MockAnswerEntryRepository,
                 answer_label_repository::MockAnswerLabelRepository,
                 comment_repository::MockCommentRepository,
             },
@@ -772,7 +799,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn search_answers_excludes_unreadable_hits_and_preserves_hit_order() {
+    async fn search_answers_excludes_unreadable_hits_and_preserves_hit_order_and_duplicates() {
         let member_group = UserGroup::new(UserGroupName::new(
             "members".to_string().try_into().unwrap(),
         ));
@@ -825,6 +852,9 @@ mod tests {
                         answer_id: visible_answer_b_id,
                     },
                     AnswerSearchHit {
+                        answer_id: visible_answer_b_id,
+                    },
+                    AnswerSearchHit {
                         answer_id: hidden_answer_id,
                     },
                     AnswerSearchHit {
@@ -838,16 +868,28 @@ mod tests {
         let mut answer_label_repository = MockAnswerLabelRepository::new();
         answer_label_repository
             .expect_get_labels_for_answers_by_answer_id()
-            .times(2)
+            .times(3)
             .returning(|_| Ok(vec![]));
         let form_label_repository = InMemoryFormLabelRepository;
         let user_repository = InMemoryUserRepository::default();
         user_repository.save_user(actor.clone());
-        let answer_entry_repository = InMemoryAnswerEntryRepository::new(vec![
-            visible_answer_a,
-            hidden_answer,
-            visible_answer_b,
-        ]);
+        let mut answer_entry_repository = MockAnswerEntryRepository::new();
+        answer_entry_repository
+            .expect_find_by_ids()
+            .withf(move |_, answer_ids| {
+                answer_ids == &vec![visible_answer_b_id, hidden_answer_id, visible_answer_a_id]
+            })
+            .return_once(move |forms, _| {
+                let form = forms
+                    .iter()
+                    .find(|form| form.id() == visible_answer_a.form_id())
+                    .unwrap();
+
+                Ok(vec![
+                    form.read_entry(visible_answer_a).unwrap(),
+                    form.read_entry(visible_answer_b).unwrap(),
+                ])
+            });
         let comment_repository = MockCommentRepository::new();
         let use_case = SearchUseCase {
             search_repository: &search_repository,
@@ -868,7 +910,14 @@ mod tests {
             .iter()
             .map(|answer| *answer.form_answer.id())
             .collect::<Vec<_>>();
-        assert_eq!(answer_ids, vec![visible_answer_b_id, visible_answer_a_id]);
+        assert_eq!(
+            answer_ids,
+            vec![
+                visible_answer_b_id,
+                visible_answer_b_id,
+                visible_answer_a_id
+            ]
+        );
     }
 
     #[tokio::test]
@@ -1037,7 +1086,12 @@ mod tests {
             .returning(|_| Ok(vec![]));
         search_repository
             .expect_search_answers()
-            .returning(|_| Ok(vec![]));
+            .returning(move |_| {
+                Ok(vec![
+                    AnswerSearchHit { answer_id },
+                    AnswerSearchHit { answer_id },
+                ])
+            });
         search_repository
             .expect_search_comments()
             .returning(move |_| {
@@ -1058,11 +1112,25 @@ mod tests {
             });
 
         let active_form_repository = InMemoryActiveFormRepository::new(vec![form]);
-        let answer_label_repository = MockAnswerLabelRepository::new();
+        let mut answer_label_repository = MockAnswerLabelRepository::new();
+        answer_label_repository
+            .expect_get_labels_for_answers_by_answer_id()
+            .times(2)
+            .returning(|_| Ok(vec![]));
         let form_label_repository = InMemoryFormLabelRepository;
         let user_repository = InMemoryUserRepository::default();
         user_repository.save_user(actor.clone());
-        let answer_entry_repository = InMemoryAnswerEntryRepository::new(vec![answer]);
+        let mut answer_entry_repository = MockAnswerEntryRepository::new();
+        answer_entry_repository
+            .expect_find_by_ids()
+            .withf(move |_, answer_ids| answer_ids == &vec![answer_id])
+            .return_once(move |forms, _| {
+                let form = forms
+                    .iter()
+                    .find(|form| form.id() == answer.form_id())
+                    .unwrap();
+                Ok(vec![form.read_entry(answer).unwrap()])
+            });
         let stored_comments = vec![first_comment, missing_author_comment, second_comment];
         let mut comment_repository = MockCommentRepository::new();
         comment_repository
@@ -1088,6 +1156,13 @@ mod tests {
             .cross_search(&actor, "comment".to_string())
             .await
             .unwrap();
+
+        let answer_ids = output
+            .answers
+            .iter()
+            .map(|answer| *answer.form_answer.id())
+            .collect::<Vec<_>>();
+        assert_eq!(answer_ids, vec![answer_id, answer_id]);
 
         let comment_ids = output
             .comments

--- a/server/usecase/src/search.rs
+++ b/server/usecase/src/search.rs
@@ -8,7 +8,9 @@ use domain::repository::form::comment_repository::CommentRepository;
 use domain::repository::form::form_label_repository::FormLabelRepository;
 use domain::repository::user_repository::UserRepository;
 use domain::search::models::NumberOfRecords;
-use domain::search::models::{NumberOfRecordsPerAggregate, Operation, UserSearchHit};
+use domain::search::models::{
+    AnswerSearchHit, NumberOfRecordsPerAggregate, Operation, UserSearchHit,
+};
 use domain::{
     account::models::AccountUser,
     auth::Actor,
@@ -63,19 +65,6 @@ impl<
     R7: CommentRepository,
 > SearchUseCase<'_, R1, R2, R3, R4, R5, R6, R7>
 {
-    /// 認可済みの `answer_entries` から `answer_id` の回答を探して返す。回答の公開範囲は
-    /// `answer_entries` を取得した時点で各フォームの読み取りガードが検証済みのため、ここでは
-    /// 同一性の照合だけを行う。
-    fn read_visible_answer(
-        answer_entries: &[Allowed<AnswerEntry, Read>],
-        answer_id: AnswerId,
-    ) -> Option<Allowed<AnswerEntry, Read>> {
-        answer_entries
-            .iter()
-            .find(|entry| *entry.value().id() == answer_id)
-            .cloned()
-    }
-
     async fn list_all_form_guards(
         &self,
     ) -> Result<Vec<AuthorizationGuard<ActiveForm, Read>>, Error> {
@@ -104,6 +93,25 @@ impl<
         }
 
         Ok(answers)
+    }
+
+    async fn visible_answer_entries_by_id(
+        &self,
+        actor: &Actor,
+    ) -> Result<HashMap<AnswerId, Allowed<AnswerEntry, Read>>, Error> {
+        let readable_forms = self
+            .list_all_form_guards()
+            .await?
+            .into_iter()
+            .filter_map(|form| form.try_read(actor.clone()).ok())
+            .collect::<Vec<_>>();
+
+        Ok(self
+            .list_all_answer_entries(&readable_forms)
+            .await?
+            .into_iter()
+            .map(|answer| (*answer.id(), answer))
+            .collect())
     }
 
     async fn visible_users(
@@ -213,6 +221,27 @@ impl<
         }))
     }
 
+    async fn visible_answer_details(
+        &self,
+        account_user: &AccountUser,
+        actor: &Actor,
+        hits: Vec<AnswerSearchHit>,
+        visible_answers_by_id: &HashMap<AnswerId, Allowed<AnswerEntry, Read>>,
+    ) -> Result<Vec<AnswerDetails>, Error> {
+        stream::iter(hits)
+            .map(|hit| async move {
+                let Some(answer) = visible_answers_by_id.get(&hit.answer_id).cloned() else {
+                    return Ok::<_, Error>(None);
+                };
+
+                self.answer_details(account_user, actor, answer).await
+            })
+            .buffered(SEARCH_DETAIL_FETCH_CONCURRENCY)
+            .try_filter_map(|visible| std::future::ready(Ok(visible)))
+            .try_collect()
+            .await
+    }
+
     async fn comments_with_authors(
         &self,
         account_user: &AccountUser,
@@ -251,6 +280,19 @@ impl<
         let users = self.search_repository.search_users(&query).await?;
 
         self.visible_users(&actor, users).await
+    }
+
+    pub async fn search_answers(
+        &self,
+        account_user: &AccountUser,
+        query: String,
+    ) -> Result<Vec<AnswerDetails>, Error> {
+        let actor = Actor::from(account_user.clone());
+        let hits = self.search_repository.search_answers(&query).await?;
+        let visible_answers_by_id = self.visible_answer_entries_by_id(&actor).await?;
+
+        self.visible_answer_details(account_user, &actor, hits, &visible_answers_by_id)
+            .await
     }
 
     pub async fn cross_search(
@@ -317,38 +359,17 @@ impl<
             .try_collect()
             .await?;
 
-        let readable_forms = self
-            .list_all_form_guards()
-            .await?
-            .into_iter()
-            .filter_map(|form| form.try_read(actor_ref.clone()).ok())
-            .collect::<Vec<_>>();
-        let answer_entries = self.list_all_answer_entries(&readable_forms).await?;
-
-        let visible_answers = stream::iter(answers)
-            .map(|entry| {
-                let answer_entries = &answer_entries;
-
-                async move {
-                    let Some(answer) = Self::read_visible_answer(answer_entries, entry.answer_id)
-                    else {
-                        return Ok::<_, Error>(None);
-                    };
-
-                    self.answer_details(account_user, actor_ref, answer).await
-                }
-            })
-            .buffered(SEARCH_DETAIL_FETCH_CONCURRENCY)
-            .try_filter_map(|visible| std::future::ready(Ok(visible)))
-            .try_collect()
+        let visible_answers_by_id = self.visible_answer_entries_by_id(actor_ref).await?;
+        let visible_answers = self
+            .visible_answer_details(account_user, actor_ref, answers, &visible_answers_by_id)
             .await?;
 
         let visible_comments: Vec<Comment> = stream::iter(comments)
             .map(|comment| {
-                let answer_entries = &answer_entries;
+                let visible_answers_by_id = &visible_answers_by_id;
 
                 async move {
-                    let Some(answer) = Self::read_visible_answer(answer_entries, comment.answer_id)
+                    let Some(answer) = visible_answers_by_id.get(&comment.answer_id).cloned()
                     else {
                         return Ok::<_, Error>(None);
                     };
@@ -748,6 +769,106 @@ mod tests {
 
         assert_eq!(output.forms.len(), 1);
         assert_eq!(*output.forms[0].form.id(), readable_form_id);
+    }
+
+    #[tokio::test]
+    async fn search_answers_excludes_unreadable_hits_and_preserves_hit_order() {
+        let member_group = UserGroup::new(UserGroupName::new(
+            "members".to_string().try_into().unwrap(),
+        ));
+        let other_group =
+            UserGroup::new(UserGroupName::new("other".to_string().try_into().unwrap()));
+        let actor = AccountUser::with_groups(
+            "viewer".to_string(),
+            Uuid::from_u128(20).into(),
+            Role::StandardUser,
+            vec![member_group.clone()],
+        );
+        let readable_form = form_restricted_to("readable answers", &member_group)
+            .change_answer_settings(
+                AnswerSettings::default().change_visibility(AnswerVisibility::PUBLIC),
+            );
+        let hidden_form = form_restricted_to("hidden answers", &other_group)
+            .change_answer_settings(
+                AnswerSettings::default().change_visibility(AnswerVisibility::PUBLIC),
+            );
+        let answer_for = |form: &ActiveForm| {
+            let question_id = *form.questions().as_slice()[0].id();
+            AnswerEntry::new(
+                *form.id(),
+                AnswerAuthor::AuthenticatedUser(*actor.id()),
+                AnswerTitle::default(),
+                PostedAnswerContents::try_new(
+                    form.questions().as_slice(),
+                    vec![FormAnswerContent {
+                        id: FormAnswerContentId::from(Uuid::new_v4()),
+                        question_id: question_id.into(),
+                        answer: "body".to_string(),
+                    }],
+                )
+                .unwrap(),
+            )
+        };
+        let visible_answer_a = answer_for(&readable_form);
+        let visible_answer_b = answer_for(&readable_form);
+        let hidden_answer = answer_for(&hidden_form);
+        let visible_answer_a_id = *visible_answer_a.id();
+        let visible_answer_b_id = *visible_answer_b.id();
+        let hidden_answer_id = *hidden_answer.id();
+
+        let mut search_repository = MockSearchRepository::new();
+        search_repository
+            .expect_search_answers()
+            .returning(move |_| {
+                Ok(vec![
+                    AnswerSearchHit {
+                        answer_id: visible_answer_b_id,
+                    },
+                    AnswerSearchHit {
+                        answer_id: hidden_answer_id,
+                    },
+                    AnswerSearchHit {
+                        answer_id: visible_answer_a_id,
+                    },
+                ])
+            });
+
+        let active_form_repository =
+            InMemoryActiveFormRepository::new(vec![readable_form, hidden_form]);
+        let mut answer_label_repository = MockAnswerLabelRepository::new();
+        answer_label_repository
+            .expect_get_labels_for_answers_by_answer_id()
+            .times(2)
+            .returning(|_| Ok(vec![]));
+        let form_label_repository = InMemoryFormLabelRepository;
+        let user_repository = InMemoryUserRepository::default();
+        user_repository.save_user(actor.clone());
+        let answer_entry_repository = InMemoryAnswerEntryRepository::new(vec![
+            visible_answer_a,
+            hidden_answer,
+            visible_answer_b,
+        ]);
+        let comment_repository = MockCommentRepository::new();
+        let use_case = SearchUseCase {
+            search_repository: &search_repository,
+            active_form_repository: &active_form_repository,
+            form_answer_label_repository: &answer_label_repository,
+            form_label_repository: &form_label_repository,
+            user_repository: &user_repository,
+            answer_entry_repository: &answer_entry_repository,
+            comment_repository: &comment_repository,
+        };
+
+        let answers = use_case
+            .search_answers(&actor, "answer".to_string())
+            .await
+            .unwrap();
+
+        let answer_ids = answers
+            .iter()
+            .map(|answer| *answer.form_answer.id())
+            .collect::<Vec<_>>();
+        assert_eq!(answer_ids, vec![visible_answer_b_id, visible_answer_a_id]);
     }
 
     #[tokio::test]

--- a/server/usecase/src/test_utils/repositories.rs
+++ b/server/usecase/src/test_utils/repositories.rs
@@ -30,7 +30,7 @@ use domain::{
     types::authorization_guard::{Allowed, AuthorizationGuard, Create, Delete, Read, Update},
 };
 use errors::Error;
-use std::sync::Mutex;
+use std::{collections::HashMap, sync::Mutex};
 use uuid::Uuid;
 
 use crate::forms::form::FormUseCase;
@@ -277,6 +277,31 @@ impl AnswerEntryRepository for InMemoryAnswerEntryRepository {
             .cloned()
             .map(|answer| _form.read_entry(answer))
             .transpose()?)
+    }
+
+    async fn find_by_ids(
+        &self,
+        forms: &[Allowed<ActiveForm, Read>],
+        answer_ids: Vec<AnswerId>,
+    ) -> Result<Vec<Allowed<AnswerEntry, Read>>, Error> {
+        let forms_by_id = forms
+            .iter()
+            .map(|form| (form.id().into_inner(), form))
+            .collect::<HashMap<_, _>>();
+
+        Ok(self
+            .answers
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|answer| answer_ids.contains(answer.id()))
+            .cloned()
+            .filter_map(|answer| {
+                forms_by_id
+                    .get(&answer.form_id().into_inner())
+                    .and_then(|form| form.read_entry(answer).ok())
+            })
+            .collect())
     }
 
     async fn list_by_form(


### PR DESCRIPTION
## 概要
- 認証済みユーザー向けに `GET /api/v1/search/answers?query=...` を追加
- 回答タイトルまたは本文に一致し、閲覧権限がある回答だけを既存の `FormAnswer` 形式で返却
- 横断検索と回答検索の詳細取得処理を共通化し、回答 ID の照合を `HashMap` に変更

## 確認事項
- `makers pretty` が成功し、nextest 137 件、doc test、Clippy、format がすべて通ることを確認
- `cargo build` と `cargo test --all-features` が成功することを確認
- OpenAPI 文書を再生成し、連続して生成しても内容が変わらないことを確認
- SQL と typed query は変更していないため、`cargo sqlx prepare --workspace` は未実行

🤖 Generated with Codex