### PR TITLE
test: OpenAPI ドキュメントの $ref 解決をテストで検証する

### DIFF
--- a/server/entrypoint/src/openapi.rs
+++ b/server/entrypoint/src/openapi.rs
@@ -235,3 +235,61 @@ pub fn versioned_api_router() -> OpenApiRouter<RealInfrastructureRepository> {
 pub fn openapi() -> utoipa::openapi::OpenApi {
     versioned_api_router().into_openapi()
 }
+
+#[cfg(test)]
+mod tests {
+    use serde_json::Value;
+
+    use super::openapi;
+
+    fn collect_refs(value: &Value, refs: &mut Vec<String>) {
+        match value {
+            Value::Object(map) => {
+                for (key, value) in map {
+                    match (key.as_str(), value) {
+                        ("$ref", Value::String(reference)) => refs.push(reference.clone()),
+                        _ => collect_refs(value, refs),
+                    }
+                }
+            }
+            Value::Array(values) => values.iter().for_each(|value| collect_refs(value, refs)),
+            _ => {}
+        }
+    }
+
+    #[test]
+    fn openapi_document_has_paths() {
+        let document = serde_json::to_value(openapi()).expect("OpenAPI document must serialize");
+
+        let paths = document
+            .pointer("/paths")
+            .and_then(Value::as_object)
+            .expect("OpenAPI document must have paths");
+
+        assert!(!paths.is_empty(), "OpenAPI document must not be empty");
+    }
+
+    #[test]
+    fn all_refs_in_openapi_document_are_resolvable() {
+        let document = serde_json::to_value(openapi()).expect("OpenAPI document must serialize");
+
+        let mut refs = Vec::new();
+        collect_refs(&document, &mut refs);
+
+        let unresolved = refs
+            .iter()
+            .filter(|reference| {
+                reference
+                    .strip_prefix('#')
+                    .is_none_or(|pointer| document.pointer(pointer).is_none())
+            })
+            .collect::<Vec<_>>();
+
+        assert!(
+            unresolved.is_empty(),
+            "OpenAPI ドキュメントに解決できない $ref があります。\
+             ハンドラの utoipa::path で参照しているスキーマが \
+             openapi.rs の components(schemas(...)) に登録されているか確認してください: {unresolved:?}"
+        );
+    }
+}


### PR DESCRIPTION
## 概要

Closes #1168

スキーマを `components(schemas(...))` に登録し忘れても OpenAPI ドキュメントの生成自体は成功してしまい、壊れた（解決できない `$ref` を含む）ドキュメントがそのまま `docs/openapi.json` に出力されます。

このため、生成されたドキュメント内のすべての `$ref` が同一ドキュメント内で解決可能であることを検証するテストを `entrypoint` に追加しました。既存の CI の `cargo test` で実行されるため、スキーマ未登録時に CI が落ちるようになります。

## 変更内容

- `server/entrypoint/src/openapi.rs` にテストを 2 件追加
  - `openapi_document_has_paths`: ドキュメントに paths が存在する（空でない）ことの検証
  - `all_refs_in_openapi_document_are_resolvable`: すべての `$ref` が JSON Pointer として解決可能であることの検証

## 動作確認

- `cargo test --package entrypoint` が通ることを確認
- `components(schemas(...))` から `CrossSearchResult` を一時的に外すとテストが失敗し、未登録スキーマ名がエラーメッセージに表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)