### PR TITLE
回答検索をフォームで絞り込めるようにする

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3718,6 +3718,16 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "form_id",
+            "in": "query",
+            "description": "Limit results to the specified form",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
           }
         ],
         "responses": {

--- a/server/domain/src/repository/search_repository.rs
+++ b/server/domain/src/repository/search_repository.rs
@@ -2,9 +2,12 @@ use async_trait::async_trait;
 use errors::Error;
 use mockall::automock;
 
-use crate::search::models::{
-    AnswerLabelSearchHit, AnswerSearchHit, CommentSearchHit, FormLabelSearchHit, FormSearchHit,
-    NumberOfRecordsPerAggregate, SearchableFieldsWithOperation, UserSearchHit,
+use crate::{
+    form::models::FormId,
+    search::models::{
+        AnswerLabelSearchHit, AnswerSearchHit, CommentSearchHit, FormLabelSearchHit, FormSearchHit,
+        NumberOfRecordsPerAggregate, SearchableFieldsWithOperation, UserSearchHit,
+    },
 };
 
 #[automock]
@@ -25,7 +28,7 @@ pub trait SearchRepository: Send + Sync + 'static {
     async fn search_answers(
         &self,
         query: &str,
-        form_id: Option<crate::form::models::FormId>,
+        form_id: Option<FormId>,
     ) -> Result<Vec<AnswerSearchHit>, Error>;
     async fn search_comments(&self, query: &str) -> Result<Vec<CommentSearchHit>, Error>;
     async fn sync_search_engine(&self, data: &[SearchableFieldsWithOperation])

--- a/server/domain/src/repository/search_repository.rs
+++ b/server/domain/src/repository/search_repository.rs
@@ -22,10 +22,15 @@ pub trait SearchRepository: Send + Sync + 'static {
         &self,
         query: &str,
     ) -> Result<Vec<AnswerLabelSearchHit>, Error>;
-    async fn search_answers(&self, query: &str) -> Result<Vec<AnswerSearchHit>, Error>;
+    async fn search_answers(
+        &self,
+        query: &str,
+        form_id: Option<crate::form::models::FormId>,
+    ) -> Result<Vec<AnswerSearchHit>, Error>;
     async fn search_comments(&self, query: &str) -> Result<Vec<CommentSearchHit>, Error>;
     async fn sync_search_engine(&self, data: &[SearchableFieldsWithOperation])
     -> Result<(), Error>;
     async fn fetch_search_engine_stats(&self) -> Result<NumberOfRecordsPerAggregate, Error>;
-    async fn initialize_search_engine(&self) -> Result<(), Error>;
+    /// 検索インデックスを初期化し、既存の回答文書に再投影が必要かを返す。
+    async fn initialize_search_engine(&self) -> Result<bool, Error>;
 }

--- a/server/domain/src/search/models.rs
+++ b/server/domain/src/search/models.rs
@@ -43,6 +43,7 @@ pub struct FormMetaData {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct AnswerTitleSearchDocument {
     pub id: AnswerId,
+    pub form_id: FormId,
     pub title: AnswerTitle,
 }
 

--- a/server/infra/resource/src/database/components.rs
+++ b/server/infra/resource/src/database/components.rs
@@ -330,14 +330,18 @@ pub trait SearchDatabase: Send + Sync {
         &self,
         query: &str,
     ) -> Result<Vec<AnswerLabelSearchHit>, InfraError>;
-    async fn search_answers(&self, query: &str) -> Result<Vec<AnswerSearchHit>, InfraError>;
+    async fn search_answers(
+        &self,
+        query: &str,
+        form_id: Option<FormId>,
+    ) -> Result<Vec<AnswerSearchHit>, InfraError>;
     async fn search_comments(&self, query: &str) -> Result<Vec<CommentSearchHit>, InfraError>;
     async fn sync_search_engine(
         &self,
         data: &[SearchableFieldsWithOperation],
     ) -> Result<(), InfraError>;
     async fn search_engine_stats(&self) -> Result<NumberOfRecordsPerAggregate, InfraError>;
-    async fn initialize_search_engine(&self) -> Result<(), InfraError>;
+    async fn initialize_search_engine(&self) -> Result<bool, InfraError>;
 }
 
 #[automock]

--- a/server/infra/resource/src/database/search.rs
+++ b/server/infra/resource/src/database/search.rs
@@ -4,40 +4,126 @@ use crate::database::{
     components::{FormAnswerDatabase, SearchDatabase},
     connection::ConnectionPool,
 };
+use crate::records::FormAnswerRecord;
 use async_trait::async_trait;
-use domain::search::models::{
-    AnswerLabelSearchHit, AnswerSearchHit, AnswerTitleSearchDocument, CommentSearchHit,
-    FormAnswerComments, FormLabelSearchHit, FormMetaData, FormSearchHit, LabelForFormAnswers,
-    LabelForForms, NumberOfRecordsPerAggregate, UserSearchHit, Users,
-};
 use domain::{
     account::models::UserId,
-    search::models::{Operation, SearchableFields, SearchableFieldsWithOperation},
+    form::{
+        answer::{AnswerId, FormAnswerContentId},
+        models::FormId,
+        question::QuestionId,
+    },
+    search::models::{
+        AnswerLabelSearchHit, AnswerSearchHit, AnswerTitleSearchDocument, CommentSearchHit,
+        FormAnswerComments, FormLabelSearchHit, FormMetaData, FormSearchHit, LabelForFormAnswers,
+        LabelForForms, NumberOfRecordsPerAggregate, Operation, SearchableFields,
+        SearchableFieldsWithOperation, UserSearchHit, Users,
+    },
 };
 use errors::infra::InfraError;
+use futures::{future::try_join_all, try_join};
 use itertools::Itertools;
-use meilisearch_sdk::search::Selectors;
+use meilisearch_sdk::{errors::Error as MeilisearchError, search::Selectors};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use uuid::Uuid;
 
 #[derive(Serialize, Deserialize)]
 struct AnswerContentSearchDocument {
-    id: domain::form::answer::FormAnswerContentId,
-    form_id: domain::form::models::FormId,
-    answer_id: domain::form::answer::AnswerId,
-    question_id: domain::form::question::QuestionId,
+    id: FormAnswerContentId,
+    form_id: FormId,
+    answer_id: AnswerId,
+    question_id: QuestionId,
     answer: String,
 }
 
 #[derive(Deserialize)]
 struct FormIdPresence {
     #[serde(default)]
-    form_id: Option<domain::form::models::FormId>,
+    form_id: Option<FormId>,
 }
 
-fn form_filter(form_id: domain::form::models::FormId) -> String {
+fn form_filter(form_id: FormId) -> String {
     format!("form_id = \"{form_id}\"")
+}
+
+fn form_ids_from_answer_titles(
+    data: &[SearchableFieldsWithOperation],
+) -> HashMap<AnswerId, FormId> {
+    data.iter()
+        .filter_map(|(fields, operation)| match (fields, operation) {
+            (SearchableFields::AnswerTitle(answer), Operation::Create | Operation::Update) => {
+                Some((answer.id, answer.form_id))
+            }
+            _ => None,
+        })
+        .collect()
+}
+
+fn unresolved_content_answer_ids(
+    data: &[SearchableFieldsWithOperation],
+    form_ids_by_answer_id: &HashMap<AnswerId, FormId>,
+) -> Vec<AnswerId> {
+    data.iter()
+        .filter_map(|(fields, operation)| match (fields, operation) {
+            (SearchableFields::RealAnswers(content), Operation::Create | Operation::Update) => {
+                Some(content.answer_id)
+            }
+            _ => None,
+        })
+        .unique()
+        .filter(|answer_id| !form_ids_by_answer_id.contains_key(answer_id))
+        .collect()
+}
+
+fn answer_content_documents(
+    data: &[SearchableFieldsWithOperation],
+    form_ids_by_answer_id: &HashMap<AnswerId, FormId>,
+) -> Result<HashMap<FormAnswerContentId, AnswerContentSearchDocument>, InfraError> {
+    data.iter()
+        .filter_map(|(fields, operation)| match (fields, operation) {
+            (SearchableFields::RealAnswers(content), Operation::Create | Operation::Update) => {
+                Some(content)
+            }
+            _ => None,
+        })
+        .map(|content| {
+            let form_id = form_ids_by_answer_id
+                .get(&content.answer_id)
+                .copied()
+                .ok_or_else(|| InfraError::Unexpected {
+                    cause: format!(
+                        "form id for answer {} was not found while updating its search document",
+                        content.answer_id
+                    ),
+                })?;
+
+            Ok((
+                content.id,
+                AnswerContentSearchDocument {
+                    id: content.id,
+                    form_id,
+                    answer_id: content.answer_id,
+                    question_id: content.question_id,
+                    answer: content.answer.clone(),
+                },
+            ))
+        })
+        .collect()
+}
+
+fn form_ids_from_answer_records(
+    records: impl IntoIterator<Item = FormAnswerRecord>,
+) -> Result<HashMap<AnswerId, FormId>, InfraError> {
+    records
+        .into_iter()
+        .map(|record| {
+            Ok((
+                Uuid::parse_str(&record.id)?.into(),
+                Uuid::parse_str(&record.form_id)?.into(),
+            ))
+        })
+        .collect()
 }
 
 async fn answer_documents_need_reprojection(
@@ -64,8 +150,8 @@ async fn answer_documents_need_reprojection(
 }
 
 fn merge_answer_hits(
-    title_answer_ids: impl IntoIterator<Item = domain::form::answer::AnswerId>,
-    content_answer_ids: impl IntoIterator<Item = domain::form::answer::AnswerId>,
+    title_answer_ids: impl IntoIterator<Item = AnswerId>,
+    content_answer_ids: impl IntoIterator<Item = AnswerId>,
 ) -> Vec<AnswerSearchHit> {
     title_answer_ids
         .into_iter()
@@ -159,7 +245,7 @@ impl SearchDatabase for ConnectionPool {
     async fn search_answers(
         &self,
         query: &str,
-        form_id: Option<domain::form::models::FormId>,
+        form_id: Option<FormId>,
     ) -> Result<Vec<AnswerSearchHit>, InfraError> {
         let filter = form_id.map(form_filter);
         let title_search = async {
@@ -184,7 +270,7 @@ impl SearchDatabase for ConnectionPool {
             }
             search.execute::<AnswerContentSearchDocument>().await
         };
-        let (title_results, content_results) = futures::try_join!(title_search, content_search)?;
+        let (title_results, content_results) = try_join!(title_search, content_search)?;
 
         Ok(merge_answer_hits(
             title_results.hits.into_iter().map(|hit| hit.result.id),
@@ -219,73 +305,21 @@ impl SearchDatabase for ConnectionPool {
         &self,
         data: &[SearchableFieldsWithOperation],
     ) -> Result<(), InfraError> {
-        let mut form_ids_by_answer_id = data
-            .iter()
-            .filter_map(|(fields, operation)| match (fields, operation) {
-                (SearchableFields::AnswerTitle(answer), Operation::Create | Operation::Update) => {
-                    Some((answer.id, answer.form_id))
-                }
-                _ => None,
-            })
-            .collect::<HashMap<_, _>>();
-        let unresolved_content_answer_ids = data
-            .iter()
-            .filter_map(|(fields, operation)| match (fields, operation) {
-                (SearchableFields::RealAnswers(content), Operation::Create | Operation::Update) => {
-                    Some(content.answer_id)
-                }
-                _ => None,
-            })
-            .unique()
-            .filter(|answer_id| !form_ids_by_answer_id.contains_key(answer_id))
-            .collect_vec();
-        let database_form_ids: HashMap<
-            domain::form::answer::AnswerId,
-            domain::form::models::FormId,
-        > = if unresolved_content_answer_ids.is_empty() {
+        let indexed_form_ids = form_ids_from_answer_titles(data);
+        let unresolved_answer_ids = unresolved_content_answer_ids(data, &indexed_form_ids);
+        let database_form_ids = if unresolved_answer_ids.is_empty() {
             HashMap::new()
         } else {
-            self.get_answers_by_answer_ids(unresolved_content_answer_ids)
-                .await?
-                .into_iter()
-                .map(|record| {
-                    Ok((
-                        Uuid::parse_str(&record.id)?.into(),
-                        Uuid::parse_str(&record.form_id)?.into(),
-                    ))
-                })
-                .collect::<Result<HashMap<_, _>, InfraError>>()?
+            form_ids_from_answer_records(
+                self.get_answers_by_answer_ids(unresolved_answer_ids)
+                    .await?,
+            )?
         };
-        form_ids_by_answer_id.extend(database_form_ids);
-        let content_documents = data
-            .iter()
-            .filter_map(|(fields, operation)| match (fields, operation) {
-                (SearchableFields::RealAnswers(content), Operation::Create | Operation::Update) => {
-                    Some(content)
-                }
-                _ => None,
-            })
-            .map(|content| {
-                let form_id = form_ids_by_answer_id.get(&content.answer_id).copied().ok_or_else(|| {
-                    InfraError::Unexpected {
-                        cause: format!(
-                            "form id for answer {} was not found while updating its search document",
-                            content.answer_id
-                        ),
-                    }
-                })?;
-                Ok((
-                    content.id,
-                    AnswerContentSearchDocument {
-                        id: content.id,
-                        form_id,
-                        answer_id: content.answer_id,
-                        question_id: content.question_id,
-                        answer: content.answer.clone(),
-                    },
-                ))
-            })
-            .collect::<Result<HashMap<_, _>, InfraError>>()?;
+        let form_ids_by_answer_id = indexed_form_ids
+            .into_iter()
+            .chain(database_form_ids)
+            .collect();
+        let content_documents = answer_content_documents(data, &form_ids_by_answer_id)?;
 
         let futures = data
             .iter()
@@ -381,7 +415,7 @@ impl SearchDatabase for ConnectionPool {
             })
             .collect::<Vec<_>>();
 
-        futures::future::try_join_all(futures).await?;
+        try_join_all(futures).await?;
 
         Ok(())
     }
@@ -428,11 +462,11 @@ impl SearchDatabase for ConnectionPool {
                     .wait_for_completion(&self.meilisearch_client, None, None)
                     .await?;
 
-                Ok::<_, meilisearch_sdk::errors::Error>(())
+                Ok::<_, MeilisearchError>(())
             })
             .collect_vec();
 
-        futures::future::try_join_all(futures).await?;
+        try_join_all(futures).await?;
 
         let settings_futures = ["answers", "real_answers"].into_iter().map(async |index| {
             self.meilisearch_client
@@ -442,9 +476,9 @@ impl SearchDatabase for ConnectionPool {
                 .wait_for_completion(&self.meilisearch_client, None, None)
                 .await?;
 
-            Ok::<_, meilisearch_sdk::errors::Error>(())
+            Ok::<_, MeilisearchError>(())
         });
-        futures::future::try_join_all(settings_futures).await?;
+        try_join_all(settings_futures).await?;
 
         answer_documents_need_reprojection(self).await
     }
@@ -452,8 +486,12 @@ impl SearchDatabase for ConnectionPool {
 
 #[cfg(test)]
 mod tests {
-    use super::{AnswerContentSearchDocument, form_filter, merge_answer_hits};
-    use domain::form::{answer::AnswerId, models::FormId, question::QuestionId};
+    use super::{answer_content_documents, form_filter, merge_answer_hits};
+    use domain::{
+        form::{answer::AnswerId, models::FormId},
+        search::models::{Operation, RealAnswers, SearchableFields},
+    };
+    use std::collections::HashMap;
     use uuid::Uuid;
 
     fn answer_id(value: u128) -> AnswerId {
@@ -470,13 +508,21 @@ mod tests {
     #[test]
     fn answer_content_search_document_contains_form_id() {
         let form_id = FormId::from(Uuid::from_u128(1));
-        let document = AnswerContentSearchDocument {
-            id: Uuid::from_u128(2).into(),
-            form_id,
-            answer_id: answer_id(3),
-            question_id: QuestionId::from(Uuid::from_u128(4)),
-            answer: "content".to_string(),
-        };
+        let content_id = Uuid::from_u128(2).into();
+        let answer_id = answer_id(3);
+        let data = [(
+            SearchableFields::RealAnswers(RealAnswers {
+                id: content_id,
+                answer_id,
+                question_id: Uuid::from_u128(4).into(),
+                answer: "content".to_string(),
+            }),
+            Operation::Update,
+        )];
+        let document = answer_content_documents(&data, &HashMap::from([(answer_id, form_id)]))
+            .unwrap()
+            .remove(&content_id)
+            .unwrap();
 
         assert_eq!(
             serde_json::to_value(document).unwrap()["form_id"],

--- a/server/infra/resource/src/database/search.rs
+++ b/server/infra/resource/src/database/search.rs
@@ -1,11 +1,14 @@
 use crate::database::config::{MEILISEARCH, MeiliSearch};
 use crate::database::meilisearch_schemas::MeilisearchStatsSchema;
-use crate::database::{components::SearchDatabase, connection::ConnectionPool};
+use crate::database::{
+    components::{FormAnswerDatabase, SearchDatabase},
+    connection::ConnectionPool,
+};
 use async_trait::async_trait;
 use domain::search::models::{
     AnswerLabelSearchHit, AnswerSearchHit, AnswerTitleSearchDocument, CommentSearchHit,
     FormAnswerComments, FormLabelSearchHit, FormMetaData, FormSearchHit, LabelForFormAnswers,
-    LabelForForms, NumberOfRecordsPerAggregate, RealAnswers, UserSearchHit, Users,
+    LabelForForms, NumberOfRecordsPerAggregate, UserSearchHit, Users,
 };
 use domain::{
     account::models::UserId,
@@ -14,6 +17,51 @@ use domain::{
 use errors::infra::InfraError;
 use itertools::Itertools;
 use meilisearch_sdk::search::Selectors;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use uuid::Uuid;
+
+#[derive(Serialize, Deserialize)]
+struct AnswerContentSearchDocument {
+    id: domain::form::answer::FormAnswerContentId,
+    form_id: domain::form::models::FormId,
+    answer_id: domain::form::answer::AnswerId,
+    question_id: domain::form::question::QuestionId,
+    answer: String,
+}
+
+#[derive(Deserialize)]
+struct FormIdPresence {
+    #[serde(default)]
+    form_id: Option<domain::form::models::FormId>,
+}
+
+fn form_filter(form_id: domain::form::models::FormId) -> String {
+    format!("form_id = \"{form_id}\"")
+}
+
+async fn answer_documents_need_reprojection(
+    connection: &ConnectionPool,
+) -> Result<bool, InfraError> {
+    for index in ["answers", "real_answers"] {
+        let missing_form_id = connection
+            .meilisearch_client
+            .index(index)
+            .search()
+            .with_filter("form_id NOT EXISTS")
+            .with_limit(1)
+            .execute::<FormIdPresence>()
+            .await?
+            .hits
+            .into_iter()
+            .any(|hit| hit.result.form_id.is_none());
+        if missing_form_id {
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
+}
 
 fn merge_answer_hits(
     title_answer_ids: impl IntoIterator<Item = domain::form::answer::AnswerId>,
@@ -108,24 +156,33 @@ impl SearchDatabase for ConnectionPool {
     }
 
     #[tracing::instrument]
-    async fn search_answers(&self, query: &str) -> Result<Vec<AnswerSearchHit>, InfraError> {
+    async fn search_answers(
+        &self,
+        query: &str,
+        form_id: Option<domain::form::models::FormId>,
+    ) -> Result<Vec<AnswerSearchHit>, InfraError> {
+        let filter = form_id.map(form_filter);
         let title_search = async {
-            self.meilisearch_client
-                .index("answers")
-                .search()
+            let index = self.meilisearch_client.index("answers");
+            let mut search = index.search();
+            search
                 .with_query(query)
-                .with_attributes_to_highlight(Selectors::All)
-                .execute::<AnswerTitleSearchDocument>()
-                .await
+                .with_attributes_to_highlight(Selectors::All);
+            if let Some(filter) = filter.as_deref() {
+                search.with_filter(filter);
+            }
+            search.execute::<AnswerTitleSearchDocument>().await
         };
         let content_search = async {
-            self.meilisearch_client
-                .index("real_answers")
-                .search()
+            let index = self.meilisearch_client.index("real_answers");
+            let mut search = index.search();
+            search
                 .with_query(query)
-                .with_attributes_to_highlight(Selectors::All)
-                .execute::<RealAnswers>()
-                .await
+                .with_attributes_to_highlight(Selectors::All);
+            if let Some(filter) = filter.as_deref() {
+                search.with_filter(filter);
+            }
+            search.execute::<AnswerContentSearchDocument>().await
         };
         let (title_results, content_results) = futures::try_join!(title_search, content_search)?;
 
@@ -162,6 +219,74 @@ impl SearchDatabase for ConnectionPool {
         &self,
         data: &[SearchableFieldsWithOperation],
     ) -> Result<(), InfraError> {
+        let mut form_ids_by_answer_id = data
+            .iter()
+            .filter_map(|(fields, operation)| match (fields, operation) {
+                (SearchableFields::AnswerTitle(answer), Operation::Create | Operation::Update) => {
+                    Some((answer.id, answer.form_id))
+                }
+                _ => None,
+            })
+            .collect::<HashMap<_, _>>();
+        let unresolved_content_answer_ids = data
+            .iter()
+            .filter_map(|(fields, operation)| match (fields, operation) {
+                (SearchableFields::RealAnswers(content), Operation::Create | Operation::Update) => {
+                    Some(content.answer_id)
+                }
+                _ => None,
+            })
+            .unique()
+            .filter(|answer_id| !form_ids_by_answer_id.contains_key(answer_id))
+            .collect_vec();
+        let database_form_ids: HashMap<
+            domain::form::answer::AnswerId,
+            domain::form::models::FormId,
+        > = if unresolved_content_answer_ids.is_empty() {
+            HashMap::new()
+        } else {
+            self.get_answers_by_answer_ids(unresolved_content_answer_ids)
+                .await?
+                .into_iter()
+                .map(|record| {
+                    Ok((
+                        Uuid::parse_str(&record.id)?.into(),
+                        Uuid::parse_str(&record.form_id)?.into(),
+                    ))
+                })
+                .collect::<Result<HashMap<_, _>, InfraError>>()?
+        };
+        form_ids_by_answer_id.extend(database_form_ids);
+        let content_documents = data
+            .iter()
+            .filter_map(|(fields, operation)| match (fields, operation) {
+                (SearchableFields::RealAnswers(content), Operation::Create | Operation::Update) => {
+                    Some(content)
+                }
+                _ => None,
+            })
+            .map(|content| {
+                let form_id = form_ids_by_answer_id.get(&content.answer_id).copied().ok_or_else(|| {
+                    InfraError::Unexpected {
+                        cause: format!(
+                            "form id for answer {} was not found while updating its search document",
+                            content.answer_id
+                        ),
+                    }
+                })?;
+                Ok((
+                    content.id,
+                    AnswerContentSearchDocument {
+                        id: content.id,
+                        form_id,
+                        answer_id: content.answer_id,
+                        question_id: content.question_id,
+                        answer: content.answer.clone(),
+                    },
+                ))
+            })
+            .collect::<Result<HashMap<_, _>, InfraError>>()?;
+
         let futures = data
             .iter()
             .map(async |(searchable_fields, operation)| match operation {
@@ -181,7 +306,7 @@ impl SearchDatabase for ConnectionPool {
                     SearchableFields::RealAnswers(answers) => {
                         self.meilisearch_client
                             .index("real_answers")
-                            .add_or_replace(&[answers], Some("id"))
+                            .add_or_replace(&[&content_documents[&answers.id]], Some("id"))
                             .await
                     }
                     SearchableFields::FormAnswerComments(comments) => {
@@ -283,7 +408,7 @@ impl SearchDatabase for ConnectionPool {
     }
 
     #[tracing::instrument]
-    async fn initialize_search_engine(&self) -> Result<(), InfraError> {
+    async fn initialize_search_engine(&self) -> Result<bool, InfraError> {
         let index_with_uid = vec![
             ("form_meta_data", "id"),
             ("answers", "id"),
@@ -309,18 +434,54 @@ impl SearchDatabase for ConnectionPool {
 
         futures::future::try_join_all(futures).await?;
 
-        Ok(())
+        let settings_futures = ["answers", "real_answers"].into_iter().map(async |index| {
+            self.meilisearch_client
+                .index(index)
+                .set_filterable_attributes(["form_id"])
+                .await?
+                .wait_for_completion(&self.meilisearch_client, None, None)
+                .await?;
+
+            Ok::<_, meilisearch_sdk::errors::Error>(())
+        });
+        futures::future::try_join_all(settings_futures).await?;
+
+        answer_documents_need_reprojection(self).await
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::merge_answer_hits;
-    use domain::form::answer::AnswerId;
+    use super::{AnswerContentSearchDocument, form_filter, merge_answer_hits};
+    use domain::form::{answer::AnswerId, models::FormId, question::QuestionId};
     use uuid::Uuid;
 
     fn answer_id(value: u128) -> AnswerId {
         Uuid::from_u128(value).into()
+    }
+
+    #[test]
+    fn answer_form_filter_uses_the_form_id_attribute() {
+        let form_id = FormId::from(Uuid::from_u128(1));
+
+        assert_eq!(form_filter(form_id), format!("form_id = \"{form_id}\""));
+    }
+
+    #[test]
+    fn answer_content_search_document_contains_form_id() {
+        let form_id = FormId::from(Uuid::from_u128(1));
+        let document = AnswerContentSearchDocument {
+            id: Uuid::from_u128(2).into(),
+            form_id,
+            answer_id: answer_id(3),
+            question_id: QuestionId::from(Uuid::from_u128(4)),
+            answer: "content".to_string(),
+        };
+
+        assert_eq!(
+            serde_json::to_value(document).unwrap()["form_id"],
+            form_id.to_string()
+        );
     }
 
     #[test]

--- a/server/infra/resource/src/messaging/schema.rs
+++ b/server/infra/resource/src/messaging/schema.rs
@@ -133,6 +133,7 @@ impl TryFrom<FormMetaData> for domain::search::models::FormMetaData {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct AnswerTitleSearchDocument {
     pub id: String,
+    pub form_id: String,
     pub title: Option<NonEmptyString>,
 }
 
@@ -140,6 +141,7 @@ impl From<domain::search::models::AnswerTitleSearchDocument> for AnswerTitleSear
     fn from(answer: domain::search::models::AnswerTitleSearchDocument) -> Self {
         Self {
             id: answer.id.to_string(),
+            form_id: answer.form_id.to_string(),
             title: answer.title.into_inner(),
         }
     }
@@ -151,6 +153,7 @@ impl TryFrom<AnswerTitleSearchDocument> for domain::search::models::AnswerTitleS
     fn try_from(answer: AnswerTitleSearchDocument) -> Result<Self, Self::Error> {
         Ok(Self {
             id: Uuid::from_str(&answer.id)?.into(),
+            form_id: Uuid::from_str(&answer.form_id)?.into(),
             title: domain::form::answer::AnswerTitle::new(answer.title),
         })
     }
@@ -361,6 +364,7 @@ mod tests {
     #[test]
     fn answers_create_or_update_payload_uses_after_image() {
         let answer_id = Uuid::from_u128(1);
+        let form_id = Uuid::from_u128(2);
         let schema: RabbitMQSchema = serde_json::from_value(json!({
             "payload": {
                 "op": "u",
@@ -368,6 +372,7 @@ mod tests {
                 "before": null,
                 "after": {
                     "id": answer_id.to_string(),
+                    "form_id": form_id.to_string(),
                     "title": "検索できるタイトル"
                 }
             }
@@ -381,6 +386,7 @@ mod tests {
         };
 
         assert_eq!(document.id.into_inner(), answer_id);
+        assert_eq!(document.form_id.into_inner(), form_id);
         assert_eq!(
             serde_json::to_value(document.title).unwrap(),
             json!("検索できるタイトル")
@@ -390,12 +396,14 @@ mod tests {
     #[test]
     fn answers_delete_payload_uses_before_image_and_preserves_null_title() {
         let answer_id = Uuid::from_u128(1);
+        let form_id = Uuid::from_u128(2);
         let schema: RabbitMQSchema = serde_json::from_value(json!({
             "payload": {
                 "op": "d",
                 "source": { "table": "answers" },
                 "before": {
                     "id": answer_id.to_string(),
+                    "form_id": form_id.to_string(),
                     "title": null
                 },
                 "after": null

--- a/server/infra/resource/src/repository/search_repository_impl.rs
+++ b/server/infra/resource/src/repository/search_repository_impl.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 use async_trait::async_trait;
 use domain::{
+    form::models::FormId,
     repository::search_repository::SearchRepository,
     search::models::{
         AnswerLabelSearchHit, AnswerSearchHit, CommentSearchHit, FormLabelSearchHit, FormSearchHit,
@@ -52,7 +53,7 @@ impl<Client: DatabaseComponents + 'static> SearchRepository for Repository<Clien
     async fn search_answers(
         &self,
         query: &str,
-        form_id: Option<domain::form::models::FormId>,
+        form_id: Option<FormId>,
     ) -> Result<Vec<AnswerSearchHit>, Error> {
         self.client
             .search()

--- a/server/infra/resource/src/repository/search_repository_impl.rs
+++ b/server/infra/resource/src/repository/search_repository_impl.rs
@@ -49,10 +49,14 @@ impl<Client: DatabaseComponents + 'static> SearchRepository for Repository<Clien
             .map_err(Into::into)
     }
 
-    async fn search_answers(&self, query: &str) -> Result<Vec<AnswerSearchHit>, Error> {
+    async fn search_answers(
+        &self,
+        query: &str,
+        form_id: Option<domain::form::models::FormId>,
+    ) -> Result<Vec<AnswerSearchHit>, Error> {
         self.client
             .search()
-            .search_answers(query)
+            .search_answers(query, form_id)
             .await
             .map_err(Into::into)
     }
@@ -84,7 +88,7 @@ impl<Client: DatabaseComponents + 'static> SearchRepository for Repository<Clien
             .map_err(Into::into)
     }
 
-    async fn initialize_search_engine(&self) -> Result<(), Error> {
+    async fn initialize_search_engine(&self) -> Result<bool, Error> {
         self.client
             .search()
             .initialize_search_engine()

--- a/server/presentation/src/handlers/search_handler.rs
+++ b/server/presentation/src/handlers/search_handler.rs
@@ -22,7 +22,7 @@ use crate::schemas::error_responses::*;
 use crate::{
     handlers::error_handler::handle_error,
     schemas::search_schemas::{
-        AnswerSearchResult, CrossSearchResult, SearchQuery, UserSearchResult,
+        AnswerSearchQuery, AnswerSearchResult, CrossSearchResult, SearchQuery, UserSearchResult,
     },
 };
 
@@ -174,6 +174,7 @@ pub async fn search_users(
     summary = "回答検索を行う",
     params(
         ("query" = String, Query, description = "Search query"),
+        ("form_id" = Option<String>, Query, format = "uuid", description = "Limit results to the specified form"),
     ),
     responses(
         AnswerSearchResponse,
@@ -188,7 +189,7 @@ pub async fn search_users(
 pub async fn search_answers(
     Extension(user): Extension<AccountUser>,
     State(repository): State<RealInfrastructureRepository>,
-    query: Result<Query<SearchQuery>, QueryRejection>,
+    query: Result<Query<AnswerSearchQuery>, QueryRejection>,
 ) -> Result<AnswerSearchResponse, Response> {
     let search_use_case = SearchUseCase {
         search_repository: repository.search_repository(),
@@ -200,10 +201,18 @@ pub async fn search_answers(
         comment_repository: repository.comment_repository(),
     };
 
-    let query = required_query(query).map_err(handle_error)?;
+    let Query(search_query) = query.map_err_to_error().map_err(handle_error)?;
+    let query = search_query
+        .query
+        .map(|query| query.into_inner())
+        .ok_or_else(|| {
+            handle_error(Error::from(PresentationError::QueryRejection {
+                cause: "query is required".to_string(),
+            }))
+        })?;
 
     let answers = search_use_case
-        .search_answers(&user, query)
+        .search_answers(&user, query, search_query.form_id)
         .await
         .map_err(handle_error)?;
 

--- a/server/presentation/src/schemas/search_schemas.rs
+++ b/server/presentation/src/schemas/search_schemas.rs
@@ -1,4 +1,7 @@
-use domain::{auth::Actor, form::answer::AnswerId};
+use domain::{
+    auth::Actor,
+    form::{answer::AnswerId, models::FormId},
+};
 use serde::{Deserialize, Serialize};
 use types::non_empty_string::NonEmptyString;
 use usecase::models::{AnswerDetails, CommentWithAuthor, CrossSearchOutput};
@@ -25,6 +28,15 @@ impl From<AnswerDetails> for FormAnswer {
 pub struct SearchQuery {
     #[serde(default)]
     pub query: Option<NonEmptyString>,
+}
+
+#[derive(Deserialize, Debug, PartialEq, utoipa::ToSchema)]
+pub struct AnswerSearchQuery {
+    #[serde(default)]
+    pub query: Option<NonEmptyString>,
+    #[serde(default)]
+    #[schema(value_type = Option<String>, format = "uuid")]
+    pub form_id: Option<FormId>,
 }
 
 #[derive(Serialize, Debug, utoipa::ToSchema)]
@@ -115,6 +127,33 @@ mod tests {
     use types::non_empty_vec::NonEmptyVec;
     use usecase::models::{ActiveFormWithLabels, AnswerDetails, CommentWithAuthor};
     use uuid::Uuid;
+
+    #[test]
+    fn answer_search_query_accepts_optional_form_id() {
+        let form_id = Uuid::from_u128(7);
+        let query: AnswerSearchQuery = serde_json::from_value(serde_json::json!({
+            "query": "keyword",
+            "form_id": form_id.to_string(),
+        }))
+        .unwrap();
+
+        assert_eq!(query.form_id, Some(form_id.into()));
+
+        let query_without_form: AnswerSearchQuery =
+            serde_json::from_value(serde_json::json!({ "query": "keyword" })).unwrap();
+        assert_eq!(query_without_form.form_id, None);
+    }
+
+    #[test]
+    fn answer_search_query_rejects_invalid_form_id() {
+        assert!(
+            serde_json::from_value::<AnswerSearchQuery>(serde_json::json!({
+                "query": "keyword",
+                "form_id": "not-a-uuid",
+            }))
+            .is_err()
+        );
+    }
 
     fn standard_user(name: &str) -> AccountUser {
         AccountUser::new(

--- a/server/usecase/src/search.rs
+++ b/server/usecase/src/search.rs
@@ -17,7 +17,7 @@ use domain::{
     form::{
         answer::{AnswerAuthor, AnswerEntry, AnswerId},
         comment::Comment,
-        models::ActiveForm,
+        models::{ActiveForm, FormId},
     },
     pagination::{PageLimit, PageRequest},
     repository::{
@@ -292,9 +292,22 @@ impl<
         &self,
         account_user: &AccountUser,
         query: String,
+        form_id: Option<FormId>,
     ) -> Result<Vec<AnswerDetails>, Error> {
         let actor = Actor::from(account_user.clone());
-        let hits = self.search_repository.search_answers(&query).await?;
+        if let Some(form_id) = form_id {
+            let Some(form) = self.active_form_repository.get(form_id).await? else {
+                return Ok(Vec::new());
+            };
+            if form.try_read(actor.clone()).is_err() {
+                return Ok(Vec::new());
+            }
+        }
+
+        let hits = self
+            .search_repository
+            .search_answers(&query, form_id)
+            .await?;
         let answer_ids = unique_answer_ids(hits.iter().map(|hit| hit.answer_id));
         let visible_answers_by_id = self
             .visible_answer_entries_by_id(&actor, answer_ids)
@@ -315,7 +328,7 @@ impl<
             self.search_repository.search_users(&query),
             self.search_repository.search_labels_for_forms(&query),
             self.search_repository.search_labels_for_answers(&query),
-            self.search_repository.search_answers(&query),
+            self.search_repository.search_answers(&query, None),
             self.search_repository.search_comments(&query)
         )?;
 
@@ -503,45 +516,7 @@ impl<
 
                         let answer_entries = self.list_all_answer_entries(&form_guards).await?;
 
-                        let answer_titles = answer_entries
-                            .iter()
-                            .map(|entry| {
-                                let entry = entry.value();
-                                (
-                                    domain::search::models::SearchableFields::AnswerTitle(
-                                        domain::search::models::AnswerTitleSearchDocument {
-                                            id: *entry.id(),
-                                            title: entry.title().clone(),
-                                        },
-                                    ),
-                                    Operation::Update,
-                                )
-                            })
-                            .collect::<Vec<_>>();
-
-                        let answer_contents = answer_entries
-                            .iter()
-                            .flat_map(|entry| {
-                                let entry = entry.value();
-                                entry
-                                    .contents()
-                                    .iter()
-                                    .map(|content| {
-                                        (
-                                            domain::search::models::SearchableFields::RealAnswers(
-                                                domain::search::models::RealAnswers {
-                                                    id: content.id,
-                                                    answer_id: entry.id().to_owned(),
-                                                    question_id: content.question_id,
-                                                    answer: content.answer.to_owned(),
-                                                },
-                                            ),
-                                            Operation::Update,
-                                        )
-                                    })
-                                    .collect::<Vec<_>>()
-                            })
-                            .collect::<Vec<_>>();
+                        let answer_documents = answer_search_documents(&answer_entries);
 
                         let comments = stream::iter(answer_entries.clone())
                         .then(|answer| async move {
@@ -639,8 +614,7 @@ impl<
 
                         let data = forms
                             .into_iter()
-                            .chain(answer_titles)
-                            .chain(answer_contents)
+                            .chain(answer_documents)
                             .chain(comments)
                             .chain(labels_for_forms)
                             .chain(labels_for_answers)
@@ -659,8 +633,57 @@ impl<
     }
 
     pub async fn initialize_search_engine(&self) -> Result<(), Error> {
-        self.search_repository.initialize_search_engine().await
+        if self.search_repository.initialize_search_engine().await? {
+            let system = Actor::System;
+            let form_guards = self
+                .list_all_form_guards()
+                .await?
+                .into_iter()
+                .map(|guard| guard.try_read(system.clone()).map_err(Into::into))
+                .collect::<Result<Vec<_>, Error>>()?;
+            let answer_entries = self.list_all_answer_entries(&form_guards).await?;
+            let documents = answer_search_documents(&answer_entries);
+            self.search_repository
+                .sync_search_engine(&documents)
+                .await?;
+        }
+
+        Ok(())
     }
+}
+
+fn answer_search_documents(
+    answer_entries: &[Allowed<AnswerEntry, Read>],
+) -> Vec<SearchableFieldsWithOperation> {
+    answer_entries
+        .iter()
+        .flat_map(|entry| {
+            let entry = entry.value();
+            std::iter::once((
+                domain::search::models::SearchableFields::AnswerTitle(
+                    domain::search::models::AnswerTitleSearchDocument {
+                        id: *entry.id(),
+                        form_id: *entry.form_id(),
+                        title: entry.title().clone(),
+                    },
+                ),
+                Operation::Update,
+            ))
+            .chain(entry.contents().iter().map(|content| {
+                (
+                    domain::search::models::SearchableFields::RealAnswers(
+                        domain::search::models::RealAnswers {
+                            id: content.id,
+                            answer_id: *entry.id(),
+                            question_id: content.question_id,
+                            answer: content.answer.to_owned(),
+                        },
+                    ),
+                    Operation::Update,
+                )
+            }))
+        })
+        .collect()
 }
 
 fn unique_answer_ids(answer_ids: impl IntoIterator<Item = AnswerId>) -> Vec<AnswerId> {
@@ -767,7 +790,7 @@ mod tests {
             .returning(|_| Ok(vec![]));
         search_repository
             .expect_search_answers()
-            .returning(|_| Ok(vec![]));
+            .returning(|_, _| Ok(vec![]));
         search_repository
             .expect_search_comments()
             .returning(|_| Ok(vec![]));
@@ -819,6 +842,7 @@ mod tests {
             .change_answer_settings(
                 AnswerSettings::default().change_visibility(AnswerVisibility::PUBLIC),
             );
+        let readable_form_id = *readable_form.id();
         let answer_for = |form: &ActiveForm| {
             let question_id = *form.questions().as_slice()[0].id();
             AnswerEntry::new(
@@ -846,7 +870,8 @@ mod tests {
         let mut search_repository = MockSearchRepository::new();
         search_repository
             .expect_search_answers()
-            .returning(move |_| {
+            .withf(move |_, form_id| *form_id == Some(readable_form_id))
+            .returning(move |_, _| {
                 Ok(vec![
                     AnswerSearchHit {
                         answer_id: visible_answer_b_id,
@@ -902,7 +927,7 @@ mod tests {
         };
 
         let answers = use_case
-            .search_answers(&actor, "answer".to_string())
+            .search_answers(&actor, "answer".to_string(), Some(readable_form_id))
             .await
             .unwrap();
 
@@ -918,6 +943,76 @@ mod tests {
                 visible_answer_a_id
             ]
         );
+    }
+
+    #[tokio::test]
+    async fn search_answers_returns_empty_without_searching_for_a_missing_form() {
+        let actor = AccountUser::new(
+            "viewer".to_string(),
+            Uuid::from_u128(20).into(),
+            Role::StandardUser,
+        );
+        let missing_form_id = Uuid::from_u128(21).into();
+        let search_repository = MockSearchRepository::new();
+        let active_form_repository = InMemoryActiveFormRepository::default();
+        let answer_label_repository = MockAnswerLabelRepository::new();
+        let form_label_repository = InMemoryFormLabelRepository;
+        let user_repository = InMemoryUserRepository::default();
+        let answer_entry_repository = InMemoryAnswerEntryRepository::default();
+        let comment_repository = MockCommentRepository::new();
+        let use_case = SearchUseCase {
+            search_repository: &search_repository,
+            active_form_repository: &active_form_repository,
+            form_answer_label_repository: &answer_label_repository,
+            form_label_repository: &form_label_repository,
+            user_repository: &user_repository,
+            answer_entry_repository: &answer_entry_repository,
+            comment_repository: &comment_repository,
+        };
+
+        let answers = use_case
+            .search_answers(&actor, "answer".to_string(), Some(missing_form_id))
+            .await
+            .unwrap();
+
+        assert!(answers.is_empty());
+    }
+
+    #[tokio::test]
+    async fn search_answers_returns_empty_without_searching_for_an_unreadable_form() {
+        let permitted_group = UserGroup::new(UserGroupName::new(
+            "permitted".to_string().try_into().unwrap(),
+        ));
+        let actor = AccountUser::new(
+            "viewer".to_string(),
+            Uuid::from_u128(20).into(),
+            Role::StandardUser,
+        );
+        let unreadable_form = form_restricted_to("unreadable", &permitted_group);
+        let unreadable_form_id = *unreadable_form.id();
+        let search_repository = MockSearchRepository::new();
+        let active_form_repository = InMemoryActiveFormRepository::new(vec![unreadable_form]);
+        let answer_label_repository = MockAnswerLabelRepository::new();
+        let form_label_repository = InMemoryFormLabelRepository;
+        let user_repository = InMemoryUserRepository::default();
+        let answer_entry_repository = InMemoryAnswerEntryRepository::default();
+        let comment_repository = MockCommentRepository::new();
+        let use_case = SearchUseCase {
+            search_repository: &search_repository,
+            active_form_repository: &active_form_repository,
+            form_answer_label_repository: &answer_label_repository,
+            form_label_repository: &form_label_repository,
+            user_repository: &user_repository,
+            answer_entry_repository: &answer_entry_repository,
+            comment_repository: &comment_repository,
+        };
+
+        let answers = use_case
+            .search_answers(&actor, "answer".to_string(), Some(unreadable_form_id))
+            .await
+            .unwrap();
+
+        assert!(answers.is_empty());
     }
 
     #[tokio::test]
@@ -977,7 +1072,7 @@ mod tests {
             .returning(|_| Ok(vec![]));
         search_repository
             .expect_search_answers()
-            .returning(move |_| {
+            .returning(move |_, _| {
                 Ok(vec![
                     AnswerSearchHit {
                         answer_id: missing_author_answer_id,
@@ -1086,7 +1181,7 @@ mod tests {
             .returning(|_| Ok(vec![]));
         search_repository
             .expect_search_answers()
-            .returning(move |_| {
+            .returning(move |_, _| {
                 Ok(vec![
                     AnswerSearchHit { answer_id },
                     AnswerSearchHit { answer_id },

--- a/server/usecase/src/search.rs
+++ b/server/usecase/src/search.rs
@@ -7,10 +7,6 @@ use domain::repository::form::answer_label_repository::AnswerLabelRepository;
 use domain::repository::form::comment_repository::CommentRepository;
 use domain::repository::form::form_label_repository::FormLabelRepository;
 use domain::repository::user_repository::UserRepository;
-use domain::search::models::NumberOfRecords;
-use domain::search::models::{
-    AnswerSearchHit, NumberOfRecordsPerAggregate, Operation, UserSearchHit,
-};
 use domain::{
     account::models::AccountUser,
     auth::Actor,
@@ -23,14 +19,23 @@ use domain::{
     repository::{
         form::active_form_repository::ActiveFormRepository, search_repository::SearchRepository,
     },
-    search::models::SearchableFieldsWithOperation,
+    search::models::{
+        AnswerSearchHit, AnswerTitleSearchDocument, FormAnswerComments, FormMetaData,
+        LabelForFormAnswers, LabelForForms, NumberOfRecords, NumberOfRecordsPerAggregate,
+        Operation, RealAnswers, SearchableFields, SearchableFieldsWithOperation, UserSearchHit,
+        Users,
+    },
     types::authorization_guard::{Allowed, AuthorizationGuard, Read},
 };
 use errors::Error;
 use futures::{StreamExt, TryStreamExt, stream, try_join};
-use std::collections::{HashMap, HashSet};
-use std::sync::Arc;
-use std::time::Duration;
+use std::{
+    collections::{HashMap, HashSet},
+    future::ready,
+    iter::once,
+    sync::Arc,
+    time::Duration,
+};
 use tokio::sync::{Notify, mpsc::Receiver};
 use tokio::time;
 
@@ -152,7 +157,7 @@ impl<
     async fn visible_form_with_labels(
         &self,
         actor: &Actor,
-        form_id: domain::form::models::FormId,
+        form_id: FormId,
     ) -> Result<Option<ActiveFormWithLabels>, Error> {
         let Some(form) = self.active_form_repository.get(form_id).await? else {
             return Ok(None);
@@ -243,7 +248,7 @@ impl<
                 self.answer_details(account_user, actor, answer).await
             })
             .buffered(SEARCH_DETAIL_FETCH_CONCURRENCY)
-            .try_filter_map(|visible| std::future::ready(Ok(visible)))
+            .try_filter_map(|visible| ready(Ok(visible)))
             .try_collect()
             .await
     }
@@ -343,7 +348,7 @@ impl<
         let visible_forms = stream::iter(forms)
             .map(|form| async move { self.visible_form_with_labels(actor_ref, form.form_id).await })
             .buffered(SEARCH_DETAIL_FETCH_CONCURRENCY)
-            .try_filter_map(|visible| std::future::ready(Ok(visible)))
+            .try_filter_map(|visible| ready(Ok(visible)))
             .try_collect()
             .await?;
 
@@ -364,7 +369,7 @@ impl<
                     })
             })
             .buffered(SEARCH_DETAIL_FETCH_CONCURRENCY)
-            .try_filter_map(|visible| std::future::ready(Ok(visible)))
+            .try_filter_map(|visible| ready(Ok(visible)))
             .try_collect()
             .await?;
 
@@ -383,7 +388,7 @@ impl<
                     })
             })
             .buffered(SEARCH_DETAIL_FETCH_CONCURRENCY)
-            .try_filter_map(|visible| std::future::ready(Ok(visible)))
+            .try_filter_map(|visible| ready(Ok(visible)))
             .try_collect()
             .await?;
 
@@ -415,7 +420,7 @@ impl<
                 }
             })
             .buffered(SEARCH_DETAIL_FETCH_CONCURRENCY)
-            .try_filter_map(|visible| std::future::ready(Ok(visible)))
+            .try_filter_map(|visible| ready(Ok(visible)))
             .try_collect()
             .await?;
         let visible_comments = self
@@ -496,14 +501,14 @@ impl<
                             .await?
                             .into_iter()
                             .map(|guard| guard.try_read(system.clone()).map_err(Into::into))
-                            .collect::<Result<Vec<_>, errors::Error>>()?;
+                            .collect::<Result<Vec<_>, Error>>()?;
 
                         let forms = form_guards
                             .iter()
                             .map(|form| {
                                 Ok((
-                                    domain::search::models::SearchableFields::FormMetaData(
-                                        domain::search::models::FormMetaData {
+                                    SearchableFields::FormMetaData(
+                                        FormMetaData {
                                             id: form.value().id().to_owned(),
                                             title: form.value().title().to_owned(),
                                             description: form.value().description().to_owned(),
@@ -512,7 +517,7 @@ impl<
                                     Operation::Update,
                                 ))
                             })
-                            .collect::<Result<Vec<_>, errors::Error>>()?;
+                            .collect::<Result<Vec<_>, Error>>()?;
 
                         let answer_entries = self.list_all_answer_entries(&form_guards).await?;
 
@@ -529,8 +534,8 @@ impl<
                                         .map(|comment| comment.into_inner())
                                         .map(|comment| {
                                             (
-                                                domain::search::models::SearchableFields::FormAnswerComments(
-                                                    domain::search::models::FormAnswerComments {
+                                                SearchableFields::FormAnswerComments(
+                                                    FormAnswerComments {
                                                         id: comment.comment_id().to_owned(),
                                                         answer_id: comment.answer_id().to_owned(),
                                                         content: comment
@@ -561,8 +566,8 @@ impl<
                                 let label = guard.try_read(system.clone())?.into_inner();
 
                                 Ok((
-                                    domain::search::models::SearchableFields::LabelForForms(
-                                        domain::search::models::LabelForForms {
+                                    SearchableFields::LabelForForms(
+                                        LabelForForms {
                                             id: label.id().to_owned(),
                                             name: label.name().to_owned().into_inner().into_inner(),
                                         },
@@ -570,7 +575,7 @@ impl<
                                     Operation::Update,
                                 ))
                             })
-                            .collect::<Result<Vec<_>, errors::Error>>()?;
+                            .collect::<Result<Vec<_>, Error>>()?;
 
                         let labels_for_answers = self
                             .form_answer_label_repository
@@ -581,8 +586,8 @@ impl<
                                 let label = guard.try_read(system.clone())?.into_inner();
 
                                 Ok((
-                                    domain::search::models::SearchableFields::LabelForFormAnswers(
-                                        domain::search::models::LabelForFormAnswers {
+                                    SearchableFields::LabelForFormAnswers(
+                                        LabelForFormAnswers {
                                             id: label.id().to_owned(),
                                             name: label.name().to_owned().into_inner(),
                                         },
@@ -590,7 +595,7 @@ impl<
                                     Operation::Update,
                                 ))
                             })
-                            .collect::<Result<Vec<_>, errors::Error>>()?;
+                            .collect::<Result<Vec<_>, Error>>()?;
 
                         let users = self
                             .user_repository
@@ -601,8 +606,8 @@ impl<
                                 let user = guard.try_read(system.clone())?.into_inner();
 
                                 Ok((
-                                    domain::search::models::SearchableFields::Users(
-                                        domain::search::models::Users {
+                                    SearchableFields::Users(
+                                        Users {
                                             id: user.id().into_inner(),
                                             name: user.name().to_owned(),
                                         },
@@ -610,7 +615,7 @@ impl<
                                     Operation::Update,
                                 ))
                             })
-                            .collect::<Result<Vec<_>, errors::Error>>()?;
+                            .collect::<Result<Vec<_>, Error>>()?;
 
                         let data = forms
                             .into_iter()
@@ -659,26 +664,22 @@ fn answer_search_documents(
         .iter()
         .flat_map(|entry| {
             let entry = entry.value();
-            std::iter::once((
-                domain::search::models::SearchableFields::AnswerTitle(
-                    domain::search::models::AnswerTitleSearchDocument {
-                        id: *entry.id(),
-                        form_id: *entry.form_id(),
-                        title: entry.title().clone(),
-                    },
-                ),
+            once((
+                SearchableFields::AnswerTitle(AnswerTitleSearchDocument {
+                    id: *entry.id(),
+                    form_id: *entry.form_id(),
+                    title: entry.title().clone(),
+                }),
                 Operation::Update,
             ))
             .chain(entry.contents().iter().map(|content| {
                 (
-                    domain::search::models::SearchableFields::RealAnswers(
-                        domain::search::models::RealAnswers {
-                            id: content.id,
-                            answer_id: *entry.id(),
-                            question_id: content.question_id,
-                            answer: content.answer.to_owned(),
-                        },
-                    ),
+                    SearchableFields::RealAnswers(RealAnswers {
+                        id: content.id,
+                        answer_id: *entry.id(),
+                        question_id: content.question_id,
+                        answer: content.answer.to_owned(),
+                    }),
                     Operation::Update,
                 )
             }))


### PR DESCRIPTION
## 概要
- 回答検索 API に省略可能な `form_id` クエリパラメータを追加
- 回答タイトルと回答内容の両方を、Meilisearch の検索時点で対象フォームに絞り込み
- 既存検索文書へフォーム ID を必要時のみ再投影し、従来の認可チェックを維持

Closes #1219

## 確認事項
- `cargo build` が成功し、ワークスペース全体をコンパイルできることを確認
- `makers pretty` が成功し、nextest 143 件、doc test、Clippy、rustfmt がすべて成功
- `cargo test --all-features` が成功し、全 feature のテストが通ることを確認
- OpenAPI を再生成し、`form_id` が UUID 形式の省略可能なクエリパラメータとして反映されることを確認

## 補足
- SQL は変更していないため、`.sqlx` メタデータの更新はありません
- 実際の Meilisearch を起動した統合テストは、既存のテスト基盤がないため未実施です。検索式、両インデックスへの適用、再投影経路は単体テストと静的検査で確認しています

🤖 Generated with Codex