### PR TITLE
feat: 回答間の関連を保持する

### DIFF
--- a/.sqlx/query-3081e4b27c4dc2d718955f8800142dcab33b20b18b77104b12a6c62c719aadd2.json
+++ b/.sqlx/query-3081e4b27c4dc2d718955f8800142dcab33b20b18b77104b12a6c62c719aadd2.json
@@ -1,0 +1,31 @@
+{
+  "db_name": "MySQL",
+  "query": "SELECT answer_id FROM answer_identities WHERE form_id = ? ORDER BY answer_id FOR UPDATE",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "answer_id",
+        "type_info": {
+          "type": "String",
+          "flags": "NOT_NULL | PRIMARY_KEY | NO_DEFAULT_VALUE",
+          "collation": 224,
+          "max_size": 144
+        },
+        "origin": {
+          "Table": {
+            "table": "seichi_portal.answer_identities",
+            "name": "answer_id"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "3081e4b27c4dc2d718955f8800142dcab33b20b18b77104b12a6c62c719aadd2"
+}

--- a/.sqlx/query-346321b56ac0ed10b182f798d6d124c0d14c79f88e7814c13e11fb604801f1b5.json
+++ b/.sqlx/query-346321b56ac0ed10b182f798d6d124c0d14c79f88e7814c13e11fb604801f1b5.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "MySQL",
+  "query": "INSERT INTO answer_identities (answer_id, form_id) VALUES (?, ?)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": []
+  },
+  "hash": "346321b56ac0ed10b182f798d6d124c0d14c79f88e7814c13e11fb604801f1b5"
+}

--- a/.sqlx/query-38df7820d417a1f19a47ef53d7f95e38d1f032060142d1388e12460ef57a7a73.json
+++ b/.sqlx/query-38df7820d417a1f19a47ef53d7f95e38d1f032060142d1388e12460ef57a7a73.json
@@ -1,0 +1,60 @@
+{
+  "db_name": "MySQL",
+  "query": "SELECT identity_row.form_id, identity_row.answer_id,\n                        active_answer.id IS NULL AS `is_archived!: bool`\n                    FROM answer_relations relation\n                    INNER JOIN answer_identities identity_row ON identity_row.answer_id =\n                        CASE WHEN relation.answer_id_first = ? THEN relation.answer_id_second ELSE relation.answer_id_first END\n                    LEFT JOIN answers active_answer ON active_answer.id = identity_row.answer_id\n                    WHERE relation.answer_id_first = ? OR relation.answer_id_second = ?\n                    ORDER BY identity_row.answer_id",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "form_id",
+        "type_info": {
+          "type": "String",
+          "flags": "NOT_NULL | NO_DEFAULT_VALUE",
+          "collation": 224,
+          "max_size": 144
+        },
+        "origin": {
+          "Table": {
+            "table": "seichi_portal.answer_identities",
+            "name": "form_id"
+          }
+        }
+      },
+      {
+        "ordinal": 1,
+        "name": "answer_id",
+        "type_info": {
+          "type": "String",
+          "flags": "NOT_NULL | PRIMARY_KEY | NO_DEFAULT_VALUE",
+          "collation": 224,
+          "max_size": 144
+        },
+        "origin": {
+          "Table": {
+            "table": "seichi_portal.answer_identities",
+            "name": "answer_id"
+          }
+        }
+      },
+      {
+        "ordinal": 2,
+        "name": "is_archived!: bool",
+        "type_info": {
+          "type": "Long",
+          "flags": "NOT_NULL | BINARY",
+          "collation": 63,
+          "max_size": 1
+        },
+        "origin": "Expression"
+      }
+    ],
+    "parameters": {
+      "Right": 3
+    },
+    "nullable": [
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "38df7820d417a1f19a47ef53d7f95e38d1f032060142d1388e12460ef57a7a73"
+}

--- a/.sqlx/query-6475416bed9e7852c49885d3f4edce3c0b55e9ad0db03b71705d6ed244a9abcf.json
+++ b/.sqlx/query-6475416bed9e7852c49885d3f4edce3c0b55e9ad0db03b71705d6ed244a9abcf.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "MySQL",
+  "query": "DELETE FROM answer_relations WHERE answer_id_first = ? OR answer_id_second = ?",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": []
+  },
+  "hash": "6475416bed9e7852c49885d3f4edce3c0b55e9ad0db03b71705d6ed244a9abcf"
+}

--- a/.sqlx/query-f30e9086799857d3622550e1a9161a85a5a23911dd6be65de92eb781d46cb6c5.json
+++ b/.sqlx/query-f30e9086799857d3622550e1a9161a85a5a23911dd6be65de92eb781d46cb6c5.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "MySQL",
+  "query": "UPDATE answers SET title = ?, publication = ? WHERE id = ? AND form_id = ?",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 4
+    },
+    "nullable": []
+  },
+  "hash": "f30e9086799857d3622550e1a9161a85a5a23911dd6be65de92eb781d46cb6c5"
+}

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -5860,6 +5860,17 @@
               "null"
             ]
           },
+          "related_answer_ids": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "省略時は既存の関連を変更しません。空配列は全解除、配列は直接関連の全置換です。"
+          },
           "title": {
             "type": [
               "string",
@@ -6207,7 +6218,8 @@
           "timestamp",
           "publication",
           "answers",
-          "labels"
+          "labels",
+          "related_answers"
         ],
         "properties": {
           "answers": {
@@ -6235,6 +6247,12 @@
           },
           "publication": {
             "$ref": "#/components/schemas/AnswerPublication"
+          },
+          "related_answers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RelatedAnswer"
+            }
           },
           "timestamp": {
             "type": "string",
@@ -7048,6 +7066,34 @@
               }
             ]
           }
+        ]
+      },
+      "RelatedAnswer": {
+        "type": "object",
+        "required": [
+          "form_id",
+          "answer_id",
+          "lifecycle"
+        ],
+        "properties": {
+          "answer_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "form_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "lifecycle": {
+            "$ref": "#/components/schemas/RelatedAnswerLifecycleSchema"
+          }
+        }
+      },
+      "RelatedAnswerLifecycleSchema": {
+        "type": "string",
+        "enum": [
+          "ACTIVE",
+          "ARCHIVED"
         ]
       },
       "ReplaceAnswerLabelSchema": {

--- a/server/domain/src/form/answer/mod.rs
+++ b/server/domain/src/form/answer/mod.rs
@@ -2,6 +2,7 @@ mod author;
 mod content;
 mod entry;
 mod label;
+mod relation;
 mod settings;
 mod title;
 
@@ -9,6 +10,7 @@ pub use author::{AnswerAuthor, TemporaryAnswerAuthor, TemporaryAnswerAuthorId};
 pub use content::{FormAnswerContent, FormAnswerContentId, PostedAnswerContents};
 pub use entry::{AnswerEntry, AnswerId, AnswerPagePosition, AnswerPublication};
 pub use label::{AnswerLabel, AnswerLabelId};
+pub use relation::AnswerRelation;
 pub use settings::{
     AnswerAcceptancePeriod, AnswerAuthorDisclosure, AnswerAuthorPublicationPolicy, AnswerSettings,
     AnswerVisibility, DefaultAnswerTitle,

--- a/server/domain/src/form/answer/relation.rs
+++ b/server/domain/src/form/answer/relation.rs
@@ -1,0 +1,58 @@
+use errors::domain::DomainError;
+
+use super::AnswerId;
+
+/// 二つの回答の直接的な関連を表す、順序を持たない永続ドメイン概念です。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct AnswerRelation {
+    endpoints: [AnswerId; 2],
+}
+
+impl AnswerRelation {
+    /// 端点を決定的な順序へ正規化します。自己関連はドメイン上存在できません。
+    pub fn new(first: AnswerId, second: AnswerId) -> Result<Self, DomainError> {
+        if first == second {
+            return Err(DomainError::InvalidEntity {
+                message: "an answer cannot be related to itself".to_string(),
+            });
+        }
+
+        Ok(Self {
+            endpoints: if first < second {
+                [first, second]
+            } else {
+                [second, first]
+            },
+        })
+    }
+
+    pub fn endpoints(&self) -> [AnswerId; 2] {
+        self.endpoints
+    }
+
+    pub fn other_endpoint(&self, answer_id: AnswerId) -> Option<AnswerId> {
+        match self.endpoints {
+            [first, second] if first == answer_id => Some(second),
+            [first, second] if second == answer_id => Some(first),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use uuid::Uuid;
+
+    #[test]
+    fn normalizes_undirected_endpoints_and_rejects_self_relations() {
+        let first = AnswerId::from(Uuid::from_u128(2));
+        let second = AnswerId::from(Uuid::from_u128(1));
+
+        let relation = AnswerRelation::new(first, second).unwrap();
+
+        assert_eq!(relation.endpoints(), [second, first]);
+        assert_eq!(relation.other_endpoint(second), Some(first));
+        assert!(AnswerRelation::new(first, first).is_err());
+    }
+}

--- a/server/domain/src/form/models.rs
+++ b/server/domain/src/form/models.rs
@@ -279,6 +279,15 @@ impl Allowed<ActiveForm, Read> {
 }
 
 impl Allowed<ActiveForm, Update> {
+    /// `entry` に対する更新操作を認可します。回答メタデータ以外の、回答を起点とする
+    /// 管理者操作でも親フォームの認可境界を維持するために使います。
+    pub fn authorize_entry_update(
+        &self,
+        entry: AnswerEntry,
+    ) -> Result<Allowed<AnswerEntry, Update>, DomainError> {
+        self.authorize_update(entry)
+    }
+
     /// `entry` のタイトルと個別公開状態を変更し、更新認可済みで返します。指定しない値が変わらないことは
     /// [`AnswerEntry::with_title`] と [`AnswerEntry::change_publication`] による構築で保証され、所属と更新権限は [`ActiveForm`] の
     /// ガード経由で保証される。
@@ -296,7 +305,7 @@ impl Allowed<ActiveForm, Update> {
             Some(publication) => entry.change_publication(publication),
             None => entry,
         };
-        self.authorize_update(entry)
+        self.authorize_entry_update(entry)
     }
 }
 

--- a/server/domain/src/repository.rs
+++ b/server/domain/src/repository.rs
@@ -11,6 +11,7 @@ pub trait Repositories: Send + Sync {
     type ConcreteActiveFormRepository: form::active_form_repository::ActiveFormRepository;
     type ConcreteArchivedFormRepository: form::archived_form_repository::ArchivedFormRepository;
     type ConcreteAnswerEntryRepository: form::answer_entry_repository::AnswerEntryRepository;
+    type ConcreteAnswerRelationRepository: form::answer_relation_repository::AnswerRelationRepository;
     type ConcreteAnswerLabelRepository: form::answer_label_repository::AnswerLabelRepository;
     type ConcreteCommentThreadRepository: form::comment_thread_repository::CommentThreadRepository;
     type ConcreteMessageThreadRepository: form::message_thread_repository::MessageThreadRepository;
@@ -24,6 +25,7 @@ pub trait Repositories: Send + Sync {
     fn active_form_repository(&self) -> &Self::ConcreteActiveFormRepository;
     fn archived_form_repository(&self) -> &Self::ConcreteArchivedFormRepository;
     fn answer_entry_repository(&self) -> &Self::ConcreteAnswerEntryRepository;
+    fn answer_relation_repository(&self) -> &Self::ConcreteAnswerRelationRepository;
     fn answer_label_repository(&self) -> &Self::ConcreteAnswerLabelRepository;
     fn comment_thread_repository(&self) -> &Self::ConcreteCommentThreadRepository;
     fn message_thread_repository(&self) -> &Self::ConcreteMessageThreadRepository;

--- a/server/domain/src/repository/form.rs
+++ b/server/domain/src/repository/form.rs
@@ -1,6 +1,7 @@
 pub mod active_form_repository;
 pub mod answer_entry_repository;
 pub mod answer_label_repository;
+pub mod answer_relation_repository;
 pub mod archived_form_repository;
 pub mod comment_thread_repository;
 pub mod form_label_repository;

--- a/server/domain/src/repository/form/answer_relation_repository.rs
+++ b/server/domain/src/repository/form/answer_relation_repository.rs
@@ -1,0 +1,59 @@
+use async_trait::async_trait;
+use errors::Error;
+
+use crate::{
+    form::{
+        answer::{AnswerEntry, AnswerId},
+        models::FormId,
+    },
+    types::authorization_guard::{Allowed, Update},
+};
+
+/// 保存先での回答のライフサイクルです。関連先の本文はここでは保持しません。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RelatedAnswerLifecycle {
+    Active,
+    Archived,
+}
+
+/// 関連先を API に参照として返すための read model です。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RelatedAnswerReference {
+    pub form_id: FormId,
+    pub answer_id: AnswerId,
+    pub lifecycle: RelatedAnswerLifecycle,
+}
+
+#[async_trait]
+pub trait AnswerRelationRepository: Send + Sync + 'static {
+    /// 関連の全置換が実行可能かを、副作用なしで確認します。
+    /// 実行時にも競合を防ぐため [`Self::replace_for_answer`] が同じ検証を再実行します。
+    async fn validate_replace_for_answer(
+        &self,
+        answer: &Allowed<AnswerEntry, Update>,
+        related_answer_ids: &[AnswerId],
+    ) -> Result<(), Error>;
+
+    /// 指定回答から伸びる直接関連を、入力集合で全置換します。
+    /// `answer` の更新認可は関連の作成・削除に必要な管理者認可の証明です。
+    async fn replace_for_answer(
+        &self,
+        answer: Allowed<AnswerEntry, Update>,
+        related_answer_ids: Vec<AnswerId>,
+    ) -> Result<(), Error>;
+
+    /// 回答メタデータと関連を同一の永続化単位で更新します。
+    /// 関連指定を伴う PATCH が、並行アーカイブによる関係更新失敗だけを残さないための境界です。
+    async fn update_answer_meta_and_replace(
+        &self,
+        answer: Allowed<AnswerEntry, Update>,
+        related_answer_ids: Vec<AnswerId>,
+    ) -> Result<(), Error>;
+
+    /// 指定回答と直接つながる回答を取得します。呼び出し側は表示前に各参照を
+    /// 個別の Read 認可で絞り込みます。
+    async fn list_for_answer(
+        &self,
+        answer_id: AnswerId,
+    ) -> Result<Vec<RelatedAnswerReference>, Error>;
+}

--- a/server/errors/src/infra.rs
+++ b/server/errors/src/infra.rs
@@ -20,6 +20,10 @@ pub enum InfraError {
     FormNotFound { id: Uuid },
     #[error("Answer Not Fount: id = {}", .id)]
     AnswerNotFount { id: i32 },
+    #[error("Answer relation source is not active: id = {}", .id)]
+    AnswerRelationSourceNotActive { id: Uuid },
+    #[error("Answer relation target is not active: id = {}", .id)]
+    AnswerRelationTargetNotActive { id: Uuid },
     #[error("Outgoing Error: {}", .cause)]
     Outgoing { cause: String },
     #[error("Unexpected Error: {}", .cause)]
@@ -68,6 +72,12 @@ impl PartialEq for InfraError {
             }
             Self::AnswerNotFount { id: left } => {
                 matches!(other, Self::AnswerNotFount { id: right } if left == right)
+            }
+            Self::AnswerRelationSourceNotActive { id: left } => {
+                matches!(other, Self::AnswerRelationSourceNotActive { id: right } if left == right)
+            }
+            Self::AnswerRelationTargetNotActive { id: left } => {
+                matches!(other, Self::AnswerRelationTargetNotActive { id: right } if left == right)
             }
             Self::Outgoing { cause: left } => {
                 matches!(other, Self::Outgoing { cause: right } if left == right)

--- a/server/infra/resource/src/database/components.rs
+++ b/server/infra/resource/src/database/components.rs
@@ -41,6 +41,7 @@ use uuid::Uuid;
 pub trait DatabaseComponents: Send + Sync {
     type ConcreteFormDatabase: FormDatabase;
     type ConcreteFormAnswerDatabase: FormAnswerDatabase;
+    type ConcreteFormAnswerRelationDatabase: FormAnswerRelationDatabase;
     type ConcreteFormAnswerLabelDatabase: FormAnswerLabelDatabase;
     type ConcreteFormMessageDatabase: FormMessageDatabase;
     type ConcreteFormCommentDatabase: FormCommentDatabase;
@@ -53,6 +54,7 @@ pub trait DatabaseComponents: Send + Sync {
     type ConcreteMinecraftBanDatabase: MinecraftBanDatabase;
     fn form(&self) -> &Self::ConcreteFormDatabase;
     fn form_answer(&self) -> &Self::ConcreteFormAnswerDatabase;
+    fn form_answer_relation(&self) -> &Self::ConcreteFormAnswerRelationDatabase;
     fn form_answer_label(&self) -> &Self::ConcreteFormAnswerLabelDatabase;
     fn form_message(&self) -> &Self::ConcreteFormMessageDatabase;
     fn form_comment(&self) -> &Self::ConcreteFormCommentDatabase;
@@ -118,6 +120,42 @@ pub trait FormAnswerDatabase: Send + Sync {
     async fn size(&self) -> Result<u32, InfraError>;
     /// 回答本文 (`real_answers`) の件数を返す。
     async fn content_size(&self) -> Result<u32, InfraError>;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RelatedAnswerRecord {
+    pub form_id: FormId,
+    pub answer_id: AnswerId,
+    pub is_archived: bool,
+}
+
+#[automock]
+#[async_trait]
+pub trait FormAnswerRelationDatabase: Send + Sync {
+    /// 関連先と source が現在アクティブな回答として存在するか、副作用なしで確認します。
+    async fn validate_answer_relation_replacement(
+        &self,
+        answer_id: AnswerId,
+        related_answer_ids: &[AnswerId],
+    ) -> Result<(), InfraError>;
+
+    /// 対象 registry 行を決定的順序でロックし、アクティブ回答だけを関連先として
+    /// 受け入れた上で、指定回答の直接関連を全置換します。
+    async fn replace_answer_relations(
+        &self,
+        answer_id: AnswerId,
+        related_answer_ids: Vec<AnswerId>,
+    ) -> Result<(), InfraError>;
+    /// 回答メタデータと関連を一つの transaction で更新します。
+    async fn update_answer_meta_and_replace_relations(
+        &self,
+        answer: &AnswerEntry,
+        related_answer_ids: Vec<AnswerId>,
+    ) -> Result<(), InfraError>;
+    async fn get_answer_relations(
+        &self,
+        answer_id: AnswerId,
+    ) -> Result<Vec<RelatedAnswerRecord>, InfraError>;
 }
 
 #[automock]

--- a/server/infra/resource/src/database/connection.rs
+++ b/server/infra/resource/src/database/connection.rs
@@ -141,6 +141,7 @@ impl ConnectionPool {
 impl DatabaseComponents for ConnectionPool {
     type ConcreteDiscordAPI = Self;
     type ConcreteFormAnswerDatabase = Self;
+    type ConcreteFormAnswerRelationDatabase = Self;
     type ConcreteFormAnswerLabelDatabase = Self;
     type ConcreteFormCommentDatabase = Self;
     type ConcreteFormDatabase = Self;
@@ -156,6 +157,10 @@ impl DatabaseComponents for ConnectionPool {
     }
 
     fn form_answer(&self) -> &Self::ConcreteFormAnswerDatabase {
+        self
+    }
+
+    fn form_answer_relation(&self) -> &Self::ConcreteFormAnswerRelationDatabase {
         self
     }
 

--- a/server/infra/resource/src/database/forms.rs
+++ b/server/infra/resource/src/database/forms.rs
@@ -1,4 +1,5 @@
 pub mod answer_label;
+pub mod answer_relations;
 pub mod answers;
 pub mod comment;
 pub mod form;

--- a/server/infra/resource/src/database/forms/answer_relations.rs
+++ b/server/infra/resource/src/database/forms/answer_relations.rs
@@ -1,0 +1,353 @@
+use std::collections::HashSet;
+use std::str::FromStr;
+
+use async_trait::async_trait;
+use domain::form::{
+    answer::{AnswerId, AnswerRelation},
+    models::FormId,
+};
+use errors::infra::InfraError;
+use itertools::Itertools;
+use sqlx::{AssertSqlSafe, Row, query};
+use uuid::Uuid;
+
+use crate::database::{
+    components::{FormAnswerRelationDatabase, RelatedAnswerRecord},
+    connection::{ConnectionPool, DatabaseTransaction},
+};
+
+fn normalized_relations(
+    answer_id: AnswerId,
+    related_answer_ids: Vec<AnswerId>,
+) -> Result<Vec<AnswerRelation>, InfraError> {
+    let relations = related_answer_ids
+        .into_iter()
+        .map(|related_answer_id| AnswerRelation::new(answer_id, related_answer_id))
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| InfraError::Unexpected {
+            cause: error.to_string(),
+        })?;
+    let unique = relations.iter().copied().collect::<HashSet<_>>();
+    if unique.len() != relations.len() {
+        return Err(InfraError::Unexpected {
+            cause: "duplicate related answer ids are not allowed".to_string(),
+        });
+    }
+    Ok(relations)
+}
+
+async fn fetch_answer_identities(
+    txn: &mut DatabaseTransaction,
+    answer_ids: &[String],
+    for_update: bool,
+) -> Result<HashSet<String>, InfraError> {
+    let sql = format!(
+        "SELECT answer_id FROM answer_identities WHERE answer_id IN ({}) ORDER BY answer_id{}",
+        std::iter::repeat_n("?", answer_ids.len()).join(", "),
+        if for_update { " FOR UPDATE" } else { "" },
+    );
+
+    Ok(answer_ids
+        .iter()
+        .fold(query(AssertSqlSafe(&*sql)), |query, answer_id| {
+            query.bind(answer_id)
+        })
+        .fetch_all(&mut **txn)
+        .await?
+        .into_iter()
+        .map(|row| row.try_get("answer_id"))
+        .collect::<Result<_, sqlx::Error>>()?)
+}
+
+async fn fetch_active_answer_ids(
+    txn: &mut DatabaseTransaction,
+    answer_ids: &[String],
+    for_update: bool,
+) -> Result<HashSet<String>, InfraError> {
+    let sql = format!(
+        "SELECT id FROM answers WHERE id IN ({}) ORDER BY id{}",
+        std::iter::repeat_n("?", answer_ids.len()).join(", "),
+        if for_update { " FOR UPDATE" } else { "" },
+    );
+
+    Ok(answer_ids
+        .iter()
+        .fold(query(AssertSqlSafe(&*sql)), |query, answer_id| {
+            query.bind(answer_id)
+        })
+        .fetch_all(&mut **txn)
+        .await?
+        .into_iter()
+        .map(|row| row.try_get("id"))
+        .collect::<Result<_, sqlx::Error>>()?)
+}
+
+async fn ensure_active_relation_participants(
+    txn: &mut DatabaseTransaction,
+    answer_id: AnswerId,
+    answer_id_string: &str,
+    target_ids: &[String],
+    locked_ids: &[String],
+    for_update: bool,
+) -> Result<(), InfraError> {
+    let identity_ids = fetch_answer_identities(txn, locked_ids, for_update).await?;
+    if !identity_ids.contains(answer_id_string) {
+        return Err(InfraError::AnswerRelationSourceNotActive {
+            id: answer_id.into_inner(),
+        });
+    }
+    if let Some(target_id) = target_ids
+        .iter()
+        .find(|target_id| !identity_ids.contains(*target_id))
+    {
+        return Err(InfraError::AnswerRelationTargetNotActive {
+            id: Uuid::from_str(target_id)?,
+        });
+    }
+
+    let active_ids = fetch_active_answer_ids(txn, locked_ids, for_update).await?;
+    if !active_ids.contains(answer_id_string) {
+        return Err(InfraError::AnswerRelationSourceNotActive {
+            id: answer_id.into_inner(),
+        });
+    }
+    if let Some(target_id) = target_ids
+        .iter()
+        .find(|target_id| !active_ids.contains(*target_id))
+    {
+        return Err(InfraError::AnswerRelationTargetNotActive {
+            id: Uuid::from_str(target_id)?,
+        });
+    }
+
+    Ok(())
+}
+
+struct RelationParticipants {
+    relations: Vec<AnswerRelation>,
+    answer_id_string: String,
+    target_ids: Vec<String>,
+    locked_ids: Vec<String>,
+}
+
+fn relation_participants(
+    answer_id: AnswerId,
+    related_answer_ids: Vec<AnswerId>,
+) -> Result<RelationParticipants, InfraError> {
+    let relations = normalized_relations(answer_id, related_answer_ids)?;
+    let answer_id_string = answer_id.to_string();
+    let target_ids = relations
+        .iter()
+        .filter_map(|relation| relation.other_endpoint(answer_id))
+        .map(|id| id.to_string())
+        .collect::<Vec<_>>();
+    let mut locked_ids = std::iter::once(answer_id_string.clone())
+        .chain(target_ids.iter().cloned())
+        .collect::<Vec<_>>();
+    locked_ids.sort();
+
+    Ok(RelationParticipants {
+        relations,
+        answer_id_string,
+        target_ids,
+        locked_ids,
+    })
+}
+
+async fn replace_relations_in_transaction(
+    txn: &mut DatabaseTransaction,
+    answer_id_string: &str,
+    relations: &[AnswerRelation],
+) -> Result<(), InfraError> {
+    sqlx::query!(
+        "DELETE FROM answer_relations WHERE answer_id_first = ? OR answer_id_second = ?",
+        answer_id_string,
+        answer_id_string,
+    )
+    .execute(&mut **txn)
+    .await?;
+
+    if !relations.is_empty() {
+        // 行数で VALUES の placeholder が変わるため、AssertSqlSafe で動的 SQL を使う。
+        let sql = format!(
+            "INSERT INTO answer_relations (answer_id_first, answer_id_second) VALUES {}",
+            std::iter::repeat_n("(?, ?)", relations.len()).join(", ")
+        );
+        relations
+            .iter()
+            .flat_map(|relation| relation.endpoints())
+            .fold(query(AssertSqlSafe(&*sql)), |query, endpoint| {
+                query.bind(endpoint.to_string())
+            })
+            .execute(&mut **txn)
+            .await?;
+    }
+
+    Ok(())
+}
+
+#[async_trait]
+impl FormAnswerRelationDatabase for ConnectionPool {
+    async fn validate_answer_relation_replacement(
+        &self,
+        answer_id: AnswerId,
+        related_answer_ids: &[AnswerId],
+    ) -> Result<(), InfraError> {
+        let RelationParticipants {
+            answer_id_string,
+            target_ids,
+            locked_ids,
+            ..
+        } = relation_participants(answer_id, related_answer_ids.to_vec())?;
+
+        self.read_only_transaction(move |txn| {
+            Box::pin(async move {
+                ensure_active_relation_participants(
+                    txn,
+                    answer_id,
+                    &answer_id_string,
+                    &target_ids,
+                    &locked_ids,
+                    false,
+                )
+                .await
+            })
+        })
+        .await
+    }
+
+    async fn replace_answer_relations(
+        &self,
+        answer_id: AnswerId,
+        related_answer_ids: Vec<AnswerId>,
+    ) -> Result<(), InfraError> {
+        let RelationParticipants {
+            relations,
+            answer_id_string,
+            target_ids,
+            locked_ids,
+        } = relation_participants(answer_id, related_answer_ids)?;
+
+        self.read_write_transaction(move |txn| {
+            Box::pin(async move {
+                ensure_active_relation_participants(
+                    txn,
+                    answer_id,
+                    &answer_id_string,
+                    &target_ids,
+                    &locked_ids,
+                    true,
+                )
+                .await?;
+
+                replace_relations_in_transaction(txn, &answer_id_string, &relations).await
+            })
+        })
+        .await
+    }
+
+    async fn update_answer_meta_and_replace_relations(
+        &self,
+        answer: &domain::form::answer::AnswerEntry,
+        related_answer_ids: Vec<AnswerId>,
+    ) -> Result<(), InfraError> {
+        let answer = answer.clone();
+        let answer_id = *answer.id();
+        let RelationParticipants {
+            relations,
+            answer_id_string,
+            target_ids,
+            locked_ids,
+        } = relation_participants(answer_id, related_answer_ids)?;
+        let title = answer
+            .title()
+            .to_owned()
+            .into_inner()
+            .map(|title| title.into_inner());
+        let publication = answer.publication().to_string();
+        let form_id = answer.form_id().to_string();
+
+        self.read_write_transaction(move |txn| {
+            Box::pin(async move {
+                ensure_active_relation_participants(
+                    txn,
+                    answer_id,
+                    &answer_id_string,
+                    &target_ids,
+                    &locked_ids,
+                    true,
+                )
+                .await?;
+
+                sqlx::query!(
+                    "UPDATE answers SET title = ?, publication = ? WHERE id = ? AND form_id = ?",
+                    title,
+                    publication,
+                    &answer_id_string,
+                    form_id,
+                )
+                .execute(&mut **txn)
+                .await?;
+
+                replace_relations_in_transaction(txn, &answer_id_string, &relations).await
+            })
+        })
+        .await
+    }
+
+    async fn get_answer_relations(
+        &self,
+        answer_id: AnswerId,
+    ) -> Result<Vec<RelatedAnswerRecord>, InfraError> {
+        self.read_only_transaction(|txn| {
+            Box::pin(async move {
+                let answer_id = answer_id.to_string();
+                let rows = sqlx::query!(
+                    r"SELECT identity_row.form_id, identity_row.answer_id,
+                        active_answer.id IS NULL AS `is_archived!: bool`
+                    FROM answer_relations relation
+                    INNER JOIN answer_identities identity_row ON identity_row.answer_id =
+                        CASE WHEN relation.answer_id_first = ? THEN relation.answer_id_second ELSE relation.answer_id_first END
+                    LEFT JOIN answers active_answer ON active_answer.id = identity_row.answer_id
+                    WHERE relation.answer_id_first = ? OR relation.answer_id_second = ?
+                    ORDER BY identity_row.answer_id",
+                    &answer_id,
+                    &answer_id,
+                    &answer_id,
+                )
+                .fetch_all(&mut **txn)
+                .await?;
+
+                rows.into_iter()
+                    .map(|row| {
+                        Ok::<_, InfraError>(RelatedAnswerRecord {
+                            form_id: FormId::from(Uuid::from_str(&row.form_id)?),
+                            answer_id: AnswerId::from(Uuid::from_str(&row.answer_id)?),
+                            is_archived: row.is_archived,
+                        })
+                    })
+                    .collect()
+            })
+        })
+        .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn answer_id(value: u128) -> AnswerId {
+        AnswerId::from(Uuid::from_u128(value))
+    }
+
+    #[test]
+    fn replacement_input_rejects_self_and_duplicate_targets() {
+        let source = answer_id(1);
+        let target = answer_id(2);
+
+        assert!(normalized_relations(source, vec![source]).is_err());
+        assert!(normalized_relations(source, vec![target, target]).is_err());
+        assert_eq!(normalized_relations(source, vec![target]).unwrap().len(), 1);
+    }
+}

--- a/server/infra/resource/src/database/forms/answers.rs
+++ b/server/infra/resource/src/database/forms/answers.rs
@@ -294,6 +294,14 @@ impl FormAnswerDatabase for ConnectionPool {
                 .execute(&mut **txn)
                 .await?;
 
+                sqlx::query!(
+                    "INSERT INTO answer_identities (answer_id, form_id) VALUES (?, ?)",
+                    &answer_id,
+                    &form_id,
+                )
+                .execute(&mut **txn)
+                .await?;
+
                 if !contents.is_empty() {
                     let sql = format!(
                         "INSERT INTO real_answers (id, answer_id, question_id, answer) VALUES {}",

--- a/server/infra/resource/src/database/forms/form.rs
+++ b/server/infra/resource/src/database/forms/form.rs
@@ -751,6 +751,15 @@ async fn copy_active_form_to_archive(
 
     copy_form_group_restrictions_to_archive(txn, &form_id).await?;
 
+    // 関連更新は registry 行を同じ決定的順序でロックするため、アーカイブも
+    // 回答 ID 順に同じ行をロックして回答のアクティブ性判定と直列化する。
+    sqlx::query!(
+        "SELECT answer_id FROM answer_identities WHERE form_id = ? ORDER BY answer_id FOR UPDATE",
+        &form_id,
+    )
+    .fetch_all(&mut **txn)
+    .await?;
+
     execute_typed_query!(
         txn,
         r"INSERT INTO archived_answers (id, form_id, author_type, user, temporary_user_id, title, publication, timestamp)
@@ -854,6 +863,14 @@ async fn restore_archived_form_to_active(
     );
 
     restore_form_group_restrictions_from_archive(txn, &form_id).await?;
+
+    // archive と同じ registry 行ロック順にそろえ、関連更新との競合を直列化する。
+    sqlx::query!(
+        "SELECT answer_id FROM answer_identities WHERE form_id = ? ORDER BY answer_id FOR UPDATE",
+        &form_id,
+    )
+    .fetch_all(&mut **txn)
+    .await?;
 
     execute_typed_query!(
         txn,

--- a/server/infra/resource/src/repository.rs
+++ b/server/infra/resource/src/repository.rs
@@ -70,6 +70,7 @@ impl<Client: DatabaseComponents + 'static, H: HealthCheckRepository + Send + Syn
     type ConcreteActiveFormRepository = Repository<Client>;
     type ConcreteArchivedFormRepository = Repository<Client>;
     type ConcreteAnswerEntryRepository = Repository<Client>;
+    type ConcreteAnswerRelationRepository = Repository<Client>;
     type ConcreteAnswerLabelRepository = Repository<Client>;
     type ConcreteCommentThreadRepository = Repository<Client>;
     type ConcreteFormLabelRepository = Repository<Client>;
@@ -124,6 +125,10 @@ impl<Client: DatabaseComponents + 'static, H: HealthCheckRepository + Send + Syn
     }
 
     fn answer_entry_repository(&self) -> &Self::ConcreteAnswerEntryRepository {
+        &self.db
+    }
+
+    fn answer_relation_repository(&self) -> &Self::ConcreteAnswerRelationRepository {
         &self.db
     }
 

--- a/server/infra/resource/src/repository/form_repository_impls.rs
+++ b/server/infra/resource/src/repository/form_repository_impls.rs
@@ -1,5 +1,6 @@
 pub mod answer_entry_repository_impl;
 pub mod answer_label_repository_impl;
+pub mod answer_relation_repository_impl;
 pub mod comment_thread_repository_impl;
 pub mod form_label_repository_impl;
 pub mod form_repository_impl;

--- a/server/infra/resource/src/repository/form_repository_impls/answer_relation_repository_impl.rs
+++ b/server/infra/resource/src/repository/form_repository_impls/answer_relation_repository_impl.rs
@@ -1,0 +1,89 @@
+use async_trait::async_trait;
+use domain::{
+    form::answer::{AnswerEntry, AnswerId},
+    repository::form::answer_relation_repository::{
+        AnswerRelationRepository, RelatedAnswerLifecycle, RelatedAnswerReference,
+    },
+    types::authorization_guard::{Allowed, Update},
+};
+use errors::{Error, domain::DomainError, infra::InfraError, usecase::UseCaseError};
+
+use crate::{
+    database::components::{DatabaseComponents, FormAnswerRelationDatabase},
+    repository::Repository,
+};
+
+#[async_trait]
+impl<Client> AnswerRelationRepository for Repository<Client>
+where
+    Client: DatabaseComponents + 'static,
+{
+    async fn validate_replace_for_answer(
+        &self,
+        answer: &Allowed<AnswerEntry, Update>,
+        related_answer_ids: &[AnswerId],
+    ) -> Result<(), Error> {
+        self.client
+            .form_answer_relation()
+            .validate_answer_relation_replacement(*answer.id(), related_answer_ids)
+            .await
+            .map_err(map_relation_replacement_error)
+    }
+
+    async fn replace_for_answer(
+        &self,
+        answer: Allowed<AnswerEntry, Update>,
+        related_answer_ids: Vec<AnswerId>,
+    ) -> Result<(), Error> {
+        self.client
+            .form_answer_relation()
+            .replace_answer_relations(*answer.id(), related_answer_ids)
+            .await
+            .map_err(map_relation_replacement_error)
+    }
+
+    async fn update_answer_meta_and_replace(
+        &self,
+        answer: Allowed<AnswerEntry, Update>,
+        related_answer_ids: Vec<AnswerId>,
+    ) -> Result<(), Error> {
+        self.client
+            .form_answer_relation()
+            .update_answer_meta_and_replace_relations(answer.value(), related_answer_ids)
+            .await
+            .map_err(map_relation_replacement_error)
+    }
+
+    async fn list_for_answer(
+        &self,
+        answer_id: AnswerId,
+    ) -> Result<Vec<RelatedAnswerReference>, Error> {
+        Ok(self
+            .client
+            .form_answer_relation()
+            .get_answer_relations(answer_id)
+            .await?
+            .into_iter()
+            .map(|record| RelatedAnswerReference {
+                form_id: record.form_id,
+                answer_id: record.answer_id,
+                lifecycle: if record.is_archived {
+                    RelatedAnswerLifecycle::Archived
+                } else {
+                    RelatedAnswerLifecycle::Active
+                },
+            })
+            .collect())
+    }
+}
+
+fn map_relation_replacement_error(error: InfraError) -> Error {
+    match error {
+        InfraError::AnswerRelationSourceNotActive { .. } => UseCaseError::AnswerNotFound.into(),
+        InfraError::AnswerRelationTargetNotActive { id } => DomainError::InvalidEntity {
+            message: format!("related answer {id} does not exist or is archived"),
+        }
+        .into(),
+        error => error.into(),
+    }
+}

--- a/server/migration/migrations/20260730000000_add_answer_relations.down.sql
+++ b/server/migration/migrations/20260730000000_add_answer_relations.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE answer_relations;
+DROP TABLE answer_identities;

--- a/server/migration/migrations/20260730000000_add_answer_relations.up.sql
+++ b/server/migration/migrations/20260730000000_add_answer_relations.up.sql
@@ -1,0 +1,25 @@
+CREATE TABLE answer_identities (
+    answer_id CHAR(36) NOT NULL PRIMARY KEY,
+    form_id CHAR(36) NOT NULL,
+    INDEX idx_answer_identities_form_id_answer_id (form_id, answer_id)
+);
+
+INSERT INTO answer_identities (answer_id, form_id)
+SELECT id, form_id FROM answers
+ON DUPLICATE KEY UPDATE form_id = VALUES(form_id);
+
+INSERT INTO answer_identities (answer_id, form_id)
+SELECT id, form_id FROM archived_answers
+ON DUPLICATE KEY UPDATE form_id = VALUES(form_id);
+
+CREATE TABLE answer_relations (
+    answer_id_first CHAR(36) NOT NULL,
+    answer_id_second CHAR(36) NOT NULL,
+    PRIMARY KEY (answer_id_first, answer_id_second),
+    CONSTRAINT fk_answer_relations_first FOREIGN KEY (answer_id_first)
+        REFERENCES answer_identities(answer_id),
+    CONSTRAINT fk_answer_relations_second FOREIGN KEY (answer_id_second)
+        REFERENCES answer_identities(answer_id),
+    CONSTRAINT chk_answer_relations_distinct CHECK (answer_id_first <> answer_id_second),
+    CONSTRAINT chk_answer_relations_normalized CHECK (answer_id_first < answer_id_second)
+);

--- a/server/presentation/src/handlers/error_handler.rs
+++ b/server/presentation/src/handlers/error_handler.rs
@@ -221,6 +221,24 @@ fn handle_infra_error(err: InfraError) -> impl IntoResponse {
                 "ANSWER_NOT_FOUND",
             )
         }
+        InfraError::AnswerRelationSourceNotActive { id } => {
+            tracing::error!("Answer relation source is not active: id = {}", id);
+            problem_response(
+                StatusCode::NOT_FOUND,
+                "Not Found",
+                "Answer not found.",
+                "ANSWER_NOT_FOUND",
+            )
+        }
+        InfraError::AnswerRelationTargetNotActive { id } => {
+            tracing::error!("Answer relation target is not active: id = {}", id);
+            problem_response(
+                StatusCode::UNPROCESSABLE_ENTITY,
+                "Unprocessable Entity",
+                "Related answer does not exist or is archived.",
+                "INVALID_ENTITY",
+            )
+        }
         InfraError::Outgoing { cause } => {
             tracing::error!("Outgoing Error: {}", cause);
             problem_response(

--- a/server/presentation/src/handlers/form/answer_handler.rs
+++ b/server/presentation/src/handlers/form/answer_handler.rs
@@ -52,6 +52,7 @@ type ResourceAnswerUseCase<'a> = AnswerUseCase<
     ResourceRepository,
     ResourceRepository,
     ResourceRepository,
+    ResourceRepository,
 >;
 
 fn build_answer_use_case<'a>(
@@ -64,6 +65,7 @@ fn build_answer_use_case<'a>(
         user_repository: repository.user_repository(),
         form_submission_restriction_repository: repository.form_submission_restriction_repository(),
         answer_entry_repository: repository.answer_entry_repository(),
+        answer_relation_repository: repository.answer_relation_repository(),
         discord_answer_webhook_notifier,
         application_event_publisher: Some(&APPLICATION_EVENT_PUBLISHER),
     }
@@ -254,10 +256,11 @@ pub async fn get_all_answers(
         items: answers
             .into_iter()
             .map(|answer_details| {
-                FormAnswer::new(
+                FormAnswer::with_related_answers(
                     answer_details.answer,
                     answer_details.form_id,
                     answer_details.labels,
+                    answer_details.related_answers,
                 )
             })
             .collect_vec(),
@@ -299,10 +302,11 @@ pub async fn get_answer_handler(
         .await
         .map_err(handle_error)?;
 
-    Ok(GetAnswerResponse::Ok(FormAnswer::new(
+    Ok(GetAnswerResponse::Ok(FormAnswer::with_related_answers(
         answer_details.answer,
         answer_details.form_id,
         answer_details.labels,
+        answer_details.related_answers,
     )))
 }
 
@@ -352,10 +356,11 @@ pub async fn get_answer_by_form_id_handler(
         items: answers
             .into_iter()
             .map(|answer_details| {
-                FormAnswer::new(
+                FormAnswer::with_related_answers(
                     answer_details.answer,
                     answer_details.form_id,
                     answer_details.labels,
+                    answer_details.related_answers,
                 )
             })
             .collect_vec(),
@@ -501,13 +506,21 @@ pub async fn update_answer_handler(
     let Json(schema) = json.map_err_to_error().map_err(handle_error)?;
 
     let answer_details = form_answer_use_case
-        .update_answer_meta(form_id, answer_id, &user, schema.title, schema.publication)
+        .update_answer_meta(
+            form_id,
+            answer_id,
+            &user,
+            schema.title,
+            schema.publication,
+            schema.related_answer_ids,
+        )
         .await
         .map_err(handle_error)?;
 
-    Ok(UpdateAnswerResponse::Ok(FormAnswer::new(
+    Ok(UpdateAnswerResponse::Ok(FormAnswer::with_related_answers(
         answer_details.answer,
         answer_details.form_id,
         answer_details.labels,
+        answer_details.related_answers,
     )))
 }

--- a/server/presentation/src/handlers/search_handler.rs
+++ b/server/presentation/src/handlers/search_handler.rs
@@ -110,6 +110,7 @@ pub async fn cross_search(
         user_repository: repository.user_repository(),
         answer_entry_repository: repository.answer_entry_repository(),
         comment_thread_repository: repository.comment_thread_repository(),
+        answer_relation_repository: repository.answer_relation_repository(),
     };
 
     let query = required_query(query).map_err(handle_error)?;
@@ -153,6 +154,7 @@ pub async fn search_users(
         user_repository: repository.user_repository(),
         answer_entry_repository: repository.answer_entry_repository(),
         comment_thread_repository: repository.comment_thread_repository(),
+        answer_relation_repository: repository.answer_relation_repository(),
     };
 
     let query = required_query(query).map_err(handle_error)?;
@@ -198,6 +200,7 @@ pub async fn search_answers(
         user_repository: repository.user_repository(),
         answer_entry_repository: repository.answer_entry_repository(),
         comment_thread_repository: repository.comment_thread_repository(),
+        answer_relation_repository: repository.answer_relation_repository(),
     };
 
     let Query(search_query) = query.map_err_to_error().map_err(handle_error)?;
@@ -231,6 +234,7 @@ pub async fn start_sync(
         user_repository: repository.user_repository(),
         answer_entry_repository: repository.answer_entry_repository(),
         comment_thread_repository: repository.comment_thread_repository(),
+        answer_relation_repository: repository.answer_relation_repository(),
     };
 
     search_use_case
@@ -250,6 +254,7 @@ pub async fn start_watch_out_of_sync(
         user_repository: repository.user_repository(),
         answer_entry_repository: repository.answer_entry_repository(),
         comment_thread_repository: repository.comment_thread_repository(),
+        answer_relation_repository: repository.answer_relation_repository(),
     };
 
     search_use_case
@@ -268,6 +273,7 @@ pub async fn initialize_search_engine(
         user_repository: repository.user_repository(),
         answer_entry_repository: repository.answer_entry_repository(),
         comment_thread_repository: repository.comment_thread_repository(),
+        answer_relation_repository: repository.answer_relation_repository(),
     };
 
     search_use_case.initialize_search_engine().await

--- a/server/presentation/src/schemas/form/form_request_schemas.rs
+++ b/server/presentation/src/schemas/form/form_request_schemas.rs
@@ -1,7 +1,7 @@
 use domain::account::models::UserGroupId;
 use domain::form::question::{ChoiceId, QuestionId, QuestionType, TemplateKey};
 use domain::form::{
-    answer::{AnswerLabelId, AnswerPublication, AnswerTitle},
+    answer::{AnswerId, AnswerLabelId, AnswerPublication, AnswerTitle},
     models::{
         AnswerAcceptancePeriod, AnswerVisibility, DefaultAnswerTitle, DiscordWebhookUrl,
         FormLabelId, FormTitle, Visibility,
@@ -239,6 +239,26 @@ mod tests {
         }
     }
 
+    #[test]
+    fn related_answer_ids_preserves_omitted_clear_and_replace_commands() {
+        let related_answer_id = uuid::Uuid::from_u128(1);
+
+        let omitted = serde_json::from_str::<AnswerUpdateSchema>(r#"{}"#).unwrap();
+        let clear =
+            serde_json::from_str::<AnswerUpdateSchema>(r#"{"related_answer_ids":[]}"#).unwrap();
+        let replace = serde_json::from_str::<AnswerUpdateSchema>(&format!(
+            r#"{{"related_answer_ids":["{related_answer_id}"]}}"#
+        ))
+        .unwrap();
+
+        assert_eq!(omitted.related_answer_ids, None);
+        assert_eq!(clear.related_answer_ids, Some(vec![]));
+        assert_eq!(
+            replace.related_answer_ids,
+            Some(vec![AnswerId::from(related_answer_id)])
+        );
+    }
+
     /// 型が生成するスキーマだけを見ている。`AnswerSettingsSchema` は
     /// レスポンス側と名前が衝突していて `docs/openapi.json` にはリクエスト側が
     /// 出ないため、`default_answer_title` については実文書を検証できていない。
@@ -340,6 +360,10 @@ pub struct AnswerUpdateSchema {
     #[serde(default)]
     #[schema(value_type = Option<String>)]
     pub publication: Option<AnswerPublication>,
+    /// 省略時は既存の関連を変更しません。空配列は全解除、配列は直接関連の全置換です。
+    #[serde(default)]
+    #[schema(value_type = Option<Vec<String>>, format = "uuid")]
+    pub related_answer_ids: Option<Vec<AnswerId>>,
 }
 
 #[derive(Deserialize, Debug, utoipa::ToSchema)]

--- a/server/presentation/src/schemas/form/form_response_schemas.rs
+++ b/server/presentation/src/schemas/form/form_response_schemas.rs
@@ -11,6 +11,9 @@ use domain::form::{
     },
     question::{Choice, Question, QuestionType},
 };
+use domain::repository::form::answer_relation_repository::{
+    RelatedAnswerLifecycle, RelatedAnswerReference,
+};
 use itertools::Itertools;
 use serde::Serialize;
 use types::non_empty_string::NonEmptyString;
@@ -562,6 +565,34 @@ pub struct FormAnswer {
     publication: AnswerPublication,
     answers: Vec<AnswerContent>,
     labels: Vec<AnswerLabels>,
+    related_answers: Vec<RelatedAnswer>,
+}
+
+#[derive(Serialize, Debug, utoipa::ToSchema)]
+pub struct RelatedAnswer {
+    form_id: Uuid,
+    answer_id: Uuid,
+    lifecycle: RelatedAnswerLifecycleSchema,
+}
+
+#[derive(Serialize, Debug, utoipa::ToSchema)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum RelatedAnswerLifecycleSchema {
+    Active,
+    Archived,
+}
+
+impl From<RelatedAnswerReference> for RelatedAnswer {
+    fn from(reference: RelatedAnswerReference) -> Self {
+        Self {
+            form_id: reference.form_id.into_inner(),
+            answer_id: reference.answer_id.into_inner(),
+            lifecycle: match reference.lifecycle {
+                RelatedAnswerLifecycle::Active => RelatedAnswerLifecycleSchema::Active,
+                RelatedAnswerLifecycle::Archived => RelatedAnswerLifecycleSchema::Archived,
+            },
+        }
+    }
 }
 
 #[derive(Serialize, Debug, utoipa::ToSchema)]
@@ -572,6 +603,15 @@ pub struct AnswerListPageResponse {
 
 impl FormAnswer {
     pub fn new(answer: PublishedAnswerEntry, form_id: FormId, labels: Vec<AnswerLabel>) -> Self {
+        Self::with_related_answers(answer, form_id, labels, Vec::new())
+    }
+
+    pub fn with_related_answers(
+        answer: PublishedAnswerEntry,
+        form_id: FormId,
+        labels: Vec<AnswerLabel>,
+        related_answers: Vec<RelatedAnswerReference>,
+    ) -> Self {
         FormAnswer {
             id: answer.id.into(),
             author: answer.author.into(),
@@ -585,6 +625,7 @@ impl FormAnswer {
                 .map(AnswerContent::from_ref)
                 .collect_vec(),
             labels: labels.into_iter().map(Into::into).collect_vec(),
+            related_answers: related_answers.into_iter().map(Into::into).collect(),
         }
     }
 }

--- a/server/presentation/src/schemas/search_schemas.rs
+++ b/server/presentation/src/schemas/search_schemas.rs
@@ -12,7 +12,12 @@ use crate::schemas::{
 
 impl From<AnswerDetails> for FormAnswer {
     fn from(details: AnswerDetails) -> Self {
-        Self::new(details.answer, details.form_id, details.labels)
+        Self::with_related_answers(
+            details.answer,
+            details.form_id,
+            details.labels,
+            details.related_answers,
+        )
     }
 }
 
@@ -248,6 +253,7 @@ mod tests {
                 labels: vec![AnswerLabel::new(
                     "answer label".to_string().try_into().unwrap(),
                 )],
+                related_answers: vec![],
             }],
             label_for_forms: vec![FormLabel::new(FormLabelName::new(
                 "matching form label".to_string().try_into().unwrap(),

--- a/server/usecase/src/forms/answer.rs
+++ b/server/usecase/src/forms/answer.rs
@@ -7,7 +7,7 @@ use domain::{
     form::{
         answer::{
             AnswerAuthor, AnswerAuthorDisclosure, AnswerEntry, AnswerId, AnswerLabel,
-            AnswerPagePosition, AnswerPublication, AnswerTitle, FormAnswerContent,
+            AnswerPagePosition, AnswerPublication, AnswerRelation, AnswerTitle, FormAnswerContent,
             PostedAnswerContents,
         },
         models::{ActiveForm, FormId},
@@ -20,6 +20,7 @@ use domain::{
             active_form_repository::ActiveFormRepository,
             answer_entry_repository::AnswerEntryRepository,
             answer_label_repository::AnswerLabelRepository,
+            answer_relation_repository::AnswerRelationRepository,
         },
         form_submission_restriction_repository::FormSubmissionRestrictionRepository,
     },
@@ -52,12 +53,14 @@ pub struct AnswerUseCase<
     UserRepo: UserRepository,
     FormSubmissionRestrictionRepo: FormSubmissionRestrictionRepository,
     AnswerEntryRepo: AnswerEntryRepository,
+    AnswerRelationRepo: AnswerRelationRepository,
 > {
     pub active_form_repository: &'a FormRepo,
     pub answer_label_repository: &'a AnswerLabelRepo,
     pub user_repository: &'a UserRepo,
     pub form_submission_restriction_repository: &'a FormSubmissionRestrictionRepo,
     pub answer_entry_repository: &'a AnswerEntryRepo,
+    pub answer_relation_repository: &'a AnswerRelationRepo,
     pub discord_answer_webhook_notifier: Option<&'a dyn DiscordAnswerWebhookNotifier>,
     pub application_event_publisher: Option<&'a dyn ApplicationEventPublisher>,
 }
@@ -68,7 +71,8 @@ impl<
     R3: UserRepository,
     R4: FormSubmissionRestrictionRepository,
     R5: AnswerEntryRepository,
-> AnswerUseCase<'_, R1, R2, R3, R4, R5>
+    R6: AnswerRelationRepository,
+> AnswerUseCase<'_, R1, R2, R3, R4, R5, R6>
 {
     async fn read_form(
         &self,
@@ -117,11 +121,76 @@ impl<
             }
         };
 
+        let related_answers = self
+            .visible_related_answers(actor, *form_answer.id())
+            .await?;
+
         Ok(AnswerDetails {
             form_id,
             answer: PublishedAnswerEntry::new(form_answer.into_inner(), author),
             labels,
+            related_answers,
         })
+    }
+
+    async fn visible_related_answers(
+        &self,
+        user: &AccountUser,
+        answer_id: AnswerId,
+    ) -> Result<
+        Vec<domain::repository::form::answer_relation_repository::RelatedAnswerReference>,
+        Error,
+    > {
+        use domain::{
+            account::models::Role,
+            repository::form::answer_relation_repository::RelatedAnswerLifecycle,
+        };
+
+        let actor = Actor::from(user.clone());
+        let is_administrator = user.role() == &Role::Administrator;
+        let related_answers = self
+            .answer_relation_repository
+            .list_for_answer(answer_id)
+            .await?;
+
+        stream::iter(related_answers)
+            .then(|related_answer| {
+                let actor = actor.clone();
+                async move {
+                    if is_administrator {
+                        return Ok(Some(related_answer));
+                    }
+                    if related_answer.lifecycle == RelatedAnswerLifecycle::Archived {
+                        return Ok(None);
+                    }
+                    let Some(form) = self
+                        .active_form_repository
+                        .get(related_answer.form_id)
+                        .await?
+                    else {
+                        return Ok(None);
+                    };
+                    let Ok(form) = form.try_read(actor.clone()) else {
+                        return Ok(None);
+                    };
+                    match self
+                        .answer_entry_repository
+                        .get(&form, related_answer.answer_id)
+                        .await
+                    {
+                        Ok(answer) => Ok(answer.map(|_| related_answer)),
+                        Err(Error::Domain {
+                            source: DomainError::Forbidden,
+                        }) => Ok(None),
+                        Err(error) => Err(error),
+                    }
+                }
+            })
+            .collect::<Vec<Result<Option<_>, Error>>>()
+            .await
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()
+            .map(|answers| answers.into_iter().flatten().collect())
     }
 
     async fn notify_discord_answer_webhook(
@@ -506,17 +575,35 @@ impl<
         actor: &AccountUser,
         title: Option<AnswerTitle>,
         publication: Option<AnswerPublication>,
+        related_answer_ids: Option<Vec<AnswerId>>,
     ) -> Result<AnswerDetails, Error> {
         let actor_ref = Actor::from(actor.clone());
         let form = self.read_form(form_id, &actor_ref).await?;
+        let related_answer_ids = related_answer_ids
+            .map(|related_answer_ids| validate_related_answer_ids(answer_id, related_answer_ids))
+            .transpose()?;
 
-        let form_answer = match (title, publication) {
-            (None, None) => self
+        if let Some(related_answer_ids) = &related_answer_ids {
+            let form_update = self
+                .active_form_repository
+                .get(form_id)
+                .await?
+                .ok_or(FormNotFound)?
+                .into_update()
+                .try_update(actor_ref.clone())?;
+            let answer = self
                 .answer_entry_repository
                 .get(&form, answer_id)
                 .await?
-                .ok_or(AnswerNotFound)?,
-            (title, publication) => {
+                .ok_or(AnswerNotFound)?;
+            let answer_update = form_update.authorize_entry_update(answer.into_inner())?;
+            self.answer_relation_repository
+                .validate_replace_for_answer(&answer_update, related_answer_ids)
+                .await?;
+        }
+
+        let form_answer = match related_answer_ids {
+            Some(related_answer_ids) => {
                 let form_update = self
                     .active_form_repository
                     .get(form_id)
@@ -532,8 +619,8 @@ impl<
                 let updated_entry =
                     form_update.change_entry_meta(entry.into_inner(), title, publication)?;
 
-                self.answer_entry_repository
-                    .update(&form_update, &updated_entry)
+                self.answer_relation_repository
+                    .update_answer_meta_and_replace(updated_entry, related_answer_ids)
                     .await?;
 
                 self.answer_entry_repository
@@ -541,6 +628,38 @@ impl<
                     .await?
                     .ok_or(AnswerNotFound)?
             }
+            None => match (title, publication) {
+                (None, None) => self
+                    .answer_entry_repository
+                    .get(&form, answer_id)
+                    .await?
+                    .ok_or(AnswerNotFound)?,
+                (title, publication) => {
+                    let form_update = self
+                        .active_form_repository
+                        .get(form_id)
+                        .await?
+                        .ok_or(FormNotFound)?
+                        .into_update()
+                        .try_update(actor_ref.clone())?;
+                    let entry = self
+                        .answer_entry_repository
+                        .get(&form, answer_id)
+                        .await?
+                        .ok_or(AnswerNotFound)?;
+                    let updated_entry =
+                        form_update.change_entry_meta(entry.into_inner(), title, publication)?;
+
+                    self.answer_entry_repository
+                        .update(&form_update, &updated_entry)
+                        .await?;
+
+                    self.answer_entry_repository
+                        .get(&form, answer_id)
+                        .await?
+                        .ok_or(AnswerNotFound)?
+                }
+            },
         };
 
         let labels = self
@@ -559,6 +678,24 @@ impl<
         self.build_answer_details(actor, form_id, form_answer, author_disclosure, labels)
             .await
     }
+}
+
+fn validate_related_answer_ids(
+    answer_id: AnswerId,
+    related_answer_ids: Vec<AnswerId>,
+) -> Result<Vec<AnswerId>, DomainError> {
+    let mut relations = std::collections::HashSet::new();
+
+    for related_answer_id in &related_answer_ids {
+        let relation = AnswerRelation::new(answer_id, *related_answer_id)?;
+        if !relations.insert(relation) {
+            return Err(DomainError::InvalidEntity {
+                message: "duplicate related answer ids are not allowed".to_string(),
+            });
+        }
+    }
+
+    Ok(related_answer_ids)
 }
 
 fn answer_submitted_event(
@@ -606,7 +743,10 @@ mod tests {
             question::Question,
         },
         pagination::PageLimit,
-        repository::form::answer_label_repository::AnswerLabelRepository,
+        repository::form::{
+            answer_label_repository::AnswerLabelRepository,
+            answer_relation_repository::{RelatedAnswerLifecycle, RelatedAnswerReference},
+        },
         types::authorization_guard::{AuthorizationGuard, Create, Delete, Update},
     };
     use errors::domain::DomainError;
@@ -796,6 +936,7 @@ mod tests {
             form_submission_restriction_repository: &repositories
                 .form_submission_restriction_repository,
             answer_entry_repository: &repositories.answer_entry_repository,
+            answer_relation_repository: &repositories.answer_relation_repository,
             discord_answer_webhook_notifier: None,
             application_event_publisher: Some(&publisher),
         };
@@ -847,6 +988,7 @@ mod tests {
             form_submission_restriction_repository: &repositories
                 .form_submission_restriction_repository,
             answer_entry_repository: &repositories.answer_entry_repository,
+            answer_relation_repository: &repositories.answer_relation_repository,
             discord_answer_webhook_notifier: Some(&notifier),
             application_event_publisher: Some(&publisher),
         };
@@ -918,6 +1060,7 @@ mod tests {
             form_submission_restriction_repository: &repositories
                 .form_submission_restriction_repository,
             answer_entry_repository: &repositories.answer_entry_repository,
+            answer_relation_repository: &repositories.answer_relation_repository,
             discord_answer_webhook_notifier: Some(&notifier),
             application_event_publisher: Some(&publisher),
         };
@@ -977,6 +1120,7 @@ mod tests {
             form_submission_restriction_repository: &repositories
                 .form_submission_restriction_repository,
             answer_entry_repository: &repositories.answer_entry_repository,
+            answer_relation_repository: &repositories.answer_relation_repository,
             discord_answer_webhook_notifier: None,
             application_event_publisher: None,
         };
@@ -1031,6 +1175,7 @@ mod tests {
             form_submission_restriction_repository: &repositories
                 .form_submission_restriction_repository,
             answer_entry_repository: &repositories.answer_entry_repository,
+            answer_relation_repository: &repositories.answer_relation_repository,
             discord_answer_webhook_notifier: None,
             application_event_publisher: None,
         };
@@ -1042,6 +1187,7 @@ mod tests {
                 &administrator,
                 None,
                 Some(AnswerPublication::PRIVATE),
+                None,
             )
             .await
             .unwrap();
@@ -1053,6 +1199,294 @@ mod tests {
                 source: DomainError::Forbidden
             })
         ));
+    }
+
+    #[tokio::test]
+    async fn update_answer_meta_replaces_related_answers_only_when_the_command_is_present() {
+        let form = sample_form();
+        let form_id = *form.id();
+        let administrator = active_user("administrator", Role::Administrator);
+        let answer = AnswerEntry::new(
+            form_id,
+            AnswerAuthor::Temporary(TemporaryAnswerAuthor::new(
+                "author".to_string(),
+                "contact".to_string(),
+            )),
+            AnswerTitle::default(),
+            PostedAnswerContents::try_new(form.questions().as_slice(), vec![answer_to(&form)])
+                .unwrap(),
+        );
+        let answer_id = *answer.id();
+        let mut repositories = FormUseCaseTestRepositories::with_active_forms(vec![form]);
+        repositories.answer_entry_repository =
+            crate::test_utils::repositories::InMemoryAnswerEntryRepository::new(vec![answer]);
+        let labels = EmptyAnswerLabelRepository;
+        let usecase = AnswerUseCase {
+            active_form_repository: &repositories.active_form_repository,
+            answer_label_repository: &labels,
+            user_repository: &repositories.user_repository,
+            form_submission_restriction_repository: &repositories
+                .form_submission_restriction_repository,
+            answer_entry_repository: &repositories.answer_entry_repository,
+            answer_relation_repository: &repositories.answer_relation_repository,
+            discord_answer_webhook_notifier: None,
+            application_event_publisher: None,
+        };
+
+        usecase
+            .update_answer_meta(form_id, answer_id, &administrator, None, None, None)
+            .await
+            .unwrap();
+        assert_eq!(
+            repositories
+                .answer_relation_repository
+                .replaced_targets(answer_id),
+            None
+        );
+
+        let first_target = Uuid::new_v4().into();
+        let second_target = Uuid::new_v4().into();
+        usecase
+            .update_answer_meta(
+                form_id,
+                answer_id,
+                &administrator,
+                None,
+                None,
+                Some(vec![first_target, second_target]),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            repositories
+                .answer_relation_repository
+                .replaced_targets(answer_id),
+            Some(vec![first_target, second_target])
+        );
+
+        usecase
+            .update_answer_meta(form_id, answer_id, &administrator, None, None, Some(vec![]))
+            .await
+            .unwrap();
+        assert_eq!(
+            repositories
+                .answer_relation_repository
+                .replaced_targets(answer_id),
+            Some(vec![])
+        );
+    }
+
+    #[tokio::test]
+    async fn update_answer_meta_rejects_invalid_related_answers_before_persisting_metadata() {
+        let form = sample_form();
+        let form_id = *form.id();
+        let administrator = active_user("administrator", Role::Administrator);
+        let answer = AnswerEntry::new(
+            form_id,
+            AnswerAuthor::Temporary(TemporaryAnswerAuthor::new(
+                "author".to_string(),
+                "contact".to_string(),
+            )),
+            AnswerTitle::default(),
+            PostedAnswerContents::try_new(form.questions().as_slice(), vec![answer_to(&form)])
+                .unwrap(),
+        );
+        let answer_id = *answer.id();
+        let mut repositories = FormUseCaseTestRepositories::with_active_forms(vec![form]);
+        repositories.answer_entry_repository =
+            crate::test_utils::repositories::InMemoryAnswerEntryRepository::new(vec![answer]);
+        let labels = EmptyAnswerLabelRepository;
+        let usecase = AnswerUseCase {
+            active_form_repository: &repositories.active_form_repository,
+            answer_label_repository: &labels,
+            user_repository: &repositories.user_repository,
+            form_submission_restriction_repository: &repositories
+                .form_submission_restriction_repository,
+            answer_entry_repository: &repositories.answer_entry_repository,
+            answer_relation_repository: &repositories.answer_relation_repository,
+            discord_answer_webhook_notifier: None,
+            application_event_publisher: None,
+        };
+
+        let self_relation = usecase
+            .update_answer_meta(
+                form_id,
+                answer_id,
+                &administrator,
+                Some(AnswerTitle::new(Some(
+                    "changed".to_string().try_into().unwrap(),
+                ))),
+                Some(AnswerPublication::PRIVATE),
+                Some(vec![answer_id]),
+            )
+            .await;
+        assert!(matches!(
+            self_relation,
+            Err(Error::Domain {
+                source: DomainError::InvalidEntity { .. }
+            })
+        ));
+        let unchanged_answer = usecase
+            .get_answers(form_id, answer_id, &administrator)
+            .await
+            .unwrap();
+        assert_eq!(unchanged_answer.answer.title, AnswerTitle::default());
+        assert_eq!(
+            unchanged_answer.answer.publication,
+            AnswerPublication::PUBLIC
+        );
+
+        let archived_or_missing_target = Uuid::new_v4().into();
+        repositories
+            .answer_relation_repository
+            .mark_target_archived_or_missing(archived_or_missing_target);
+        let archived_or_missing_relation = usecase
+            .update_answer_meta(
+                form_id,
+                answer_id,
+                &administrator,
+                Some(AnswerTitle::new(Some(
+                    "changed again".to_string().try_into().unwrap(),
+                ))),
+                Some(AnswerPublication::PRIVATE),
+                Some(vec![archived_or_missing_target]),
+            )
+            .await;
+        assert!(matches!(
+            archived_or_missing_relation,
+            Err(Error::Domain {
+                source: DomainError::InvalidEntity { .. }
+            })
+        ));
+        let still_unchanged_answer = usecase
+            .get_answers(form_id, answer_id, &administrator)
+            .await
+            .unwrap();
+        assert_eq!(still_unchanged_answer.answer.title, AnswerTitle::default());
+        assert_eq!(
+            still_unchanged_answer.answer.publication,
+            AnswerPublication::PUBLIC
+        );
+
+        let target = Uuid::new_v4().into();
+        let duplicate_relation = usecase
+            .update_answer_meta(
+                form_id,
+                answer_id,
+                &administrator,
+                None,
+                None,
+                Some(vec![target, target]),
+            )
+            .await;
+        assert!(matches!(
+            duplicate_relation,
+            Err(Error::Domain {
+                source: DomainError::InvalidEntity { .. }
+            })
+        ));
+        assert_eq!(
+            repositories
+                .answer_relation_repository
+                .replaced_targets(answer_id),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn related_answers_are_visible_to_standard_users_only_when_active_and_readable() {
+        let form = sample_form().change_answer_settings(
+            AnswerSettings::default()
+                .change_visibility(domain::form::models::AnswerVisibility::PUBLIC),
+        );
+        let form_id = *form.id();
+        let source = AnswerEntry::new(
+            form_id,
+            AnswerAuthor::Temporary(TemporaryAnswerAuthor::new(
+                "source".to_string(),
+                "contact".to_string(),
+            )),
+            AnswerTitle::default(),
+            PostedAnswerContents::try_new(form.questions().as_slice(), vec![answer_to(&form)])
+                .unwrap(),
+        );
+        let readable_target = AnswerEntry::new(
+            form_id,
+            AnswerAuthor::Temporary(TemporaryAnswerAuthor::new(
+                "target".to_string(),
+                "contact".to_string(),
+            )),
+            AnswerTitle::default(),
+            PostedAnswerContents::try_new(form.questions().as_slice(), vec![answer_to(&form)])
+                .unwrap(),
+        );
+        let private_target = AnswerEntry::new(
+            form_id,
+            AnswerAuthor::Temporary(TemporaryAnswerAuthor::new(
+                "private target".to_string(),
+                "contact".to_string(),
+            )),
+            AnswerTitle::default(),
+            PostedAnswerContents::try_new(form.questions().as_slice(), vec![answer_to(&form)])
+                .unwrap(),
+        )
+        .change_publication(AnswerPublication::PRIVATE);
+        let source_id = *source.id();
+        let readable_relation = RelatedAnswerReference {
+            form_id,
+            answer_id: *readable_target.id(),
+            lifecycle: RelatedAnswerLifecycle::Active,
+        };
+        let unreadable_relation = RelatedAnswerReference {
+            form_id,
+            answer_id: *private_target.id(),
+            lifecycle: RelatedAnswerLifecycle::Active,
+        };
+        let archived_relation = RelatedAnswerReference {
+            form_id: Uuid::new_v4().into(),
+            answer_id: Uuid::new_v4().into(),
+            lifecycle: RelatedAnswerLifecycle::Archived,
+        };
+        let mut repositories = FormUseCaseTestRepositories::with_active_forms(vec![form]);
+        repositories.answer_entry_repository =
+            crate::test_utils::repositories::InMemoryAnswerEntryRepository::new(vec![
+                source,
+                readable_target,
+                private_target,
+            ]);
+        repositories.answer_relation_repository.set_related_answers(
+            source_id,
+            vec![readable_relation, unreadable_relation, archived_relation],
+        );
+        let labels = EmptyAnswerLabelRepository;
+        let usecase = AnswerUseCase {
+            active_form_repository: &repositories.active_form_repository,
+            answer_label_repository: &labels,
+            user_repository: &repositories.user_repository,
+            form_submission_restriction_repository: &repositories
+                .form_submission_restriction_repository,
+            answer_entry_repository: &repositories.answer_entry_repository,
+            answer_relation_repository: &repositories.answer_relation_repository,
+            discord_answer_webhook_notifier: None,
+            application_event_publisher: None,
+        };
+        let standard_user = active_user("standard", Role::StandardUser);
+        let administrator = active_user("administrator", Role::Administrator);
+
+        let standard_answer = usecase
+            .get_answers(form_id, source_id, &standard_user)
+            .await
+            .unwrap();
+        let administrator_answer = usecase
+            .get_answers(form_id, source_id, &administrator)
+            .await
+            .unwrap();
+
+        assert_eq!(standard_answer.related_answers, vec![readable_relation]);
+        assert_eq!(
+            administrator_answer.related_answers,
+            vec![readable_relation, unreadable_relation, archived_relation]
+        );
     }
 
     #[tokio::test]
@@ -1086,6 +1520,7 @@ mod tests {
             form_submission_restriction_repository: &repositories
                 .form_submission_restriction_repository,
             answer_entry_repository: &repositories.answer_entry_repository,
+            answer_relation_repository: &repositories.answer_relation_repository,
             discord_answer_webhook_notifier: None,
             application_event_publisher: None,
         };

--- a/server/usecase/src/models.rs
+++ b/server/usecase/src/models.rs
@@ -1,4 +1,5 @@
 use chrono::{DateTime, Utc};
+use domain::repository::form::answer_relation_repository::RelatedAnswerReference;
 use domain::{
     account::models::{AccountUser, DiscordUser},
     form::{
@@ -45,6 +46,7 @@ pub struct AnswerDetails {
     pub form_id: FormId,
     pub answer: PublishedAnswerEntry,
     pub labels: Vec<AnswerLabel>,
+    pub related_answers: Vec<RelatedAnswerReference>,
 }
 
 pub struct ActiveFormWithLabels {

--- a/server/usecase/src/search.rs
+++ b/server/usecase/src/search.rs
@@ -21,7 +21,13 @@ use domain::{
     },
     pagination::{PageLimit, PageRequest},
     repository::{
-        form::active_form_repository::ActiveFormRepository, search_repository::SearchRepository,
+        form::{
+            active_form_repository::ActiveFormRepository,
+            answer_relation_repository::{
+                AnswerRelationRepository, RelatedAnswerLifecycle, RelatedAnswerReference,
+            },
+        },
+        search_repository::SearchRepository,
     },
     search::models::{
         AnswerSearchHit, AnswerTitleSearchDocument, FormAnswerComments, FormMetaData,
@@ -31,7 +37,7 @@ use domain::{
     },
     types::authorization_guard::{Allowed, AuthorizationGuard, Read},
 };
-use errors::Error;
+use errors::{Error, domain::DomainError};
 use futures::{StreamExt, TryStreamExt, stream, try_join};
 use std::{
     collections::{HashMap, HashSet},
@@ -54,6 +60,7 @@ pub struct SearchUseCase<
     UserRepo: UserRepository,
     AnswerEntryRepo: AnswerEntryRepository,
     CommentThreadRepo: CommentThreadRepository,
+    AnswerRelationRepo: AnswerRelationRepository,
 > {
     pub search_repository: &'a SearchRepo,
     pub active_form_repository: &'a FormRepo,
@@ -62,6 +69,7 @@ pub struct SearchUseCase<
     pub user_repository: &'a UserRepo,
     pub answer_entry_repository: &'a AnswerEntryRepo,
     pub comment_thread_repository: &'a CommentThreadRepo,
+    pub answer_relation_repository: &'a AnswerRelationRepo,
 }
 
 impl<
@@ -72,7 +80,8 @@ impl<
     R5: UserRepository,
     R6: AnswerEntryRepository,
     R7: CommentThreadRepository,
-> SearchUseCase<'_, R1, R2, R3, R4, R5, R6, R7>
+    R8: AnswerRelationRepository,
+> SearchUseCase<'_, R1, R2, R3, R4, R5, R6, R7, R8>
 {
     async fn list_all_form_guards(
         &self,
@@ -269,11 +278,71 @@ impl<
             }
         };
 
+        let related_answers = self
+            .visible_related_answers(account_user, answer_id)
+            .await?;
+
         Ok(Some(AnswerDetails {
             form_id,
             answer: PublishedAnswerEntry::new(answer.into_inner(), author),
             labels,
+            related_answers,
         }))
+    }
+
+    async fn visible_related_answers(
+        &self,
+        account_user: &AccountUser,
+        answer_id: AnswerId,
+    ) -> Result<Vec<RelatedAnswerReference>, Error> {
+        let actor = Actor::from(account_user.clone());
+        let is_administrator = matches!(
+            account_user.role(),
+            domain::account::models::Role::Administrator
+        );
+
+        stream::iter(
+            self.answer_relation_repository
+                .list_for_answer(answer_id)
+                .await?,
+        )
+        .then(|related_answer| {
+            let actor = actor.clone();
+            async move {
+                if is_administrator {
+                    return Ok(Some(related_answer));
+                }
+                if related_answer.lifecycle == RelatedAnswerLifecycle::Archived {
+                    return Ok(None);
+                }
+                let Some(form) = self
+                    .active_form_repository
+                    .get(related_answer.form_id)
+                    .await?
+                else {
+                    return Ok(None);
+                };
+                let Ok(form) = form.try_read(actor.clone()) else {
+                    return Ok(None);
+                };
+                match self
+                    .answer_entry_repository
+                    .get(&form, related_answer.answer_id)
+                    .await
+                {
+                    Ok(answer) => Ok(answer.map(|_| related_answer)),
+                    Err(Error::Domain {
+                        source: DomainError::Forbidden,
+                    }) => Ok(None),
+                    Err(error) => Err(error),
+                }
+            }
+        })
+        .collect::<Vec<Result<Option<_>, Error>>>()
+        .await
+        .into_iter()
+        .collect::<Result<Vec<_>, _>>()
+        .map(|references| references.into_iter().flatten().collect())
     }
 
     async fn visible_answer_details(
@@ -756,8 +825,8 @@ fn unique_answer_ids(answer_ids: impl IntoIterator<Item = AnswerId>) -> Vec<Answ
 mod tests {
     use super::*;
     use crate::test_utils::repositories::{
-        InMemoryActiveFormRepository, InMemoryAnswerEntryRepository, InMemoryFormLabelRepository,
-        InMemoryUserRepository,
+        InMemoryActiveFormRepository, InMemoryAnswerEntryRepository,
+        InMemoryAnswerRelationRepository, InMemoryFormLabelRepository, InMemoryUserRepository,
     };
     use chrono::Utc;
     use domain::{
@@ -784,6 +853,12 @@ mod tests {
     };
     use types::non_empty_vec::NonEmptyVec;
     use uuid::Uuid;
+
+    fn empty_answer_relation_repository() -> &'static InMemoryAnswerRelationRepository {
+        static REPOSITORY: std::sync::LazyLock<InMemoryAnswerRelationRepository> =
+            std::sync::LazyLock::new(InMemoryAnswerRelationRepository::default);
+        &REPOSITORY
+    }
 
     fn form_restricted_to(title: &str, group: &UserGroup) -> ActiveForm {
         let question = Question::new_text(
@@ -871,6 +946,7 @@ mod tests {
             user_repository: &user_repository,
             answer_entry_repository: &answer_entry_repository,
             comment_thread_repository: &comment_repository,
+            answer_relation_repository: empty_answer_relation_repository(),
         };
 
         let output = use_case
@@ -1002,6 +1078,7 @@ mod tests {
             user_repository: &user_repository,
             answer_entry_repository: &answer_entry_repository,
             comment_thread_repository: &comment_repository,
+            answer_relation_repository: empty_answer_relation_repository(),
         };
 
         let answers = use_case
@@ -1078,6 +1155,7 @@ mod tests {
             user_repository: &user_repository,
             answer_entry_repository: &answer_entry_repository,
             comment_thread_repository: &comment_repository,
+            answer_relation_repository: empty_answer_relation_repository(),
         };
 
         let answers = use_case
@@ -1116,6 +1194,7 @@ mod tests {
             user_repository: &user_repository,
             answer_entry_repository: &answer_entry_repository,
             comment_thread_repository: &comment_repository,
+            answer_relation_repository: empty_answer_relation_repository(),
         };
 
         let answers = use_case
@@ -1153,6 +1232,7 @@ mod tests {
             user_repository: &user_repository,
             answer_entry_repository: &answer_entry_repository,
             comment_thread_repository: &comment_repository,
+            answer_relation_repository: empty_answer_relation_repository(),
         };
 
         let answers = use_case
@@ -1253,6 +1333,7 @@ mod tests {
             user_repository: &user_repository,
             answer_entry_repository: &answer_entry_repository,
             comment_thread_repository: &comment_repository,
+            answer_relation_repository: empty_answer_relation_repository(),
         };
 
         let output = use_case
@@ -1391,6 +1472,7 @@ mod tests {
             user_repository: &user_repository,
             answer_entry_repository: &answer_entry_repository,
             comment_thread_repository: &comment_repository,
+            answer_relation_repository: empty_answer_relation_repository(),
         };
 
         let output = use_case
@@ -1589,6 +1671,7 @@ mod tests {
             user_repository: &user_repository,
             answer_entry_repository: &answer_entry_repository,
             comment_thread_repository: &comment_repository,
+            answer_relation_repository: empty_answer_relation_repository(),
         };
 
         let output = use_case
@@ -1691,6 +1774,7 @@ mod tests {
             user_repository: &user_repository,
             answer_entry_repository: &answer_entry_repository,
             comment_thread_repository: &comment_repository,
+            answer_relation_repository: empty_answer_relation_repository(),
         };
 
         let output = use_case

--- a/server/usecase/src/test_utils/repositories.rs
+++ b/server/usecase/src/test_utils/repositories.rs
@@ -18,6 +18,7 @@ use domain::{
         form::{
             active_form_repository::ActiveFormRepository,
             answer_entry_repository::AnswerEntryRepository,
+            answer_relation_repository::{AnswerRelationRepository, RelatedAnswerReference},
             archived_form_repository::ArchivedFormRepository,
             form_label_repository::FormLabelRepository,
         },
@@ -47,6 +48,7 @@ pub(crate) struct FormUseCaseTestRepositories {
     pub(crate) notification_repository: InMemoryNotificationRepository,
     pub(crate) form_label_repository: InMemoryFormLabelRepository,
     pub(crate) answer_entry_repository: InMemoryAnswerEntryRepository,
+    pub(crate) answer_relation_repository: InMemoryAnswerRelationRepository,
     pub(crate) user_repository: InMemoryUserRepository,
     pub(crate) form_submission_restriction_repository: InMemoryFormSubmissionRestrictionRepository,
 }
@@ -249,6 +251,96 @@ impl FormLabelRepository for InMemoryFormLabelRepository {
 #[derive(Default)]
 pub(crate) struct InMemoryAnswerEntryRepository {
     answers: Mutex<Vec<AnswerEntry>>,
+}
+
+#[derive(Default)]
+pub(crate) struct InMemoryAnswerRelationRepository {
+    references_by_answer_id: Mutex<HashMap<AnswerId, Vec<RelatedAnswerReference>>>,
+    replaced_targets_by_answer_id: Mutex<HashMap<AnswerId, Vec<AnswerId>>>,
+    unavailable_target_ids: Mutex<std::collections::HashSet<AnswerId>>,
+}
+
+impl InMemoryAnswerRelationRepository {
+    pub(crate) fn set_related_answers(
+        &self,
+        answer_id: AnswerId,
+        related_answers: Vec<RelatedAnswerReference>,
+    ) {
+        self.references_by_answer_id
+            .lock()
+            .unwrap()
+            .insert(answer_id, related_answers);
+    }
+
+    pub(crate) fn replaced_targets(&self, answer_id: AnswerId) -> Option<Vec<AnswerId>> {
+        self.replaced_targets_by_answer_id
+            .lock()
+            .unwrap()
+            .get(&answer_id)
+            .cloned()
+    }
+
+    pub(crate) fn mark_target_archived_or_missing(&self, answer_id: AnswerId) {
+        self.unavailable_target_ids
+            .lock()
+            .unwrap()
+            .insert(answer_id);
+    }
+}
+
+#[async_trait]
+impl AnswerRelationRepository for InMemoryAnswerRelationRepository {
+    async fn validate_replace_for_answer(
+        &self,
+        _answer: &Allowed<AnswerEntry, Update>,
+        related_answer_ids: &[AnswerId],
+    ) -> Result<(), Error> {
+        if related_answer_ids.iter().any(|answer_id| {
+            self.unavailable_target_ids
+                .lock()
+                .unwrap()
+                .contains(answer_id)
+        }) {
+            return Err(errors::domain::DomainError::InvalidEntity {
+                message: "related answer does not exist or is archived".to_string(),
+            }
+            .into());
+        }
+        Ok(())
+    }
+
+    async fn replace_for_answer(
+        &self,
+        answer: Allowed<AnswerEntry, Update>,
+        related_answer_ids: Vec<AnswerId>,
+    ) -> Result<(), Error> {
+        self.replaced_targets_by_answer_id
+            .lock()
+            .unwrap()
+            .insert(*answer.id(), related_answer_ids);
+        Ok(())
+    }
+
+    async fn update_answer_meta_and_replace(
+        &self,
+        answer: Allowed<AnswerEntry, Update>,
+        related_answer_ids: Vec<AnswerId>,
+    ) -> Result<(), Error> {
+        self.replace_for_answer(answer, related_answer_ids).await
+    }
+
+    async fn list_for_answer(
+        &self,
+        answer_id: AnswerId,
+    ) -> Result<Vec<RelatedAnswerReference>, Error> {
+        Ok(self
+            .references_by_answer_id
+            .lock()
+            .unwrap()
+            .get(&answer_id)
+            .cloned()
+            .unwrap_or_default())
+    }
 }
 
 impl InMemoryAnswerEntryRepository {


### PR DESCRIPTION
## 概要

- 回答をフォーム横断で双方向に関連付けられるようにしました。
- アーカイブ後も関連を保持し、管理者にはライフサイクル付きで返します。
- 標準ユーザーには、閲覧可能なアクティブ回答だけを関連先として返します。
- 関連の更新を原子的にし、アーカイブとの競合時も部分更新を残しません。

Closes #1241

## 確認

- cargo clippy -- -D warnings
- cargo nextest run（198 passed）
- cargo sqlx prepare --workspace
- makers pretty