### PR TITLE
feat: コメント検索結果にフォームIDを含める

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -6955,10 +6955,15 @@
           {
             "type": "object",
             "required": [
+              "form_id",
               "answer_id"
             ],
             "properties": {
               "answer_id": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "form_id": {
                 "type": "string",
                 "format": "uuid"
               }

--- a/server/presentation/src/schemas/search_schemas.rs
+++ b/server/presentation/src/schemas/search_schemas.rs
@@ -1,7 +1,7 @@
 use domain::form::{answer::AnswerId, models::FormId};
 use serde::{Deserialize, Serialize};
 use types::non_empty_string::NonEmptyString;
-use usecase::models::{AnswerDetails, CommentWithAuthor, CrossSearchOutput};
+use usecase::models::{AnswerDetails, CrossSearchComment, CrossSearchOutput};
 
 use crate::schemas::{
     form::form_response_schemas::{
@@ -34,16 +34,19 @@ pub struct AnswerSearchQuery {
 #[derive(Serialize, Debug, utoipa::ToSchema)]
 pub struct SearchCommentSchema {
     #[schema(value_type = String, format = "uuid")]
+    pub form_id: FormId,
+    #[schema(value_type = String, format = "uuid")]
     pub answer_id: AnswerId,
     #[serde(flatten)]
     pub comment: AnswerComment,
 }
 
-impl From<CommentWithAuthor> for SearchCommentSchema {
-    fn from(value: CommentWithAuthor) -> Self {
+impl From<CrossSearchComment> for SearchCommentSchema {
+    fn from(value: CrossSearchComment) -> Self {
         Self {
-            answer_id: *value.comment.answer_id(),
-            comment: value.into(),
+            form_id: value.form_id,
+            answer_id: *value.comment.comment.answer_id(),
+            comment: value.comment.into(),
         }
     }
 }
@@ -118,8 +121,8 @@ mod tests {
     };
     use types::non_empty_vec::NonEmptyVec;
     use usecase::models::{
-        ActiveFormWithLabels, AnswerDetails, CommentWithAuthor, PublishedAnswerAuthor,
-        PublishedAnswerEntry,
+        ActiveFormWithLabels, AnswerDetails, CommentWithAuthor, CrossSearchComment,
+        PublishedAnswerAuthor, PublishedAnswerEntry,
     };
     use uuid::Uuid;
 
@@ -251,9 +254,12 @@ mod tests {
             label_for_answers: vec![AnswerLabel::new(
                 "matching answer label".to_string().try_into().unwrap(),
             )],
-            comments: vec![CommentWithAuthor {
-                comment,
-                commented_by: answer_author,
+            comments: vec![CrossSearchComment {
+                form_id,
+                comment: CommentWithAuthor {
+                    comment,
+                    commented_by: answer_author,
+                },
             }],
         });
 
@@ -303,6 +309,7 @@ mod tests {
             serialized["comments"][0]["answer_id"],
             answer_id.to_string()
         );
+        assert_eq!(serialized["comments"][0]["form_id"], form_id.to_string());
         assert_eq!(serialized["comments"][0]["id"], comment_id.to_string());
         assert_eq!(
             serialized["comments"][0]["commented_by"]["name"],

--- a/server/usecase/src/models.rs
+++ b/server/usecase/src/models.rs
@@ -61,6 +61,11 @@ pub struct CommentWithAuthor {
     pub commented_by: AccountUser,
 }
 
+pub struct CrossSearchComment {
+    pub form_id: FormId,
+    pub comment: CommentWithAuthor,
+}
+
 pub struct MessageWithSender {
     pub message: Message,
     pub sender: AccountUser,
@@ -82,5 +87,5 @@ pub struct CrossSearchOutput {
     pub answers: Vec<AnswerDetails>,
     pub label_for_forms: Vec<FormLabel>,
     pub label_for_answers: Vec<AnswerLabel>,
-    pub comments: Vec<CommentWithAuthor>,
+    pub comments: Vec<CrossSearchComment>,
 }

--- a/server/usecase/src/search.rs
+++ b/server/usecase/src/search.rs
@@ -1,7 +1,7 @@
 use crate::{
     models::{
-        ActiveFormWithLabels, AnswerDetails, CommentWithAuthor, CrossSearchOutput,
-        PublishedAnswerAuthor, PublishedAnswerEntry,
+        ActiveFormWithLabels, AnswerDetails, CommentWithAuthor, CrossSearchComment,
+        CrossSearchOutput, PublishedAnswerAuthor, PublishedAnswerEntry,
     },
     user_reference_resolver::resolve_user_references,
 };
@@ -266,30 +266,33 @@ impl<
             .await
     }
 
-    async fn comments_with_authors(
+    async fn cross_search_comments_with_authors(
         &self,
         account_user: &AccountUser,
-        comments: Vec<Comment>,
-    ) -> Result<Vec<CommentWithAuthor>, Error> {
+        comments: Vec<(FormId, Comment)>,
+    ) -> Result<Vec<CrossSearchComment>, Error> {
         let users = resolve_user_references(
             self.user_repository,
             account_user,
             comments
                 .iter()
-                .map(|comment| *comment.commented_by())
+                .map(|(_, comment)| *comment.commented_by())
                 .collect(),
         )
         .await?;
 
         Ok(comments
             .into_iter()
-            .filter_map(|comment| {
+            .filter_map(|(form_id, comment)| {
                 users
                     .get(comment.commented_by())
                     .cloned()
-                    .map(|commented_by| CommentWithAuthor {
-                        comment,
-                        commented_by,
+                    .map(|commented_by| CrossSearchComment {
+                        form_id,
+                        comment: CommentWithAuthor {
+                            comment,
+                            commented_by,
+                        },
                     })
             })
             .collect())
@@ -412,7 +415,7 @@ impl<
             .visible_answer_details(account_user, actor_ref, answers, &visible_answers_by_id)
             .await?;
 
-        let visible_comments: Vec<Comment> = stream::iter(comments)
+        let visible_comments: Vec<(FormId, Comment)> = stream::iter(comments)
             .map(|comment| {
                 let visible_answers_by_id = &visible_answers_by_id;
 
@@ -421,6 +424,7 @@ impl<
                     else {
                         return Ok::<_, Error>(None);
                     };
+                    let form_id = *answer.form_id();
 
                     Ok::<_, Error>(
                         self.comment_repository
@@ -428,7 +432,7 @@ impl<
                             .await?
                             .into_iter()
                             .find(|loaded| *loaded.value().comment_id() == comment.comment_id)
-                            .map(|comment| comment.into_inner()),
+                            .map(|comment| (form_id, comment.into_inner())),
                     )
                 }
             })
@@ -437,7 +441,7 @@ impl<
             .try_collect()
             .await?;
         let visible_comments = self
-            .comments_with_authors(account_user, visible_comments)
+            .cross_search_comments_with_authors(account_user, visible_comments)
             .await?;
 
         Ok(CrossSearchOutput {
@@ -1215,6 +1219,7 @@ mod tests {
         let form = form_restricted_to("comments", &member_group).change_answer_settings(
             AnswerSettings::default().change_visibility(AnswerVisibility::PUBLIC),
         );
+        let form_id = *form.id();
         let question_id = *form.questions().as_slice()[0].id();
         let answer = AnswerEntry::new(
             *form.id(),
@@ -1347,8 +1352,188 @@ mod tests {
         let comment_ids = output
             .comments
             .iter()
-            .map(|comment| *comment.comment.comment_id())
+            .map(|comment| *comment.comment.comment.comment_id())
             .collect::<Vec<_>>();
         assert_eq!(comment_ids, vec![second_comment_id, first_comment_id]);
+
+        let form_ids = output
+            .comments
+            .iter()
+            .map(|comment| comment.form_id)
+            .collect::<Vec<_>>();
+        assert_eq!(form_ids, vec![form_id, form_id]);
+    }
+
+    #[tokio::test]
+    async fn cross_search_comments_keep_authorized_answers_parent_form_and_exclude_unavailable_or_unreadable_hits()
+     {
+        let member_group = UserGroup::new(UserGroupName::new(
+            "members".to_string().try_into().unwrap(),
+        ));
+        let other_group =
+            UserGroup::new(UserGroupName::new("other".to_string().try_into().unwrap()));
+        let actor = AccountUser::with_groups(
+            "viewer".to_string(),
+            Uuid::from_u128(20).into(),
+            Role::StandardUser,
+            vec![member_group.clone()],
+        );
+        let form_a = form_restricted_to("comments a", &member_group).change_answer_settings(
+            AnswerSettings::default().change_visibility(AnswerVisibility::PUBLIC),
+        );
+        let form_b = form_restricted_to("comments b", &member_group).change_answer_settings(
+            AnswerSettings::default().change_visibility(AnswerVisibility::PUBLIC),
+        );
+        let unreadable_form = form_restricted_to("comments hidden", &other_group);
+        let form_a_id = *form_a.id();
+        let form_b_id = *form_b.id();
+        let answer = |form: &ActiveForm| {
+            AnswerEntry::new(
+                *form.id(),
+                AnswerAuthor::AuthenticatedUser(*actor.id()),
+                AnswerTitle::default(),
+                PostedAnswerContents::try_new(
+                    form.questions().as_slice(),
+                    vec![FormAnswerContent {
+                        id: FormAnswerContentId::from(Uuid::new_v4()),
+                        question_id: (*form.questions().as_slice()[0].id()).into(),
+                        answer: "body".to_string(),
+                    }],
+                )
+                .unwrap(),
+            )
+        };
+        let answer_a = answer(&form_a);
+        let answer_b = answer(&form_b);
+        let unreadable_answer = answer(&unreadable_form);
+        let answer_a_id = *answer_a.id();
+        let answer_b_id = *answer_b.id();
+        let unreadable_answer_id = *unreadable_answer.id();
+        let unavailable_answer_id = AnswerId::from(Uuid::from_u128(21));
+        let first_comment_id = CommentId::from(Uuid::from_u128(22));
+        let missing_author_comment_id = CommentId::from(Uuid::from_u128(23));
+        let second_comment_id = CommentId::from(Uuid::from_u128(24));
+        let unavailable_comment_id = CommentId::from(Uuid::from_u128(25));
+        let unreadable_comment_id = CommentId::from(Uuid::from_u128(27));
+        let comment = |answer_id, comment_id, commented_by, content: &str| unsafe {
+            Comment::from_raw_parts(
+                answer_id,
+                comment_id,
+                CommentContent::new(content.to_string().try_into().unwrap()),
+                Utc::now(),
+                commented_by,
+            )
+        };
+        let first_comment = comment(answer_a_id, first_comment_id, *actor.id(), "first");
+        let missing_author_comment = comment(
+            answer_a_id,
+            missing_author_comment_id,
+            Uuid::from_u128(26).into(),
+            "missing author",
+        );
+        let second_comment = comment(answer_b_id, second_comment_id, *actor.id(), "second");
+        let unreadable_comment = comment(
+            unreadable_answer_id,
+            unreadable_comment_id,
+            *actor.id(),
+            "unreadable",
+        );
+
+        let mut search_repository = MockSearchRepository::new();
+        search_repository
+            .expect_search_forms()
+            .returning(|_| Ok(vec![]));
+        search_repository
+            .expect_search_users()
+            .returning(|_| Ok(vec![]));
+        search_repository
+            .expect_search_labels_for_forms()
+            .returning(|_| Ok(vec![]));
+        search_repository
+            .expect_search_labels_for_answers()
+            .returning(|_| Ok(vec![]));
+        search_repository
+            .expect_search_answers()
+            .returning(|_, _| Ok(vec![]));
+        search_repository
+            .expect_search_comments()
+            .returning(move |_| {
+                Ok(vec![
+                    CommentSearchHit {
+                        comment_id: second_comment_id,
+                        answer_id: answer_b_id,
+                    },
+                    CommentSearchHit {
+                        comment_id: unavailable_comment_id,
+                        answer_id: unavailable_answer_id,
+                    },
+                    CommentSearchHit {
+                        comment_id: unreadable_comment_id,
+                        answer_id: unreadable_answer_id,
+                    },
+                    CommentSearchHit {
+                        comment_id: missing_author_comment_id,
+                        answer_id: answer_a_id,
+                    },
+                    CommentSearchHit {
+                        comment_id: first_comment_id,
+                        answer_id: answer_a_id,
+                    },
+                ])
+            });
+
+        let active_form_repository =
+            InMemoryActiveFormRepository::new(vec![form_a, form_b, unreadable_form]);
+        let answer_label_repository = MockAnswerLabelRepository::new();
+        let form_label_repository = InMemoryFormLabelRepository;
+        let user_repository = InMemoryUserRepository::default();
+        user_repository.save_user(actor.clone());
+        let answer_entry_repository =
+            InMemoryAnswerEntryRepository::new(vec![answer_a, answer_b, unreadable_answer]);
+        let mut comment_repository = MockCommentRepository::new();
+        comment_repository
+            .expect_find_by_answer()
+            .returning(move |answer| {
+                let comments = match *answer.id() {
+                    id if id == answer_a_id => {
+                        vec![first_comment.clone(), missing_author_comment.clone()]
+                    }
+                    id if id == answer_b_id => vec![second_comment.clone()],
+                    id if id == unreadable_answer_id => vec![unreadable_comment.clone()],
+                    _ => vec![],
+                };
+
+                comments
+                    .into_iter()
+                    .map(|comment| answer.authorize_comment(comment).map_err(Error::from))
+                    .collect()
+            });
+        let use_case = SearchUseCase {
+            search_repository: &search_repository,
+            active_form_repository: &active_form_repository,
+            form_answer_label_repository: &answer_label_repository,
+            form_label_repository: &form_label_repository,
+            user_repository: &user_repository,
+            answer_entry_repository: &answer_entry_repository,
+            comment_repository: &comment_repository,
+        };
+
+        let output = use_case
+            .cross_search(&actor, "comment".to_string())
+            .await
+            .unwrap();
+
+        let comment_parent_pairs = output
+            .comments
+            .iter()
+            .map(|comment| (*comment.comment.comment.comment_id(), comment.form_id))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            comment_parent_pairs,
+            vec![
+                (second_comment_id, form_b_id),
+                (first_comment_id, form_a_id)
+            ]
+        );
     }
 }


### PR DESCRIPTION
## 概要
- 横断検索のコメント結果に、親フォームを特定する `form_id` を追加しました。
- `form_id` は認可済みの回答から導出し、閲覧不可または取得不能な回答のコメントは従来どおり除外します。
- OpenAPI 定義を更新しました。

## 確認事項
- `cargo build`、`makers pretty`、コメント検索の usecase テスト、レスポンススキーマのテストが成功しました。
- 複数フォーム、取得不能・閲覧不可の回答、投稿者不在を含む検索結果を検証しています。
- 独立レビューで修正必須・任意の指摘はありませんでした。

🤖 Generated with Codex