### PR TITLE
ci: リリースノート自動生成のカテゴリ分け設定を追加する

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,27 @@
+changelog:
+  exclude:
+    authors:
+      - github-actions[bot]
+  categories:
+    - title: 🚀 新機能
+      labels:
+        - feature
+        - enhancement
+    - title: 🐛 バグ修正
+      labels:
+        - bug
+    - title: 🛠 リファクタリング
+      labels:
+        - refactoring
+    - title: ⚙️ CI
+      labels:
+        - ci
+    - title: 📖 ドキュメント
+      labels:
+        - documentation
+    - title: 📦 依存関係の更新
+      labels:
+        - dependencies
+    - title: その他の変更
+      labels:
+        - "*"


### PR DESCRIPTION
## 概要

Closes #1246

リリースノートの自動出力自体は、`image-release.yaml` の `gh release create ... --generate-notes` で既に行われる構成になっています（まだリリースは一度も切られていません）。

ただし `.github/release.yml` が無いため、このままでは生成されるノートがマージされた PR のフラットな列挙になります。本 PR ではラベルに基づくカテゴリ分けの設定を追加し、リリースノートを見やすくします。

## 変更内容

- `.github/release.yml` を追加
  - リポジトリの既存ラベル（feature / enhancement / bug / refactoring / ci / documentation / dependencies）に対応するカテゴリ分け
  - `github-actions[bot]` の PR（release/vX.Y.Z の準備 PR）をノートから除外

## 備考

- ラベルが付いていない PR は「その他の変更」に分類されます。運用上はマージ前に PR へラベルを付けることでノートの分類精度が上がります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)