### PR TITLE
chore(deps): GitHub Actions をコミットハッシュで固定する

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "helpers:pinGitHubActionDigests"
   ],
   "automerge": true,
   "platformAutomerge": true,


### PR DESCRIPTION
## 概要

- サプライチェーン攻撃対策として、GitHub Actions の参照をコミットハッシュで固定したい（#1177）
- `renovate.json` の `extends` に `helpers:pinGitHubActionDigests` を追加。マージ後、renovate が各ワークフローで使用している Actions をダイジェスト固定する PR を自動生成する

## 確認事項

- 現状のワークフロー (`.github/workflows/*.yaml`) を確認したところ、`@master` のようなブランチ参照は既に過去の変更で `vX` 形式のタグへ移行済み
- 唯一 `dtolnay/rust-toolchain@stable` のみブランチ参照が残っているが、これは rustc のリリースチャンネル(`stable`/`beta`/`nightly`)を指定するための意図的な仕様で、バージョンタグに置き換えられるものではない。renovate の github-actions manager は非 semver な ref (ブランチ名など) を `github-digest` datasource でダイジェスト固定のみ行う仕様のため、この参照も正しくハンドリングされる
- `renovate.json` の変更は `node -e "JSON.parse(...)"` で妥当な JSON であることを確認済み
- renovate 自体の実行結果（実際にダイジェスト固定 PR が作られるか）はこの PR のマージ後に renovate 側で確認が必要

🤖 Generated with Claude Code