### PR TITLE
fix: フォーム設定の discord_webhook_url と default_answer_title を API から解除できるようにする

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -6467,7 +6467,9 @@
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "description": "Discord Webhook URL。キーを省略すると変更なし、`null` を指定すると通知を無効化する。",
+            "minLength": 1
           },
           "visibility": {
             "type": [

--- a/server/presentation/src/handlers/form/form_handler.rs
+++ b/server/presentation/src/handlers/form/form_handler.rs
@@ -42,7 +42,7 @@ use crate::schemas::{
     form::{
         form_request_schemas::{
             ArchivedFormListQuery, ChoiceSchema, FormCreateSchema, FormListQuery, FormUpdateSchema,
-            QuestionSchema,
+            QuestionSchema, into_default_answer_title, into_discord_webhook_url,
         },
         form_response_schemas::{
             ArchivedFormListPageResponse, ArchivedFormSchema, FormListPageResponse, FormMetaSchema,
@@ -323,65 +323,25 @@ pub async fn create_form_handler(
     let questions = into_create_questions(questions)
         .map_err(errors::Error::from)
         .map_err(handle_error)?;
-    let (
-        discord_webhook_url,
-        visibility,
-        allowed_group_ids,
-        allow_temporary_answers,
-        answer_visibility,
-        answer_group_ids,
-        acceptance_period,
-        default_answer_title,
-        hide_author,
-    ) = settings
-        .map(|settings| {
-            let answer_settings = settings.answer_settings;
-            let (
-                answer_visibility,
-                acceptance_period,
-                default_answer_title,
-                answer_group_ids,
-                hide_author,
-            ) = answer_settings
-                .map(|answer_settings| {
-                    (
-                        answer_settings.visibility,
-                        answer_settings.acceptance_period,
-                        answer_settings.default_answer_title,
-                        answer_settings.answer_group_ids,
-                        answer_settings.hide_author,
-                    )
-                })
-                .unwrap_or_default();
-
-            (
-                settings.discord_webhook_url.and_then(|url| url.0),
-                settings.visibility,
-                settings.allowed_group_ids,
-                settings.allow_temporary_answers,
-                answer_visibility,
-                answer_group_ids,
-                acceptance_period,
-                default_answer_title,
-                hide_author,
-            )
-        })
-        .unwrap_or_default();
+    let settings = settings.unwrap_or_default();
+    let answer_settings = settings.answer_settings.unwrap_or_default();
 
     let form = form_use_case
         .create_form(
             title,
             form_description,
             questions,
-            discord_webhook_url,
-            visibility,
-            allowed_group_ids.map(AllowedUserGroups::new),
-            allow_temporary_answers,
-            answer_visibility,
-            answer_group_ids.map(AllowedUserGroups::new),
-            acceptance_period,
-            default_answer_title,
-            hide_author.map(AnswerAuthorPublicationPolicy::from_hide_author),
+            into_discord_webhook_url(settings.discord_webhook_url),
+            settings.visibility,
+            settings.allowed_group_ids.map(AllowedUserGroups::new),
+            settings.allow_temporary_answers,
+            answer_settings.visibility,
+            answer_settings.answer_group_ids.map(AllowedUserGroups::new),
+            answer_settings.acceptance_period,
+            into_default_answer_title(answer_settings.default_answer_title),
+            answer_settings
+                .hide_author
+                .map(AnswerAuthorPublicationPolicy::from_hide_author),
             &user,
         )
         .await
@@ -547,57 +507,21 @@ pub async fn update_form_handler(
     let Path(form_id) = path.map_err_to_error().map_err(handle_error)?;
     let Json(targets) = json.map_err_to_error().map_err(handle_error)?;
 
-    let title = targets.title;
-    let description = targets.description.map(FormDescription::new);
-    let (
-        acceptance_period,
-        discord_webhook_url,
-        default_answer_title,
-        visibility,
-        allowed_group_ids,
-        allow_temporary_answers,
-        answer_visibility,
-        answer_group_ids,
-        hide_author,
-    ) = if let Some(settings) = &targets.settings {
-        (
-            settings
-                .answer_settings
-                .as_ref()
-                .and_then(|answer_settings| answer_settings.acceptance_period.to_owned()),
-            settings
-                .discord_webhook_url
-                .to_owned()
-                .and_then(|url| url.0),
-            settings
-                .answer_settings
-                .as_ref()
-                .and_then(|answer_settings| answer_settings.default_answer_title.to_owned()),
-            settings.visibility,
-            settings.allowed_group_ids.to_owned(),
-            settings.allow_temporary_answers,
-            settings
-                .answer_settings
-                .as_ref()
-                .and_then(|answer_settings| answer_settings.visibility.to_owned()),
-            settings
-                .answer_settings
-                .as_ref()
-                .and_then(|answer_settings| answer_settings.answer_group_ids.to_owned()),
-            settings
-                .answer_settings
-                .as_ref()
-                .and_then(|answer_settings| answer_settings.hide_author),
-        )
-    } else {
-        (None, None, None, None, None, None, None, None, None)
-    };
-    let questions = targets
-        .questions
+    let FormUpdateSchema {
+        title,
+        description,
+        settings,
+        questions,
+        labels,
+    } = targets;
+
+    let description = description.map(FormDescription::new);
+    let settings = settings.unwrap_or_default();
+    let answer_settings = settings.answer_settings.unwrap_or_default();
+    let questions = questions
         .map(into_upsert_question_inputs)
         .transpose()
         .map_err(handle_error)?;
-    let labels = targets.labels;
 
     let (updated_form, labels) = form_use_case
         .update_form(
@@ -605,15 +529,17 @@ pub async fn update_form_handler(
             form_id,
             title,
             description,
-            acceptance_period,
-            discord_webhook_url,
-            default_answer_title,
-            visibility,
-            allowed_group_ids.map(AllowedUserGroups::new),
-            allow_temporary_answers,
-            answer_visibility,
-            answer_group_ids.map(AllowedUserGroups::new),
-            hide_author.map(AnswerAuthorPublicationPolicy::from_hide_author),
+            answer_settings.acceptance_period,
+            into_discord_webhook_url(settings.discord_webhook_url),
+            into_default_answer_title(answer_settings.default_answer_title),
+            settings.visibility,
+            settings.allowed_group_ids.map(AllowedUserGroups::new),
+            settings.allow_temporary_answers,
+            answer_settings.visibility,
+            answer_settings.answer_group_ids.map(AllowedUserGroups::new),
+            answer_settings
+                .hide_author
+                .map(AnswerAuthorPublicationPolicy::from_hide_author),
             questions,
             labels,
         )

--- a/server/presentation/src/schemas.rs
+++ b/server/presentation/src/schemas.rs
@@ -1,5 +1,6 @@
 pub mod error_response;
 pub mod error_responses;
+pub mod field_update;
 pub mod form;
 pub mod global_discord_webhook;
 pub mod notification;

--- a/server/presentation/src/schemas/field_update.rs
+++ b/server/presentation/src/schemas/field_update.rs
@@ -1,0 +1,37 @@
+use serde::{Deserialize, Deserializer};
+
+/// 部分更新リクエストにおける 1 フィールドの指定。
+///
+/// キーを省略すると `Unchanged`、`null` を指定すると `Clear`、値を指定すると `Set` になる。
+/// フィールド型を `Option<T>` にすると、serde が `null` を見た時点で `T::deserialize` を
+/// 呼ばずに `None` を返すため、キー省略と `null` 明示を区別できない。
+///
+/// このフィールドには必ず `#[serde(default)]` を付ける。付け忘れると、キーがないときに
+/// serde の `missing_field` デシリアライザが `visit_none` を返し、`null` 明示と同じ
+/// `Clear` になるため、キーを省略した PUT が既存の値を消してしまう。
+/// コンパイルエラーにならないので、テストでキー省略が `Unchanged` になることを確かめる。
+///
+/// また `Option<FieldUpdate<T>>` と書いてはならない。外側の `Option` が `null` を吸って
+/// `Unchanged` を返してしまい、`FieldUpdate` を導入した理由そのもの（三値が二値に潰れる）
+/// が再発する。
+#[derive(Debug, Default)]
+pub enum FieldUpdate<T> {
+    #[default]
+    Unchanged,
+    Clear,
+    Set(T),
+}
+
+impl<'de, T: Deserialize<'de>> Deserialize<'de> for FieldUpdate<T> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        // キーが存在するときだけこの impl が呼ばれるため、
+        // ここで観測できる `None` は `null` 明示だけを意味する。
+        Option::<T>::deserialize(deserializer).map(|value| match value {
+            Some(value) => Self::Set(value),
+            None => Self::Clear,
+        })
+    }
+}

--- a/server/presentation/src/schemas/form/form_request_schemas.rs
+++ b/server/presentation/src/schemas/form/form_request_schemas.rs
@@ -11,6 +11,32 @@ use serde::{Deserialize, Deserializer};
 use types::non_empty_string::NonEmptyString;
 use types::non_empty_vec::NonEmptyVec;
 
+use crate::schemas::field_update::FieldUpdate;
+
+/// usecase 境界の「`None` = 変更なし / `Some` = 設定」規約へ写す。
+/// 解除は「値のない `DiscordWebhookUrl` を設定する」ことで表す。
+/// `DiscordWebhookUrl` の既定値が「URL なし」であり、`FormSettings` も
+/// 未設定をこの既定値で表している。
+pub fn into_discord_webhook_url(
+    field: FieldUpdate<DiscordWebhookUrlSchema>,
+) -> Option<DiscordWebhookUrl> {
+    match field {
+        FieldUpdate::Unchanged => None,
+        FieldUpdate::Clear => Some(DiscordWebhookUrl::default()),
+        FieldUpdate::Set(url) => Some(url.0),
+    }
+}
+
+/// usecase 境界の「`None` = 変更なし / `Some` = 設定」規約へ写す。
+/// 解除は「値のない `DefaultAnswerTitle` を設定する」ことで表す。
+pub fn into_default_answer_title(field: FieldUpdate<NonEmptyString>) -> Option<DefaultAnswerTitle> {
+    match field {
+        FieldUpdate::Unchanged => None,
+        FieldUpdate::Clear => Some(DefaultAnswerTitle::new(None)),
+        FieldUpdate::Set(title) => Some(DefaultAnswerTitle::new(Some(title))),
+    }
+}
+
 #[derive(Deserialize, Debug, utoipa::IntoParams)]
 #[into_params(parameter_in = Query)]
 pub struct FormListQuery {
@@ -63,13 +89,14 @@ pub struct FormCreateSchema {
     pub questions: NonEmptyVec<QuestionSchema>,
 }
 
-#[derive(Deserialize, Debug, utoipa::ToSchema)]
+#[derive(Deserialize, Debug, Default, utoipa::ToSchema)]
 pub struct AnswerSettingsSchema {
     #[serde(default)]
     pub hide_author: Option<bool>,
+    /// 回答の既定タイトル。キーを省略すると変更なし、`null` を指定すると設定を解除する。
     #[serde(default)]
-    #[schema(value_type = Option<String>)]
-    pub default_answer_title: Option<DefaultAnswerTitle>,
+    #[schema(value_type = Option<String>, min_length = 1)]
+    pub default_answer_title: FieldUpdate<NonEmptyString>,
     #[serde(default)]
     #[schema(value_type = Option<String>)]
     pub visibility: Option<AnswerVisibility>,
@@ -87,11 +114,12 @@ pub struct AnswerAcceptancePeriodInput {
     pub end_at: Option<String>,
 }
 
-#[derive(Deserialize, Debug, utoipa::ToSchema)]
+#[derive(Deserialize, Debug, Default, utoipa::ToSchema)]
 pub struct FormSettingsSchema {
+    /// Discord Webhook URL。キーを省略すると変更なし、`null` を指定すると通知を無効化する。
     #[serde(default)]
-    #[schema(value_type = Option<Option<String>>)]
-    pub discord_webhook_url: Option<DiscordWebhookUrlSchema>,
+    #[schema(value_type = Option<String>, min_length = 1)]
+    pub discord_webhook_url: FieldUpdate<DiscordWebhookUrlSchema>,
     #[serde(default)]
     #[schema(value_type = Option<String>)]
     pub visibility: Option<Visibility>,
@@ -104,35 +132,31 @@ pub struct FormSettingsSchema {
     pub answer_settings: Option<AnswerSettingsSchema>,
 }
 
-#[derive(Clone)]
-pub struct DiscordWebhookUrlSchema(pub(crate) Option<DiscordWebhookUrl>);
+/// 値として指定された Discord Webhook URL。
+/// 「値がない」状態は `FieldUpdate` が表すため、この型は必ず URL を保持する。
+pub struct DiscordWebhookUrlSchema(DiscordWebhookUrl);
 
 impl std::fmt::Debug for DiscordWebhookUrlSchema {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         formatter
             .debug_tuple("DiscordWebhookUrlSchema")
-            .field(&self.0.as_ref().map(|_| "[REDACTED]"))
+            .field(&"[REDACTED]")
             .finish()
     }
 }
 
 impl<'de> Deserialize<'de> for DiscordWebhookUrlSchema {
+    /// `DiscordWebhookUrl` の derive された `Deserialize` は `try_new` を通らず
+    /// regex 検証を飛ばすため、この手書き impl を消して derive に委ねてはならない。
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
-        let url: Option<String> = Option::deserialize(deserializer)?;
-        match url {
-            Some(url) => {
-                let non_empty_url =
-                    NonEmptyString::try_new(url).map_err(serde::de::Error::custom)?;
-                let discord_webhook_url = DiscordWebhookUrl::try_new(Some(non_empty_url))
-                    .map_err(serde::de::Error::custom)?;
+        let url = NonEmptyString::deserialize(deserializer)?;
 
-                Ok(DiscordWebhookUrlSchema(Some(discord_webhook_url)))
-            }
-            None => Ok(DiscordWebhookUrlSchema(None)),
-        }
+        DiscordWebhookUrl::try_new(Some(url))
+            .map(Self)
+            .map_err(serde::de::Error::custom)
     }
 }
 
@@ -141,16 +165,124 @@ mod tests {
     use super::*;
     use types::non_empty_string::NonEmptyString;
 
+    /// リクエストの JSON が usecase 境界へ渡す値になるまでを通して観測する。
+    /// 外側の `Option` が「変更するか」、内側の `Option` が「設定するか解除するか」を表す。
+    fn discord_webhook_url_update(json: &str) -> Option<Option<String>> {
+        let settings = serde_json::from_str::<FormSettingsSchema>(json).unwrap();
+
+        into_discord_webhook_url(settings.discord_webhook_url)
+            .map(|url| url.into_inner().map(NonEmptyString::into_inner))
+    }
+
+    fn default_answer_title_update(json: &str) -> Option<Option<String>> {
+        let settings = serde_json::from_str::<AnswerSettingsSchema>(json).unwrap();
+
+        into_default_answer_title(settings.default_answer_title)
+            .map(|title| title.into_inner().map(NonEmptyString::into_inner))
+    }
+
+    #[test]
+    fn omitted_discord_webhook_url_changes_nothing_while_null_clears_it() {
+        assert_eq!(discord_webhook_url_update(r#"{}"#), None);
+        assert_eq!(
+            discord_webhook_url_update(r#"{"discord_webhook_url":null}"#),
+            Some(None)
+        );
+        assert_eq!(
+            discord_webhook_url_update(
+                r#"{"discord_webhook_url":"https://discord.com/api/webhooks/123/token"}"#
+            ),
+            Some(Some(
+                "https://discord.com/api/webhooks/123/token".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn discord_webhook_url_rejects_empty_and_non_discord_urls() {
+        for url in [
+            "\"\"",
+            "\"   \"",
+            "\"https://example.com/webhooks/123/token\"",
+        ] {
+            let json = format!(r#"{{"discord_webhook_url":{url}}}"#);
+
+            assert!(
+                serde_json::from_str::<FormSettingsSchema>(&json).is_err(),
+                "{url} should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn omitted_default_answer_title_changes_nothing_while_null_clears_it() {
+        assert_eq!(default_answer_title_update(r#"{}"#), None);
+        assert_eq!(
+            default_answer_title_update(r#"{"default_answer_title":null}"#),
+            Some(None)
+        );
+        assert_eq!(
+            default_answer_title_update(r#"{"default_answer_title":"回答"}"#),
+            Some(Some("回答".to_string()))
+        );
+    }
+
+    #[test]
+    fn default_answer_title_rejects_empty_strings() {
+        for title in ["\"\"", "\"   \""] {
+            let json = format!(r#"{{"default_answer_title":{title}}}"#);
+
+            assert!(
+                serde_json::from_str::<AnswerSettingsSchema>(&json).is_err(),
+                "{title} should be rejected"
+            );
+        }
+    }
+
+    /// 型が生成するスキーマだけを見ている。`AnswerSettingsSchema` は
+    /// レスポンス側と名前が衝突していて `docs/openapi.json` にはリクエスト側が
+    /// 出ないため、`default_answer_title` については実文書を検証できていない。
+    #[test]
+    fn openapi_documents_nullable_settings_fields_as_optional() {
+        fn assert_optional_and_nullable(schema: serde_json::Value, field: &str) {
+            let required = schema["required"]
+                .as_array()
+                .map(|fields| fields.as_slice())
+                .unwrap_or_default();
+
+            assert!(
+                !required.iter().any(|name| name == field),
+                "{field} must stay optional so that omitting it means no change"
+            );
+            assert!(
+                schema["properties"][field]["type"]
+                    .as_array()
+                    .is_some_and(|types| types.iter().any(|value| value == "null")),
+                "{field} must be documented as nullable so that clients can clear it"
+            );
+        }
+
+        assert_optional_and_nullable(
+            serde_json::to_value(<FormSettingsSchema as utoipa::PartialSchema>::schema()).unwrap(),
+            "discord_webhook_url",
+        );
+        assert_optional_and_nullable(
+            serde_json::to_value(<AnswerSettingsSchema as utoipa::PartialSchema>::schema())
+                .unwrap(),
+            "default_answer_title",
+        );
+    }
+
     #[test]
     fn discord_webhook_url_schema_debug_redacts_the_token() {
         let secret = "super-secret-token";
-        let schema = DiscordWebhookUrlSchema(Some(
+        let schema = DiscordWebhookUrlSchema(
             DiscordWebhookUrl::try_new(Some(
                 NonEmptyString::try_new(format!("https://discord.com/api/webhooks/123/{secret}"))
                     .unwrap(),
             ))
             .unwrap(),
-        ));
+        );
 
         assert!(!format!("{schema:?}").contains(secret));
     }


### PR DESCRIPTION
## 概要

- serde の `Option<T>` は JSON の `null` を見た時点で `T::deserialize` を呼ばずに `None` を返すため、`PUT /forms/{id}` の `settings.discord_webhook_url` と `settings.answer_settings.default_answer_title` は「キー省略」と「`null` 明示」がどちらも `None`(= 変更なし) に潰れていた。結果、いったん設定した値を API から解除する手段が存在しなかった（フロントエンドに無効化用のチェックボックスを置いても、送っても何も起きない）
- 三値を表す `FieldUpdate<T> { Unchanged, Clear, Set(T) }` を presentation 層に導入した。フィールド型を `Option<T>` にしないことが要点で、キーが存在する限り `null` でも独自の `Deserialize` が呼ばれる。`Some` だが中身がない状態に意味を持たせる形は `GlobalDiscordWebhookSetting` が doc コメントで明示的に避けているため、同じ轍を踏まないよう三値を型名で表した
- 変更は presentation 層に閉じている。`domain` / `usecase` / `infra` / migration は無変更。usecase は既に「`None` = 変更なし / `Some` = 設定」の規約で、DB のカラムも両方 nullable だったため、解除は既存経路にそのまま乗る
- あわせて、両ハンドラが settings を 9 要素タプルに詰め替えていた箇所を廃止した。`Option<Vec<UserGroupId>>` と `Option<bool>` がそれぞれ 2 つあり、取り違えてもコンパイルが通ってしまうため

### API の挙動

| リクエスト | 変更前 | 変更後 |
|---|---|---|
| キー省略 | 変更なし | 変更なし |
| `"discord_webhook_url": null` | **変更なし**（サイレントに失敗） | **解除** |
| `"discord_webhook_url": "https://discord.com/api/webhooks/..."` | 設定 | 設定 |
| `"discord_webhook_url": ""` | 422 | 422 |

`default_answer_title` も同じ 4 パターン。ワイヤ契約は増えるだけで、既存クライアントの挙動は変わらない。

## 確認事項

- `cargo test` — 全 23 ターゲット 0 failed。`discord_webhook_url` と `default_answer_title` について「省略 / `null` / 有効値 / `""` と `"   "`」の 4 パターンを、JSON から usecase 境界に渡る値までを通して固定するテストを追加した。「実装したから通るテスト」ではなく、`FieldUpdate` を `Option` に戻す・`#[serde(default)]` を外す・手書き `Deserialize` を derive に置き換える、のいずれでも落ちることを確認している
- `makers pretty` — clippy `-D warnings` クリーン、fmt 差分なし
- `makers check-openapi` — pass。`docs/openapi.json` は再生成してコミットに含めた。差分は `FormSettingsSchema.discord_webhook_url` への `description` と `minLength` の追加のみで、`type: ["string","null"]` は旧 `Option<Option<String>>` でも同じだったため文書上の型は変わっていない
- **未確認**: DB へ実際に NULL が書かれるところまでの結合テストは無し（既存スイートに DB を要するテストがないため）。`update_form_root` の `ON DUPLICATE KEY UPDATE url = VALUES(url)`、`default_answer_title` が nullable TEXT、読み戻しの `w.url AS discord_webhook_url?` をコードで追って確認したのみ
- **未確認**: フロントエンドの無効化チェックボックスが実際に `null` を送るかは別リポジトリのため未確認。`""` を送る実装だと 422 になる
- レビューで見てほしい点: `FieldUpdate` に `#[serde(default)]` を付け忘れると「キーを省略した PUT が値を消す」挙動になり、しかもコンパイルエラーにならない。doc コメントに書いてあるが、新しくフィールドを追加するときの落とし穴として共有したい

## 補足

調査中に、今回のスコープ外の既存問題を 3 件見つけた。別 issue として切り出す。

1. **`DiscordWebhookUrl::try_new` の regex がアンカーなし部分一致**（`server/domain/src/form/settings.rs:119`）。`Regex::new("https://discord.com/api/webhooks/.*")` を `is_match` しており、`https://evil.example/?u=https://discord.com/api/webhooks/x` が通る。回答データを任意ホストへ送信できるため、グローバル側と同じ `^https://discord\.com/api/webhooks/[^/?#]+/[^/?#]+$` に揃えたい
2. **リクエスト側とレスポンス側の `AnswerSettingsSchema` が名前衝突**しており、`docs/openapi.json` にはレスポンス側だけが出ている。`FormSettingsSchema.answer_settings` がレスポンス定義を `$ref` するため、生成クライアント上は「`answer_settings` を送るなら 4 フィールド全部必須」という誤った契約になっている（`AnswerAcceptancePeriodInput` が誰からも参照されない孤児になっているのが証拠）。このため今回追加した `default_answer_title` の説明も文書に出ない。テスト側にはこの範囲限定をコメントで明記した
3. **`acceptance_period` が `start_at > end_at` の検証をバイパスする**。`AnswerAcceptancePeriod` は素の `derive(Deserialize)` なので `try_new` を通らず、`{"start_at":"2030-01-01T00:00:00Z","end_at":"2020-01-01T00:00:00Z"}` が `InvalidAnswerAcceptancePeriod` を回避して通る

🤖 Generated with Claude Code