### PR TITLE
fix: フォームの Webhook URL を API 応答から隠す

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -5927,7 +5927,7 @@
             }
           },
           "settings": {
-            "$ref": "#/components/schemas/FormSettingsSchema"
+            "$ref": "#/components/schemas/FormSettingsResponseSchema"
           },
           "title": {
             "type": "string"
@@ -6380,16 +6380,17 @@
             }
           },
           "settings": {
-            "$ref": "#/components/schemas/FormSettingsSchema"
+            "$ref": "#/components/schemas/FormSettingsResponseSchema"
           },
           "title": {
             "type": "string"
           }
         }
       },
-      "FormSettingsSchema": {
+      "FormSettingsResponseSchema": {
         "type": "object",
         "required": [
+          "discord_webhook_enabled",
           "visibility",
           "allowed_group_ids",
           "allow_temporary_answers",
@@ -6408,6 +6409,42 @@
           "answer_settings": {
             "$ref": "#/components/schemas/AnswerSettingsSchema"
           },
+          "discord_webhook_enabled": {
+            "type": "boolean"
+          },
+          "visibility": {
+            "type": "string"
+          }
+        }
+      },
+      "FormSettingsSchema": {
+        "type": "object",
+        "properties": {
+          "allow_temporary_answers": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "allowed_group_ids": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "string"
+            }
+          },
+          "answer_settings": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/AnswerSettingsSchema"
+              }
+            ]
+          },
           "discord_webhook_url": {
             "type": [
               "string",
@@ -6415,7 +6452,10 @@
             ]
           },
           "visibility": {
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           }
         }
       },

--- a/server/domain/src/form/settings.rs
+++ b/server/domain/src/form/settings.rs
@@ -63,11 +63,15 @@ impl FormSettings {
     }
 
     pub fn discord_webhook_url(&self, actor: &Actor) -> Result<&DiscordWebhookUrl, DomainError> {
-        if matches!(actor, Actor::System) || is_administrator(actor) {
+        if matches!(actor, Actor::System) {
             Ok(&self.discord_webhook_url)
         } else {
             Err(DomainError::Forbidden)
         }
+    }
+
+    pub fn discord_webhook_enabled(&self) -> bool {
+        self.discord_webhook_url.0.is_some()
     }
 
     pub fn visibility(&self) -> &Visibility {
@@ -142,8 +146,47 @@ impl TryFrom<String> for Visibility {
 }
 
 #[cfg(test)]
-mod webhook_debug_tests {
+mod tests {
     use super::*;
+    use crate::account::models::{AccountUser, Role};
+    use uuid::Uuid;
+
+    #[test]
+    fn webhook_url_is_available_only_to_system() {
+        let secret = "super-secret-token";
+        let webhook = DiscordWebhookUrl::try_new(Some(
+            NonEmptyString::try_new(format!("https://discord.com/api/webhooks/123/{secret}"))
+                .unwrap(),
+        ))
+        .unwrap();
+        let settings = FormSettings::new().change_discord_webhook_url(webhook.clone());
+        let administrator = Actor::from(AccountUser::new(
+            "administrator".to_string(),
+            Uuid::new_v4().into(),
+            Role::Administrator,
+        ));
+
+        assert_eq!(settings.discord_webhook_url(&Actor::System), Ok(&webhook));
+        assert!(matches!(
+            settings.discord_webhook_url(&administrator),
+            Err(DomainError::Forbidden)
+        ));
+    }
+
+    #[test]
+    fn webhook_enabled_reports_whether_a_url_is_configured() {
+        let settings_without_webhook = FormSettings::new();
+        let settings_with_webhook = settings_without_webhook.clone().change_discord_webhook_url(
+            DiscordWebhookUrl::try_new(Some(
+                NonEmptyString::try_new("https://discord.com/api/webhooks/123/token".to_string())
+                    .unwrap(),
+            ))
+            .unwrap(),
+        );
+
+        assert!(!settings_without_webhook.discord_webhook_enabled());
+        assert!(settings_with_webhook.discord_webhook_enabled());
+    }
 
     #[test]
     fn webhook_url_and_form_settings_debug_redact_the_token() {

--- a/server/entrypoint/src/openapi.rs
+++ b/server/entrypoint/src/openapi.rs
@@ -36,7 +36,7 @@ use utoipa_axum::routes;
         presentation::schemas::form::form_response_schemas::FormListPageResponse,
         presentation::schemas::form::form_response_schemas::FormMetaSchema,
         presentation::schemas::form::form_response_schemas::FormSchema,
-        presentation::schemas::form::form_response_schemas::FormSettingsSchema,
+        presentation::schemas::form::form_response_schemas::FormSettingsResponseSchema,
         presentation::schemas::form::form_response_schemas::TemporaryAnswerAuthor,
         presentation::schemas::form::form_response_schemas::MessageContentSchema,
         presentation::schemas::form::form_response_schemas::ChoiceResponseSchema,

--- a/server/infra/resource/src/database/forms/form.rs
+++ b/server/infra/resource/src/database/forms/form.rs
@@ -4,8 +4,7 @@ use domain::account::models::UserGroupId;
 use domain::form::{
     answer::{AnswerEntry, AnswerPagePosition},
     models::{
-        AllowedUserGroups, ArchivedFormPagePosition, DiscordWebhookUrl, FormLabelId,
-        FormPagePosition,
+        AllowedUserGroups, ArchivedFormPagePosition, FormLabelId, FormPagePosition, FormSettings,
     },
     question::{Choice, Question, QuestionId, QuestionType},
 };
@@ -567,13 +566,7 @@ async fn insert_form_root(
         .map(NonEmptyString::into_inner);
     let acceptance_period_start_at = answer_settings.acceptance_period().start_at().to_owned();
     let acceptance_period_end_at = answer_settings.acceptance_period().end_at().to_owned();
-    let discord_webhook_url = form
-        .settings()
-        .discord_webhook_url(&Actor::from(created_by.clone()))
-        .ok()
-        .map(ToOwned::to_owned)
-        .and_then(DiscordWebhookUrl::into_inner)
-        .map(NonEmptyString::into_inner);
+    let discord_webhook_url = discord_webhook_url_for_persistence(form.settings());
 
     sqlx::query(
         r#"INSERT INTO form_meta_data
@@ -605,6 +598,15 @@ async fn insert_form_root(
     Ok(())
 }
 
+fn discord_webhook_url_for_persistence(settings: &FormSettings) -> Option<String> {
+    settings
+        .discord_webhook_url(&Actor::System)
+        .expect("system actor must be allowed to read the Discord webhook URL")
+        .to_owned()
+        .into_inner()
+        .map(NonEmptyString::into_inner)
+}
+
 async fn update_form_root(
     txn: &mut DatabaseTransaction,
     form: &ActiveForm,
@@ -627,13 +629,7 @@ async fn update_form_root(
     let acceptance_period_start_at = answer_settings.acceptance_period().start_at().to_owned();
     let acceptance_period_end_at = answer_settings.acceptance_period().end_at().to_owned();
 
-    let discord_webhook_url = form
-        .settings()
-        .discord_webhook_url(&Actor::from(updated_by.clone()))
-        .ok()
-        .map(ToOwned::to_owned)
-        .and_then(DiscordWebhookUrl::into_inner)
-        .map(NonEmptyString::into_inner);
+    let discord_webhook_url = discord_webhook_url_for_persistence(form.settings());
 
     sqlx::query(
         r#"UPDATE form_meta_data SET
@@ -1891,4 +1887,28 @@ async fn insert_new_choices(
         .await?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use domain::form::models::DiscordWebhookUrl;
+
+    #[test]
+    fn persistence_extracts_the_webhook_url_as_system() {
+        let url = "https://discord.com/api/webhooks/123/token";
+        let settings_with_webhook = FormSettings::new().change_discord_webhook_url(
+            DiscordWebhookUrl::try_new(Some(NonEmptyString::try_new(url.to_string()).unwrap()))
+                .unwrap(),
+        );
+
+        assert_eq!(
+            discord_webhook_url_for_persistence(&settings_with_webhook).as_deref(),
+            Some(url)
+        );
+        assert_eq!(
+            discord_webhook_url_for_persistence(&FormSettings::new()),
+            None
+        );
+    }
 }

--- a/server/presentation/src/handlers/form/form_handler.rs
+++ b/server/presentation/src/handlers/form/form_handler.rs
@@ -46,7 +46,7 @@ use crate::schemas::{
         },
         form_response_schemas::{
             ArchivedFormListPageResponse, ArchivedFormSchema, FormListPageResponse, FormMetaSchema,
-            FormSchema, FormSettingsSchema, QuestionResponseSchema,
+            FormSchema, FormSettingsResponseSchema, QuestionResponseSchema,
         },
     },
 };
@@ -171,7 +171,6 @@ fn build_form_use_case(repository: &RealInfrastructureRepository) -> ResourceFor
 }
 
 fn archived_form_schema_from_parts(
-    actor: &Actor,
     form: ArchivedForm,
     archived_by: AccountUser,
     labels: Vec<FormLabel>,
@@ -180,8 +179,7 @@ fn archived_form_schema_from_parts(
         id: form.form().id().to_owned(),
         title: form.form().title().to_owned(),
         description: form.form().description().to_owned(),
-        settings: FormSettingsSchema::from_settings_and_answer_settings(
-            actor,
+        settings: FormSettingsResponseSchema::from_settings_and_answer_settings(
             form.form().settings(),
             form.form().answer_settings(),
         ),
@@ -380,10 +378,7 @@ pub async fn create_form_handler(
         .await
         .map_err(handle_error)?;
 
-    let actor = Actor::from(user.clone());
-
     Ok(CreateFormResponse::Created(FormSchema::from_active_form(
-        &actor,
         &form,
         vec![],
     )))
@@ -427,7 +422,7 @@ pub async fn form_list_handler(
 
     let response_schema = forms
         .into_iter()
-        .map(|(form, labels)| FormSchema::from_active_form(&actor, &form, labels))
+        .map(|(form, labels)| FormSchema::from_active_form(&form, labels))
         .collect::<Vec<_>>();
 
     Ok(FormListResponse::Ok(FormListPageResponse {
@@ -469,7 +464,7 @@ pub async fn get_form_handler(
         .map_err(handle_error)?;
 
     Ok(GetFormResponse::Ok(FormSchema::from_active_form(
-        &actor, &form, labels,
+        &form, labels,
     )))
 }
 
@@ -504,16 +499,9 @@ pub async fn archive_form_handler(
         .archive_form(&user, form_id)
         .await
         .map_err(handle_error)?;
-    let actor = Actor::from(user.clone());
-
     Ok((
         StatusCode::OK,
-        Json(archived_form_schema_from_parts(
-            &actor,
-            archived_form,
-            user,
-            vec![],
-        )),
+        Json(archived_form_schema_from_parts(archived_form, user, vec![])),
     )
         .into_response())
 }
@@ -617,10 +605,7 @@ pub async fn update_form_handler(
         .await
         .map_err(handle_error)?;
 
-    let actor = Actor::from(user.clone());
-
     Ok(UpdateFormResponse::Ok(FormSchema::from_active_form(
-        &actor,
         &updated_form,
         labels,
     )))
@@ -662,16 +647,10 @@ pub async fn archived_form_list_handler(
         .transpose()
         .map_err(handle_error)?;
 
-    let actor = Actor::from(user);
     let response_schema = forms
         .into_iter()
         .map(|details| {
-            archived_form_schema_from_parts(
-                &actor,
-                details.form,
-                details.archived_by,
-                details.labels,
-            )
+            archived_form_schema_from_parts(details.form, details.archived_by, details.labels)
         })
         .collect::<Vec<_>>();
 
@@ -716,10 +695,7 @@ pub async fn get_archived_form_handler(
         .await
         .map_err(handle_error)?;
 
-    let actor = Actor::from(user.clone());
-
     Ok(ArchivedFormResponse::Ok(archived_form_schema_from_parts(
-        &actor,
         form,
         archived_by,
         labels,

--- a/server/presentation/src/handlers/search_handler.rs
+++ b/server/presentation/src/handlers/search_handler.rs
@@ -9,7 +9,7 @@ use axum::{
     response::IntoResponse,
 };
 use domain::{
-    account::models::AccountUser, auth::Actor, repository::Repositories,
+    account::models::AccountUser, repository::Repositories,
     search::models::SearchableFieldsWithOperation,
 };
 use errors::{Error, ErrorExtra, presentation::PresentationError};
@@ -119,7 +119,6 @@ pub async fn cross_search(
         .await
         .map_err(handle_error)?;
     Ok(CrossSearchResponse::Ok(CrossSearchResult::from_output(
-        &Actor::from(user),
         result,
     )))
 }

--- a/server/presentation/src/schemas/form/form_response_schemas.rs
+++ b/server/presentation/src/schemas/form/form_response_schemas.rs
@@ -64,10 +64,9 @@ impl AnswerSettingsSchema {
     }
 }
 
-#[derive(Serialize, utoipa::ToSchema)]
-pub struct FormSettingsSchema {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub discord_webhook_url: Option<Option<String>>,
+#[derive(Serialize, Debug, utoipa::ToSchema)]
+pub struct FormSettingsResponseSchema {
+    pub discord_webhook_enabled: bool,
     #[schema(value_type = String)]
     pub visibility: Visibility,
     #[schema(value_type = Vec<String>)]
@@ -76,33 +75,13 @@ pub struct FormSettingsSchema {
     pub answer_settings: AnswerSettingsSchema,
 }
 
-impl std::fmt::Debug for FormSettingsSchema {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        formatter
-            .debug_struct("FormSettingsSchema")
-            .field(
-                "discord_webhook_url",
-                &self.discord_webhook_url.as_ref().map(|_| "[REDACTED]"),
-            )
-            .field("visibility", &self.visibility)
-            .field("allowed_group_ids", &self.allowed_group_ids)
-            .field("allow_temporary_answers", &self.allow_temporary_answers)
-            .field("answer_settings", &self.answer_settings)
-            .finish()
-    }
-}
-
-impl FormSettingsSchema {
+impl FormSettingsResponseSchema {
     pub fn from_settings_and_answer_settings(
-        actor: &Actor,
         settings: &FormSettings,
         answer_settings: &AnswerSettings,
     ) -> Self {
-        FormSettingsSchema {
-            discord_webhook_url: settings
-                .discord_webhook_url(actor)
-                .ok()
-                .map(|url| url.to_owned().into_inner().map(NonEmptyString::into_inner)),
+        FormSettingsResponseSchema {
+            discord_webhook_enabled: settings.discord_webhook_enabled(),
             visibility: settings.visibility().to_owned(),
             allowed_group_ids: settings.allowed_user_groups().as_slice().to_vec(),
             allow_temporary_answers: *answer_settings.allow_temporary_answers(),
@@ -134,7 +113,7 @@ pub struct FormSchema {
     pub title: FormTitle,
     #[schema(value_type = String)]
     pub description: FormDescription,
-    pub settings: FormSettingsSchema,
+    pub settings: FormSettingsResponseSchema,
     pub metadata: FormMetaSchema,
     pub questions: Vec<QuestionResponseSchema>,
     #[schema(value_type = Vec<FormLabelResponseSchema>)]
@@ -142,13 +121,12 @@ pub struct FormSchema {
 }
 
 impl FormSchema {
-    pub fn from_active_form(actor: &Actor, form: &ActiveForm, labels: Vec<FormLabel>) -> Self {
+    pub fn from_active_form(form: &ActiveForm, labels: Vec<FormLabel>) -> Self {
         Self {
             id: *form.id(),
             title: form.title().clone(),
             description: form.description().clone(),
-            settings: FormSettingsSchema::from_settings_and_answer_settings(
-                actor,
+            settings: FormSettingsResponseSchema::from_settings_and_answer_settings(
                 form.settings(),
                 form.answer_settings(),
             ),
@@ -178,7 +156,7 @@ pub struct ArchivedFormSchema {
     pub title: FormTitle,
     #[schema(value_type = String)]
     pub description: FormDescription,
-    pub settings: FormSettingsSchema,
+    pub settings: FormSettingsResponseSchema,
     pub metadata: FormMetaSchema,
     pub archived_at: DateTime<Utc>,
     #[schema(value_type = serde_json::Value)]
@@ -667,7 +645,7 @@ mod tests {
     }
 
     #[test]
-    fn form_settings_debug_redacts_the_webhook_token() {
+    fn form_settings_response_exposes_only_whether_the_webhook_is_enabled() {
         let secret = "super-secret-token";
         let settings = FormSettings::new().change_discord_webhook_url(
             DiscordWebhookUrl::try_new(Some(
@@ -676,12 +654,27 @@ mod tests {
             ))
             .unwrap(),
         );
-        let schema = FormSettingsSchema::from_settings_and_answer_settings(
-            &Actor::System,
+        let schema = FormSettingsResponseSchema::from_settings_and_answer_settings(
             &settings,
             &AnswerSettings::default(),
         );
+        let serialized = serde_json::to_value(schema).unwrap();
+        let serialized_without_webhook = serde_json::to_value(
+            FormSettingsResponseSchema::from_settings_and_answer_settings(
+                &FormSettings::new(),
+                &AnswerSettings::default(),
+            ),
+        )
+        .unwrap();
 
-        assert!(!format!("{schema:?}").contains(secret));
+        assert_eq!(serialized["discord_webhook_enabled"], true);
+        assert!(serialized.get("discord_webhook_url").is_none());
+        assert!(!serialized.to_string().contains(secret));
+        assert_eq!(serialized_without_webhook["discord_webhook_enabled"], false);
+        assert!(
+            serialized_without_webhook
+                .get("discord_webhook_url")
+                .is_none()
+        );
     }
 }

--- a/server/presentation/src/schemas/search_schemas.rs
+++ b/server/presentation/src/schemas/search_schemas.rs
@@ -1,7 +1,4 @@
-use domain::{
-    auth::Actor,
-    form::{answer::AnswerId, models::FormId},
-};
+use domain::form::{answer::AnswerId, models::FormId};
 use serde::{Deserialize, Serialize};
 use types::non_empty_string::NonEmptyString;
 use usecase::models::{AnswerDetails, CommentWithAuthor, CrossSearchOutput};
@@ -67,12 +64,12 @@ pub struct CrossSearchResult {
 }
 
 impl CrossSearchResult {
-    pub fn from_output(actor: &Actor, output: CrossSearchOutput) -> Self {
+    pub fn from_output(output: CrossSearchOutput) -> Self {
         Self {
             forms: output
                 .forms
                 .into_iter()
-                .map(|details| FormSchema::from_active_form(actor, &details.form, details.labels))
+                .map(|details| FormSchema::from_active_form(&details.form, details.labels))
                 .collect(),
             users: output.users.into_iter().map(Into::into).collect(),
             answers: output.answers.into_iter().map(Into::into).collect(),
@@ -111,6 +108,7 @@ mod tests {
     use chrono::Utc;
     use domain::{
         account::models::{AccountUser, Role, UserGroup, UserGroupName},
+        auth::Actor,
         form::{
             answer::{
                 AnswerAuthor, AnswerEntry, AnswerId, AnswerLabel, AnswerTitle, FormAnswerContent,
@@ -194,11 +192,6 @@ mod tests {
 
     #[test]
     fn cross_search_result_preserves_detailed_resource_shape_and_comment_parent() {
-        let actor = Actor::from(AccountUser::new(
-            "admin".to_string(),
-            Uuid::from_u128(2).into(),
-            Role::Administrator,
-        ));
         let form = form_with_webhook();
         let form_id = *form.id();
         let answer_id = AnswerId::from(Uuid::from_u128(3));
@@ -237,41 +230,47 @@ mod tests {
             ))],
         );
 
-        let result = CrossSearchResult::from_output(
-            &actor,
-            CrossSearchOutput {
-                forms: vec![ActiveFormWithLabels {
-                    form,
-                    labels: vec![FormLabel::new(FormLabelName::new(
-                        "form label".to_string().try_into().unwrap(),
-                    ))],
-                }],
-                users: vec![searched_user],
-                answers: vec![AnswerDetails {
-                    form_id,
-                    form_answer: answer,
-                    author: Actor::from(answer_author.clone()),
-                    labels: vec![AnswerLabel::new(
-                        "answer label".to_string().try_into().unwrap(),
-                    )],
-                }],
-                label_for_forms: vec![FormLabel::new(FormLabelName::new(
-                    "matching form label".to_string().try_into().unwrap(),
+        let result = CrossSearchResult::from_output(CrossSearchOutput {
+            forms: vec![ActiveFormWithLabels {
+                form,
+                labels: vec![FormLabel::new(FormLabelName::new(
+                    "form label".to_string().try_into().unwrap(),
                 ))],
-                label_for_answers: vec![AnswerLabel::new(
-                    "matching answer label".to_string().try_into().unwrap(),
+            }],
+            users: vec![searched_user],
+            answers: vec![AnswerDetails {
+                form_id,
+                form_answer: answer,
+                author: Actor::from(answer_author.clone()),
+                labels: vec![AnswerLabel::new(
+                    "answer label".to_string().try_into().unwrap(),
                 )],
-                comments: vec![CommentWithAuthor {
-                    comment,
-                    commented_by: answer_author,
-                }],
-            },
-        );
+            }],
+            label_for_forms: vec![FormLabel::new(FormLabelName::new(
+                "matching form label".to_string().try_into().unwrap(),
+            ))],
+            label_for_answers: vec![AnswerLabel::new(
+                "matching answer label".to_string().try_into().unwrap(),
+            )],
+            comments: vec![CommentWithAuthor {
+                comment,
+                commented_by: answer_author,
+            }],
+        });
 
         let serialized = serde_json::to_value(result).unwrap();
 
         assert_eq!(serialized["forms"][0]["title"], "Detailed form");
         assert_eq!(serialized["forms"][0]["description"], "Form description");
+        assert_eq!(
+            serialized["forms"][0]["settings"]["discord_webhook_enabled"],
+            true
+        );
+        assert!(
+            serialized["forms"][0]["settings"]
+                .get("discord_webhook_url")
+                .is_none()
+        );
         assert_eq!(
             serialized["forms"][0]["questions"][0]["template_key"],
             "body"
@@ -313,26 +312,26 @@ mod tests {
     }
 
     #[test]
-    fn cross_search_result_omits_form_webhook_for_standard_user() {
-        let actor = Actor::from(standard_user("viewer"));
-        let result = CrossSearchResult::from_output(
-            &actor,
-            CrossSearchOutput {
-                forms: vec![ActiveFormWithLabels {
-                    form: form_with_webhook(),
-                    labels: vec![],
-                }],
-                users: vec![],
-                answers: vec![],
-                label_for_forms: vec![],
-                label_for_answers: vec![],
-                comments: vec![],
-            },
-        );
+    fn cross_search_result_exposes_webhook_status_without_url() {
+        let result = CrossSearchResult::from_output(CrossSearchOutput {
+            forms: vec![ActiveFormWithLabels {
+                form: form_with_webhook(),
+                labels: vec![],
+            }],
+            users: vec![],
+            answers: vec![],
+            label_for_forms: vec![],
+            label_for_answers: vec![],
+            comments: vec![],
+        });
 
         let serialized = serde_json::to_value(result).unwrap();
 
         assert_eq!(serialized["forms"][0]["title"], "Detailed form");
+        assert_eq!(
+            serialized["forms"][0]["settings"]["discord_webhook_enabled"],
+            true
+        );
         assert!(
             serialized["forms"][0]["settings"]
                 .get("discord_webhook_url")


### PR DESCRIPTION
## 概要
- フォーム API から Discord Webhook URL が漏れないように、応答を `discord_webhook_enabled` の真偽値へ変更
- URL 本体の取得を内部処理に限定し、管理者を含む API 利用者からは取得できないように変更
- 作成・更新リクエストの `discord_webhook_url` は維持し、OpenAPI のリクエスト用・レスポンス用スキーマを分離

## 確認事項
- `cargo build` が成功し、ワークスペース全体をコンパイルできることを確認
- `cargo test --all-features` が成功し、全機能を有効にしたテストと doctest が通ることを確認
- `makers pretty` が成功し、167 件のテスト、doctest、警告をエラーとして扱う Clippy、rustfmt がすべて通ることを確認
- OpenAPI を再生成し、レスポンスでは `discord_webhook_enabled` が必須、作成・更新リクエストでは従来どおり `discord_webhook_url` が任意であることを確認

Closes #1223

🤖 Generated with Codex
