### PR TITLE
フォーム操作をグローバルWebhookへ通知する

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,8 @@ MEILISEARCH_HOST=http://localhost:7700
 # MEILISEARCH_API_KEY=
 
 DISCORD_BOT_TOKEN=aaaaaaaaaaaaaa
+# 管理用の操作通知を送る場合に設定します。未設定の場合は通知しません。
+# DISCORD_GLOBAL_WEBHOOK_URL=https://discord.com/api/webhooks/webhook-id/webhook-token
 
 RABBITMQ_USER=user
 RABBITMQ_PASSWORD=password

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2887,6 +2887,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tower",
  "tracing",
  "types",
  "usecase",

--- a/server/entrypoint/src/main.rs
+++ b/server/entrypoint/src/main.rs
@@ -17,6 +17,9 @@ use futures::join;
 use hyper::header::SET_COOKIE;
 use presentation::api::notificator_impl::DiscordNotificator;
 use presentation::auth::{auth, optional_auth};
+use presentation::form_operation_notification::{
+    FormOperationNotificationState, notify_successful_form_operation,
+};
 use presentation::handlers::form::message_handler::{
     RealInfrastructureRepositoryWithNotificator, post_message_handler,
 };
@@ -47,6 +50,10 @@ async fn main() -> anyhow::Result<()> {
             )),
         )
         .init();
+
+    let global_webhook_url = resource::outgoing::load_discord_global_webhook_url()?;
+    let form_operation_notification_state =
+        FormOperationNotificationState::new(global_webhook_url, ENV.name.to_owned());
 
     let _guard = if ENV.name != "local" {
         let _guard = sentry::init((
@@ -99,6 +106,15 @@ async fn main() -> anyhow::Result<()> {
         .with_state(shared_repository.to_owned())
         .split_for_parts();
 
+    let (public_form_mutation_api, _) = openapi::public_form_mutation_api_router()
+        .with_state(shared_repository.to_owned())
+        .split_for_parts();
+    let public_form_mutation_api =
+        public_form_mutation_api.route_layer(middleware::from_fn_with_state(
+            form_operation_notification_state.clone(),
+            notify_successful_form_operation,
+        ));
+
     let (optional_auth_api, _) = openapi::optional_auth_api_router()
         .with_state(shared_repository.to_owned())
         .split_for_parts();
@@ -110,10 +126,22 @@ async fn main() -> anyhow::Result<()> {
     let (authenticated_api, _) = openapi::authenticated_api_router()
         .with_state(shared_repository.to_owned())
         .split_for_parts();
-    let authenticated_api = authenticated_api.route_layer(middleware::from_fn_with_state(
-        shared_repository.to_owned(),
-        auth,
-    ));
+    let (authenticated_form_mutation_api, _) = openapi::authenticated_form_mutation_api_router()
+        .with_state(shared_repository.to_owned())
+        .split_for_parts();
+    let authenticated_form_mutation_api =
+        authenticated_form_mutation_api.route_layer(middleware::from_fn_with_state(
+            form_operation_notification_state.clone(),
+            notify_successful_form_operation,
+        ));
+    // Axum では後から追加した layer が外側になるため、認証を通知より後に追加する。
+    // これによりリクエストは auth -> notification -> handler の順に通る。
+    let authenticated_api = authenticated_api
+        .merge(authenticated_form_mutation_api)
+        .route_layer(middleware::from_fn_with_state(
+            shared_repository.to_owned(),
+            auth,
+        ));
 
     // post_message_handler uses a different State type, so register it separately
     let message_post_router = Router::new()
@@ -121,6 +149,10 @@ async fn main() -> anyhow::Result<()> {
             "/forms/{form_id}/answers/{answer_id}/messages",
             post(post_message_handler),
         )
+        .route_layer(middleware::from_fn_with_state(
+            form_operation_notification_state,
+            notify_successful_form_operation,
+        ))
         .route_layer(middleware::from_fn_with_state(
             shared_repository.to_owned(),
             auth,
@@ -136,6 +168,7 @@ async fn main() -> anyhow::Result<()> {
         .nest(
             "/api/v1",
             public_api
+                .merge(public_form_mutation_api)
                 .merge(optional_auth_api)
                 .merge(authenticated_api)
                 .merge(message_post_router),

--- a/server/entrypoint/src/openapi.rs
+++ b/server/entrypoint/src/openapi.rs
@@ -95,14 +95,16 @@ impl Modify for SecurityAddon {
 }
 
 pub fn public_api_router() -> OpenApiRouter<RealInfrastructureRepository> {
+    OpenApiRouter::new().routes(routes!(
+        user_handler::start_session,
+        user_handler::end_session
+    ))
+}
+
+pub fn public_form_mutation_api_router() -> OpenApiRouter<RealInfrastructureRepository> {
     use presentation::handlers::form::answer_handler;
 
-    OpenApiRouter::new()
-        .routes(routes!(answer_handler::post_temporary_answer_handler))
-        .routes(routes!(
-            user_handler::start_session,
-            user_handler::end_session
-        ))
+    OpenApiRouter::new().routes(routes!(answer_handler::post_temporary_answer_handler))
 }
 
 pub fn optional_auth_api_router() -> OpenApiRouter<RealInfrastructureRepository> {
@@ -120,47 +122,15 @@ pub fn authenticated_api_router() -> OpenApiRouter<RealInfrastructureRepository>
     };
 
     OpenApiRouter::new()
-        .routes(routes!(form_handler::create_form_handler))
-        .routes(routes!(form_handler::update_form_handler))
-        .routes(routes!(form_handler::archive_form_handler))
         .routes(routes!(form_handler::archived_form_list_handler))
         .routes(routes!(form_handler::get_archived_form_handler))
-        .routes(routes!(form_handler::restore_archived_form_handler))
-        .routes(routes!(
-            answer_handler::get_answer_by_form_id_handler,
-            answer_handler::post_answer_handler
-        ))
+        .routes(routes!(answer_handler::get_answer_by_form_id_handler))
         .routes(routes!(answer_handler::get_all_answers))
-        .routes(routes!(
-            answer_label_handler::get_labels_for_answers,
-            answer_label_handler::create_label_for_answers
-        ))
-        .routes(routes!(
-            answer_label_handler::delete_label_for_answers,
-            answer_label_handler::edit_label_for_answers
-        ))
-        .routes(routes!(
-            form_label_handler::get_labels_for_forms,
-            form_label_handler::create_label_for_forms
-        ))
-        .routes(routes!(
-            form_label_handler::delete_label_for_forms,
-            form_label_handler::edit_label_for_forms
-        ))
-        .routes(routes!(
-            answer_handler::get_answer_handler,
-            answer_handler::update_answer_handler
-        ))
-        .routes(routes!(answer_label_handler::replace_answer_labels))
-        .routes(routes!(
-            comment_handler::get_form_comment,
-            comment_handler::post_form_comment
-        ))
+        .routes(routes!(answer_label_handler::get_labels_for_answers))
+        .routes(routes!(form_label_handler::get_labels_for_forms))
+        .routes(routes!(answer_handler::get_answer_handler))
+        .routes(routes!(comment_handler::get_form_comment))
         .routes(routes!(comment_handler::get_comment_history))
-        .routes(routes!(
-            comment_handler::update_form_comment,
-            comment_handler::delete_form_comment_handler
-        ))
         .routes(routes!(
             user_handler::get_user_info,
             user_handler::patch_user_role
@@ -193,10 +163,6 @@ pub fn authenticated_api_router() -> OpenApiRouter<RealInfrastructureRepository>
         .routes(routes!(search_handler::search_answers))
         .routes(routes!(message_handler::get_messages_handler))
         .routes(routes!(message_handler::get_message_history))
-        .routes(routes!(
-            message_handler::update_message_handler,
-            message_handler::delete_message_handler
-        ))
         .routes(routes!(notification_handler::get_notification_settings))
         .routes(routes!(
             notification_handler::get_my_notification_settings,
@@ -208,14 +174,113 @@ pub fn authenticated_api_router() -> OpenApiRouter<RealInfrastructureRepository>
         ))
 }
 
+pub fn authenticated_form_mutation_api_router() -> OpenApiRouter<RealInfrastructureRepository> {
+    use presentation::handlers::form::{
+        answer_handler, answer_label_handler, comment_handler, form_handler, form_label_handler,
+        message_handler,
+    };
+
+    OpenApiRouter::new()
+        .routes(routes!(form_handler::create_form_handler))
+        .routes(routes!(form_handler::update_form_handler))
+        .routes(routes!(form_handler::archive_form_handler))
+        .routes(routes!(form_handler::restore_archived_form_handler))
+        .routes(routes!(answer_handler::post_answer_handler))
+        .routes(routes!(answer_handler::update_answer_handler))
+        .routes(routes!(answer_label_handler::create_label_for_answers))
+        .routes(routes!(answer_label_handler::delete_label_for_answers))
+        .routes(routes!(answer_label_handler::edit_label_for_answers))
+        .routes(routes!(answer_label_handler::replace_answer_labels))
+        .routes(routes!(form_label_handler::create_label_for_forms))
+        .routes(routes!(form_label_handler::delete_label_for_forms))
+        .routes(routes!(form_label_handler::edit_label_for_forms))
+        .routes(routes!(comment_handler::post_form_comment))
+        .routes(routes!(comment_handler::update_form_comment))
+        .routes(routes!(comment_handler::delete_form_comment_handler))
+        .routes(routes!(message_handler::update_message_handler))
+        .routes(routes!(message_handler::delete_message_handler))
+}
+
 pub fn versioned_api_router() -> OpenApiRouter<RealInfrastructureRepository> {
     let combined = OpenApiRouter::with_openapi(ManuallyRegisteredApiDoc::openapi())
         .merge(public_api_router())
+        .merge(public_form_mutation_api_router())
         .merge(optional_auth_api_router())
-        .merge(authenticated_api_router());
+        .merge(authenticated_api_router())
+        .merge(authenticated_form_mutation_api_router());
     OpenApiRouter::with_openapi(ApiMetadata::openapi()).nest("/api/v1", combined)
 }
 
 pub fn openapi() -> utoipa::openapi::OpenApi {
     versioned_api_router().into_openapi()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use utoipa::openapi::{OpenApi, path::PathItem};
+
+    use super::{authenticated_form_mutation_api_router, public_form_mutation_api_router};
+
+    fn operations(openapi: OpenApi) -> BTreeSet<String> {
+        openapi
+            .paths
+            .paths
+            .into_iter()
+            .flat_map(|(path, item)| operations_for_path(path, item))
+            .collect()
+    }
+
+    fn operations_for_path(path: String, item: PathItem) -> Vec<String> {
+        [
+            ("POST", item.post),
+            ("PUT", item.put),
+            ("PATCH", item.patch),
+            ("DELETE", item.delete),
+        ]
+        .into_iter()
+        .filter_map(|(method, operation)| operation.map(|_| format!("{method} {path}")))
+        .collect()
+    }
+
+    #[test]
+    fn public_form_mutation_router_contains_only_temporary_answer_submission() {
+        assert_eq!(
+            operations(public_form_mutation_api_router().into_openapi()),
+            BTreeSet::from(["POST /forms/{id}/temporary-answers".to_string()])
+        );
+    }
+
+    #[test]
+    fn authenticated_form_mutation_router_contains_all_repository_state_mutations() {
+        let expected = [
+            "DELETE /forms/{form_id}/answers/{answer_id}/comments/{comment_id}",
+            "DELETE /forms/{form_id}/answers/{answer_id}/messages/{message_id}",
+            "DELETE /labels/answers/{label_id}",
+            "DELETE /labels/forms/{label_id}",
+            "PATCH /forms/{form_id}/answers/{answer_id}",
+            "PATCH /forms/{form_id}/answers/{answer_id}/comments/{comment_id}",
+            "PATCH /forms/{form_id}/answers/{answer_id}/messages/{message_id}",
+            "PATCH /labels/answers/{label_id}",
+            "PATCH /labels/forms/{label_id}",
+            "POST /archived-forms/{id}/restore",
+            "POST /forms",
+            "POST /forms/{form_id}/answers/{answer_id}/comments",
+            "POST /forms/{id}/answers",
+            "POST /forms/{id}/archive",
+            "POST /labels/answers",
+            "POST /labels/forms",
+            "PUT /forms/answers/{answer_id}/labels",
+            "PUT /forms/{id}",
+        ]
+        .map(str::to_string)
+        .into_iter()
+        .collect();
+
+        assert_eq!(
+            operations(authenticated_form_mutation_api_router().into_openapi()),
+            expected
+        );
+    }
 }

--- a/server/infra/resource/src/outgoing.rs
+++ b/server/infra/resource/src/outgoing.rs
@@ -2,3 +2,5 @@ mod config;
 pub mod connection;
 pub mod discord_sender_impl;
 pub mod discord_webhook_sender;
+
+pub use config::{DiscordGlobalWebhookUrl, load_discord_global_webhook_url};

--- a/server/infra/resource/src/outgoing/config.rs
+++ b/server/infra/resource/src/outgoing/config.rs
@@ -1,5 +1,7 @@
 use std::sync::LazyLock;
 
+use anyhow::{Context, Result, bail};
+use reqwest::Url;
 use serde::Deserialize;
 
 #[derive(Deserialize, Debug)]
@@ -9,3 +11,95 @@ pub struct Discord {
 
 pub static DISCORD_BOT: LazyLock<Discord> =
     LazyLock::new(|| envy::prefixed("DISCORD_").from_env::<Discord>().unwrap());
+
+#[derive(Clone)]
+pub struct DiscordGlobalWebhookUrl(String);
+
+impl DiscordGlobalWebhookUrl {
+    pub fn into_inner(self) -> String {
+        self.0
+    }
+}
+
+impl std::fmt::Debug for DiscordGlobalWebhookUrl {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("DiscordGlobalWebhookUrl([REDACTED])")
+    }
+}
+
+pub fn load_discord_global_webhook_url() -> Result<Option<DiscordGlobalWebhookUrl>> {
+    let value = match std::env::var("DISCORD_GLOBAL_WEBHOOK_URL") {
+        Ok(value) => value,
+        Err(std::env::VarError::NotPresent) => return Ok(None),
+        Err(error) => return Err(error).context("DISCORD_GLOBAL_WEBHOOK_URL could not be read"),
+    };
+
+    parse_discord_global_webhook_url(value).map(Some)
+}
+
+fn parse_discord_global_webhook_url(value: String) -> Result<DiscordGlobalWebhookUrl> {
+    if value.trim().is_empty() {
+        bail!("DISCORD_GLOBAL_WEBHOOK_URL must not be empty when set");
+    }
+
+    let url = Url::parse(&value).context("DISCORD_GLOBAL_WEBHOOK_URL must be a valid URL")?;
+    let path_segments = url
+        .path_segments()
+        .map(|segments| segments.collect::<Vec<_>>())
+        .unwrap_or_default();
+    let is_discord_webhook = url.scheme() == "https"
+        && matches!(url.host_str(), Some("discord.com") | Some("discordapp.com"))
+        && url.port().is_none()
+        && url.username().is_empty()
+        && url.password().is_none()
+        && url.query().is_none()
+        && url.fragment().is_none()
+        && matches!(path_segments.as_slice(), ["api", "webhooks", id, token] if !id.is_empty() && !token.is_empty());
+
+    if !is_discord_webhook {
+        bail!("DISCORD_GLOBAL_WEBHOOK_URL must be a Discord webhook URL");
+    }
+
+    Ok(DiscordGlobalWebhookUrl(value))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DiscordGlobalWebhookUrl, parse_discord_global_webhook_url};
+
+    #[test]
+    fn global_webhook_url_debug_output_is_redacted() {
+        let url = DiscordGlobalWebhookUrl(
+            "https://discord.com/api/webhooks/123/sensitive-token".to_string(),
+        );
+
+        let output = format!("{url:?}");
+
+        assert!(!output.contains("sensitive-token"));
+        assert_eq!(output, "DiscordGlobalWebhookUrl([REDACTED])");
+    }
+
+    #[test]
+    fn accepts_discord_webhook_url() {
+        assert!(
+            parse_discord_global_webhook_url(
+                "https://discord.com/api/webhooks/123/token".to_string()
+            )
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn rejects_empty_or_non_discord_url() {
+        for value in [
+            "",
+            "   ",
+            "http://discord.com/api/webhooks/123/token",
+            "https://example.com/api/webhooks/123/token",
+            "https://discord.com/api/webhooks/123/token/extra",
+            "https://discord.com/api/webhooks/123/token?wait=true",
+        ] {
+            assert!(parse_discord_global_webhook_url(value.to_string()).is_err());
+        }
+    }
+}

--- a/server/infra/resource/src/outgoing/discord_webhook_sender.rs
+++ b/server/infra/resource/src/outgoing/discord_webhook_sender.rs
@@ -28,11 +28,11 @@ impl DiscordWebhookField {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct DiscordWebhookMessage {
     pub discord_webhook_url: String,
     pub title: String,
-    pub link_url: String,
+    pub link_url: Option<String>,
     pub fields: Vec<DiscordWebhookField>,
 }
 
@@ -75,7 +75,7 @@ impl DiscordWebhookSender {
             .json(&request)
             .send()
             .await
-            .map_err(|error| DiscordWebhookSendError::Retryable(error.into()))?;
+            .map_err(|_| DiscordWebhookSendError::Retryable(request_error()))?;
         let status = response.status();
 
         match status {
@@ -125,6 +125,12 @@ fn status_error(status: StatusCode) -> InfraError {
     }
 }
 
+fn request_error() -> InfraError {
+    InfraError::Outgoing {
+        cause: "Discord webhook request failed".to_string(),
+    }
+}
+
 #[derive(Serialize)]
 struct DiscordWebhookRequest {
     username: String,
@@ -134,7 +140,8 @@ struct DiscordWebhookRequest {
 #[derive(Serialize)]
 struct DiscordEmbed {
     title: String,
-    url: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    url: Option<String>,
     color: i32,
     fields: Vec<DiscordEmbedField>,
 }

--- a/server/presentation/Cargo.toml
+++ b/server/presentation/Cargo.toml
@@ -24,3 +24,6 @@ base64 = { workspace = true }
 futures = { workspace = true }
 utoipa = { workspace = true }
 utoipa-axum = { workspace = true }
+
+[dev-dependencies]
+tower = "0.5.3"

--- a/server/presentation/src/form_operation_notification.rs
+++ b/server/presentation/src/form_operation_notification.rs
@@ -1,0 +1,266 @@
+use std::sync::Arc;
+
+use axum::{
+    body::Body,
+    extract::State,
+    http::{Method, Request, StatusCode},
+    middleware::Next,
+    response::Response,
+};
+use domain::account::models::AccountUser;
+use resource::outgoing::{
+    DiscordGlobalWebhookUrl,
+    discord_webhook_sender::{DiscordWebhookField, DiscordWebhookMessage, DiscordWebhookSender},
+};
+use tracing::warn;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FormOperationNotification {
+    method: Method,
+    path: String,
+    status: StatusCode,
+    environment: String,
+    requester: Requester,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum Requester {
+    Authenticated {
+        user_id: String,
+        display_name: String,
+    },
+    Anonymous,
+}
+
+trait FormOperationNotifier: Send + Sync {
+    fn notify(&self, notification: FormOperationNotification);
+}
+
+#[derive(Clone)]
+pub struct FormOperationNotificationState {
+    notifier: Arc<dyn FormOperationNotifier>,
+    environment: String,
+}
+
+impl FormOperationNotificationState {
+    pub fn new(webhook_url: Option<DiscordGlobalWebhookUrl>, environment: String) -> Self {
+        Self {
+            notifier: Arc::new(DiscordFormOperationNotifier {
+                webhook_url,
+                sender: DiscordWebhookSender::new(),
+            }),
+            environment,
+        }
+    }
+
+    #[cfg(test)]
+    fn with_notifier(
+        notifier: Arc<dyn FormOperationNotifier>,
+        environment: impl Into<String>,
+    ) -> Self {
+        Self {
+            notifier,
+            environment: environment.into(),
+        }
+    }
+}
+
+pub async fn notify_successful_form_operation(
+    State(state): State<FormOperationNotificationState>,
+    request: Request<Body>,
+    next: Next,
+) -> Response {
+    let method = request.method().clone();
+    let path = request.uri().path().to_string();
+    let requester = request
+        .extensions()
+        .get::<AccountUser>()
+        .map(|user| Requester::Authenticated {
+            user_id: user.id().to_string(),
+            display_name: user.name().to_owned(),
+        })
+        .unwrap_or(Requester::Anonymous);
+
+    let response = next.run(request).await;
+
+    if response.status().is_success() {
+        state.notifier.notify(FormOperationNotification {
+            method,
+            path,
+            status: response.status(),
+            environment: state.environment,
+            requester,
+        });
+    }
+
+    response
+}
+
+struct DiscordFormOperationNotifier {
+    webhook_url: Option<DiscordGlobalWebhookUrl>,
+    sender: DiscordWebhookSender,
+}
+
+impl FormOperationNotifier for DiscordFormOperationNotifier {
+    fn notify(&self, notification: FormOperationNotification) {
+        let Some(discord_webhook_url) = self.webhook_url.clone() else {
+            return;
+        };
+        let sender = self.sender.clone();
+
+        tokio::spawn(async move {
+            let attempts = DiscordWebhookSender::retry_policy().max_attempts();
+            let message = DiscordWebhookMessage {
+                discord_webhook_url: discord_webhook_url.into_inner(),
+                title: "フォーム操作が完了しました".to_string(),
+                link_url: None,
+                fields: notification.into_fields(),
+            };
+
+            if let Err(error) = sender.send_with_retry(message).await {
+                warn!(
+                    attempts,
+                    error = %error,
+                    "failed to send global Discord webhook after retries"
+                );
+            }
+        });
+    }
+}
+
+impl FormOperationNotification {
+    fn into_fields(self) -> Vec<DiscordWebhookField> {
+        let operation_fields = [
+            DiscordWebhookField::new("Method".to_string(), self.method.to_string(), true),
+            DiscordWebhookField::new("Path".to_string(), self.path, false),
+            DiscordWebhookField::new("Status".to_string(), self.status.as_u16().to_string(), true),
+            DiscordWebhookField::new("Environment".to_string(), self.environment, true),
+        ];
+
+        let requester_fields = match self.requester {
+            Requester::Authenticated {
+                user_id,
+                display_name,
+            } => vec![
+                DiscordWebhookField::new("User ID".to_string(), user_id, true),
+                DiscordWebhookField::new("Display Name".to_string(), display_name, true),
+            ],
+            Requester::Anonymous => vec![DiscordWebhookField::new(
+                "User".to_string(),
+                "Anonymous".to_string(),
+                true,
+            )],
+        };
+
+        operation_fields
+            .into_iter()
+            .chain(requester_fields)
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use axum::{
+        Router,
+        body::Body,
+        http::{Request, StatusCode},
+        middleware,
+        response::IntoResponse,
+        routing::post,
+    };
+    use domain::account::models::{AccountUser, Role, UserId};
+    use tower::ServiceExt;
+    use uuid::Uuid;
+
+    use super::{
+        FormOperationNotification, FormOperationNotificationState, FormOperationNotifier,
+        Requester, notify_successful_form_operation,
+    };
+
+    #[derive(Default)]
+    struct RecordingNotifier(Mutex<Vec<FormOperationNotification>>);
+
+    impl FormOperationNotifier for RecordingNotifier {
+        fn notify(&self, notification: FormOperationNotification) {
+            self.0.lock().unwrap().push(notification);
+        }
+    }
+
+    fn app(status: StatusCode, notifier: Arc<RecordingNotifier>) -> Router {
+        let state = FormOperationNotificationState::with_notifier(notifier, "test");
+
+        Router::new()
+            .route(
+                "/forms/{id}",
+                post(move || async move { status.into_response() }),
+            )
+            .route_layer(middleware::from_fn_with_state(
+                state,
+                notify_successful_form_operation,
+            ))
+    }
+
+    #[tokio::test]
+    async fn sends_notification_only_for_successful_responses() {
+        let success_notifier = Arc::new(RecordingNotifier::default());
+        let failure_notifier = Arc::new(RecordingNotifier::default());
+
+        let success_response = app(StatusCode::NO_CONTENT, success_notifier.clone())
+            .oneshot(
+                Request::post("/forms/actual-id?secret=query")
+                    .header("authorization", "Bearer secret")
+                    .body(Body::from("secret body"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let failure_response = app(StatusCode::BAD_REQUEST, failure_notifier.clone())
+            .oneshot(
+                Request::post("/forms/actual-id")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(success_response.status(), StatusCode::NO_CONTENT);
+        assert_eq!(failure_response.status(), StatusCode::BAD_REQUEST);
+        let notifications = success_notifier.0.lock().unwrap();
+        assert_eq!(notifications.len(), 1);
+        assert_eq!(notifications[0].path, "/forms/actual-id");
+        assert_eq!(notifications[0].requester, Requester::Anonymous);
+        assert!(failure_notifier.0.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn includes_authenticated_user_identity() {
+        let notifier = Arc::new(RecordingNotifier::default());
+        let user_id = UserId::from(Uuid::new_v4());
+        let mut request = Request::post("/forms/actual-id")
+            .body(Body::empty())
+            .unwrap();
+        request.extensions_mut().insert(AccountUser::new(
+            "player-name".to_string(),
+            user_id,
+            Role::StandardUser,
+        ));
+
+        app(StatusCode::OK, notifier.clone())
+            .oneshot(request)
+            .await
+            .unwrap();
+
+        let notifications = notifier.0.lock().unwrap();
+        assert_eq!(notifications.len(), 1);
+        assert_eq!(
+            notifications[0].requester,
+            Requester::Authenticated {
+                user_id: user_id.to_string(),
+                display_name: "player-name".to_string(),
+            }
+        );
+    }
+}

--- a/server/presentation/src/handlers/form/answer_handler.rs
+++ b/server/presentation/src/handlers/form/answer_handler.rs
@@ -89,7 +89,7 @@ impl DiscordAnswerWebhookNotifier for ResourceDiscordAnswerWebhookNotifier {
             let message = DiscordWebhookMessage {
                 discord_webhook_url: notification.discord_webhook_url,
                 title: notification.title,
-                link_url: notification.answer_url,
+                link_url: Some(notification.answer_url),
                 fields: notification
                     .fields
                     .into_iter()

--- a/server/presentation/src/lib.rs
+++ b/server/presentation/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod api;
 pub mod auth;
+pub mod form_operation_notification;
 pub mod handlers;
 pub mod schemas;


### PR DESCRIPTION
## 概要
- `DISCORD_GLOBAL_WEBHOOK_URL` を設定すると、フォーム・回答・コメント・メッセージ・ラベルに対する書き込み操作の成功を一つの Discord Webhook へ通知します
- 通知対象の mutation API を明示的な Router に分け、操作方法、対象パス、ステータス、環境、実行者を共通 middleware で通知します
- Webhook URL を起動時に検証し、query・リクエスト本文・認証情報・Webhook token が通知やエラーログへ出ないようにしました

## 確認事項
- `cargo build` が成功し、workspace 全体をコンパイルできることを確認しました
- `cargo test --all-features` が成功し、既存テストと追加テストがすべて通ることを確認しました
- `makers pretty` が成功し、144 テスト、doctest、Clippy、format が通ることを確認しました
- `makers check-openapi` が成功し、Router の再編後も `docs/openapi.json` に差分がないことを確認しました
- 独立レビューで、対象 20 route、認証順序、匿名回答、2xx のみの通知、機密情報の非送信、既存のフォーム単位 Webhook の維持を確認しました

## 補足
- この通知は管理者向けの運用通知であり、配送を保証する監査ログの正本ではありません。Webhook の送信失敗は API の応答へ影響させず、既存の retry 後に警告を記録します
- SQL とデータベース構造は変更していないため、`cargo sqlx prepare --workspace` は実行していません

Closes #1196

🤖 Generated with Codex
