### PR TITLE
fix: OpenAPI のフォーム ID パスパラメータを form_id に統一する

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -106,7 +106,7 @@
         ]
       }
     },
-    "/api/v1/archived-forms/{id}": {
+    "/api/v1/archived-forms/{form_id}": {
       "get": {
         "tags": [
           "Archived Forms"
@@ -115,7 +115,7 @@
         "operationId": "get_archived_form_handler",
         "parameters": [
           {
-            "name": "id",
+            "name": "form_id",
             "in": "path",
             "description": "Form ID",
             "required": true,
@@ -193,7 +193,7 @@
         ]
       }
     },
-    "/api/v1/archived-forms/{id}/restore": {
+    "/api/v1/archived-forms/{form_id}/restore": {
       "post": {
         "tags": [
           "Archived Forms"
@@ -202,7 +202,7 @@
         "operationId": "restore_archived_form_handler",
         "parameters": [
           {
-            "name": "id",
+            "name": "form_id",
             "in": "path",
             "description": "Form ID",
             "required": true,
@@ -599,6 +599,416 @@
           },
           "404": {
             "description": "The server cannot find the requested resource.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/forms/{form_id}": {
+      "get": {
+        "tags": [
+          "Forms"
+        ],
+        "summary": "フォームの取得",
+        "operationId": "get_form_handler",
+        "parameters": [
+          {
+            "name": "form_id",
+            "in": "path",
+            "description": "Form ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FormSchema"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The server could not understand the request due to invalid syntax.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access is unauthorized.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access is forbidden.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The server cannot find the requested resource.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {},
+          {
+            "bearer": []
+          }
+        ]
+      },
+      "put": {
+        "tags": [
+          "Forms"
+        ],
+        "summary": "フォームの更新",
+        "description": "questions または labels を含めた場合、その form 配下の値全体を指定内容で置換します。省略した場合は既存値を保持します。",
+        "operationId": "update_form_handler",
+        "parameters": [
+          {
+            "name": "form_id",
+            "in": "path",
+            "description": "Form ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FormUpdateSchema"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FormSchema"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The server could not understand the request due to invalid syntax.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access is unauthorized.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access is forbidden.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The server cannot find the requested resource.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Client error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/forms/{form_id}/answers": {
+      "get": {
+        "tags": [
+          "Answers"
+        ],
+        "summary": "回答の一覧取得",
+        "operationId": "get_answer_by_form_id_handler",
+        "parameters": [
+          {
+            "name": "form_id",
+            "in": "path",
+            "description": "Form ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum number of answers to return",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "maximum": 100,
+              "minimum": 1
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Cursor returned by the previous page",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AnswerListPageResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The server could not understand the request due to invalid syntax.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access is unauthorized.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access is forbidden.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The server cannot find the requested resource.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Client error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "Answers"
+        ],
+        "summary": "回答の作成",
+        "operationId": "post_answer_handler",
+        "parameters": [
+          {
+            "name": "form_id",
+            "in": "path",
+            "description": "Form ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AnswerCreateSchema"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "The request has succeeded."
+          },
+          "400": {
+            "description": "The server could not understand the request due to invalid syntax.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access is unauthorized.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access is forbidden.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The server cannot find the requested resource.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Client error",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -2269,417 +2679,7 @@
         ]
       }
     },
-    "/api/v1/forms/{id}": {
-      "get": {
-        "tags": [
-          "Forms"
-        ],
-        "summary": "フォームの取得",
-        "operationId": "get_form_handler",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "description": "Form ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "The request has succeeded.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FormSchema"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "The server could not understand the request due to invalid syntax.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Access is unauthorized.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Access is forbidden.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "The server cannot find the requested resource.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Server error",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {},
-          {
-            "bearer": []
-          }
-        ]
-      },
-      "put": {
-        "tags": [
-          "Forms"
-        ],
-        "summary": "フォームの更新",
-        "description": "questions または labels を含めた場合、その form 配下の値全体を指定内容で置換します。省略した場合は既存値を保持します。",
-        "operationId": "update_form_handler",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "description": "Form ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/FormUpdateSchema"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "The request has succeeded.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FormSchema"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "The server could not understand the request due to invalid syntax.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Access is unauthorized.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Access is forbidden.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "The server cannot find the requested resource.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Client error",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Server error",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "bearer": []
-          }
-        ]
-      }
-    },
-    "/api/v1/forms/{id}/answers": {
-      "get": {
-        "tags": [
-          "Answers"
-        ],
-        "summary": "回答の一覧取得",
-        "operationId": "get_answer_by_form_id_handler",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "description": "Form ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "description": "Maximum number of answers to return",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "format": "int32",
-              "maximum": 100,
-              "minimum": 1
-            }
-          },
-          {
-            "name": "cursor",
-            "in": "query",
-            "description": "Cursor returned by the previous page",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "The request has succeeded.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AnswerListPageResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "The server could not understand the request due to invalid syntax.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Access is unauthorized.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Access is forbidden.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "The server cannot find the requested resource.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Client error",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Server error",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "bearer": []
-          }
-        ]
-      },
-      "post": {
-        "tags": [
-          "Answers"
-        ],
-        "summary": "回答の作成",
-        "operationId": "post_answer_handler",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "description": "Form ID",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AnswerCreateSchema"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "The request has succeeded."
-          },
-          "400": {
-            "description": "The server could not understand the request due to invalid syntax.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Access is unauthorized.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Access is forbidden.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "The server cannot find the requested resource.",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Client error",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Server error",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "bearer": []
-          }
-        ]
-      }
-    },
-    "/api/v1/forms/{id}/archive": {
+    "/api/v1/forms/{form_id}/archive": {
       "post": {
         "tags": [
           "Forms"
@@ -2688,7 +2688,7 @@
         "operationId": "archive_form_handler",
         "parameters": [
           {
-            "name": "id",
+            "name": "form_id",
             "in": "path",
             "description": "Form ID",
             "required": true,
@@ -2759,7 +2759,7 @@
         ]
       }
     },
-    "/api/v1/forms/{id}/temporary-answers": {
+    "/api/v1/forms/{form_id}/temporary-answers": {
       "post": {
         "tags": [
           "Answers"
@@ -2768,7 +2768,7 @@
         "operationId": "post_temporary_answer_handler",
         "parameters": [
           {
-            "name": "id",
+            "name": "form_id",
             "in": "path",
             "description": "Form ID",
             "required": true,

--- a/server/presentation/src/handlers/form/answer_handler.rs
+++ b/server/presentation/src/handlers/form/answer_handler.rs
@@ -308,10 +308,10 @@ pub async fn get_answer_handler(
 
 #[utoipa::path(
     get,
-    path = "/forms/{id}/answers",
+    path = "/forms/{form_id}/answers",
     summary = "回答の一覧取得",
     params(
-        ("id" = String, Path, description = "Form ID"),
+        ("form_id" = String, Path, description = "Form ID"),
         AnswerListQuery,
     ),
     responses(
@@ -365,10 +365,10 @@ pub async fn get_answer_by_form_id_handler(
 
 #[utoipa::path(
     post,
-    path = "/forms/{id}/answers",
+    path = "/forms/{form_id}/answers",
     summary = "回答の作成",
     params(
-        ("id" = String, Path, description = "Form ID"),
+        ("form_id" = String, Path, description = "Form ID"),
     ),
     request_body = AnswerCreateSchema,
     responses(
@@ -417,10 +417,10 @@ pub async fn post_answer_handler(
 
 #[utoipa::path(
     post,
-    path = "/forms/{id}/temporary-answers",
+    path = "/forms/{form_id}/temporary-answers",
     summary = "未ログイン回答の作成",
     params(
-        ("id" = String, Path, description = "Form ID"),
+        ("form_id" = String, Path, description = "Form ID"),
     ),
     request_body = TemporaryAnswerCreateSchema,
     responses(

--- a/server/presentation/src/handlers/form/form_handler.rs
+++ b/server/presentation/src/handlers/form/form_handler.rs
@@ -402,10 +402,10 @@ pub async fn form_list_handler(
 
 #[utoipa::path(
     get,
-    path = "/forms/{id}",
+    path = "/forms/{form_id}",
     summary = "フォームの取得",
     params(
-        ("id" = String, Path, description = "Form ID"),
+        ("form_id" = String, Path, description = "Form ID"),
     ),
     responses(
         GetFormResponse,
@@ -439,10 +439,10 @@ pub async fn get_form_handler(
 
 #[utoipa::path(
     post,
-    path = "/forms/{id}/archive",
+    path = "/forms/{form_id}/archive",
     summary = "フォームのアーカイブ",
     params(
-        ("id" = String, Path, description = "Form ID"),
+        ("form_id" = String, Path, description = "Form ID"),
     ),
     responses(
         (status = 204, description = "There is no content to send for this request, but the headers may be useful."),
@@ -477,11 +477,11 @@ pub async fn archive_form_handler(
 
 #[utoipa::path(
     put,
-    path = "/forms/{id}",
+    path = "/forms/{form_id}",
     summary = "フォームの更新",
     description = "questions または labels を含めた場合、その form 配下の値全体を指定内容で置換します。省略した場合は既存値を保持します。",
     params(
-        ("id" = String, Path, description = "Form ID"),
+        ("form_id" = String, Path, description = "Form ID"),
     ),
     request_body = FormUpdateSchema,
     responses(
@@ -603,10 +603,10 @@ pub async fn archived_form_list_handler(
 
 #[utoipa::path(
     get,
-    path = "/archived-forms/{id}",
+    path = "/archived-forms/{form_id}",
     summary = "アーカイブ済みフォームの取得",
     params(
-        ("id" = String, Path, description = "Form ID"),
+        ("form_id" = String, Path, description = "Form ID"),
     ),
     responses(
         ArchivedFormResponse,
@@ -645,10 +645,10 @@ pub async fn get_archived_form_handler(
 
 #[utoipa::path(
     post,
-    path = "/archived-forms/{id}/restore",
+    path = "/archived-forms/{form_id}/restore",
     summary = "アーカイブ済みフォームの復元",
     params(
-        ("id" = String, Path, description = "Form ID"),
+        ("form_id" = String, Path, description = "Form ID"),
     ),
     responses(
         (status = 204, description = "There is no content to send for this request, but the headers may be useful."),


### PR DESCRIPTION
## 概要

Closes #1055

OpenAPI のパスパラメータ表記が `{id}` と `{form_id}` で揺れていたため、フォーム ID を指す箇所をすべて `{form_id}` に統一しました。

## 変更内容

以下 8 パス（form_handler / answer_handler の `#[utoipa::path]`）の `{id}` を `{form_id}` に変更し、`docs/openapi.json` を再生成:

- `/forms/{id}` (GET, PUT) → `/forms/{form_id}`
- `/forms/{id}/answers` (GET, POST) → `/forms/{form_id}/answers`
- `/forms/{id}/archive` → `/forms/{form_id}/archive`
- `/forms/{id}/temporary-answers` → `/forms/{form_id}/temporary-answers`
- `/archived-forms/{id}` → `/archived-forms/{form_id}`
- `/archived-forms/{id}/restore` → `/archived-forms/{form_id}/restore`

## 互換性

パスパラメータ名はプレースホルダーの名前が変わるだけで URL の構造自体は不変のため、API リクエストの互換性に影響はありません。OpenAPI から生成するクライアントコードでは引数名が `id` → `formId` 等に変わる可能性があります。

## 備考

`/users/{uuid}` と `/user-groups/.../{user_id}` にもユーザー ID の表記ゆれがありますが、本 issue のスコープ（form_id への統一）外のため触れていません。必要であれば別 issue を立てます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)