### PR TITLE
fix: tracing::instrument の引数暗黙記録をやめ skip_all を必須にする

### DIFF
--- a/server/infra/resource/src/database/forms/answer_label.rs
+++ b/server/infra/resource/src/database/forms/answer_label.rs
@@ -13,7 +13,7 @@ use crate::{
 
 #[async_trait]
 impl FormAnswerLabelDatabase for ConnectionPool {
-    #[tracing::instrument]
+    #[tracing::instrument(skip_all)]
     async fn create_label_for_answers(&self, label: &AnswerLabel) -> Result<(), InfraError> {
         let label_id = label.id().into_inner().to_string();
         let label_name = label.name().to_owned().into_inner();
@@ -34,7 +34,7 @@ impl FormAnswerLabelDatabase for ConnectionPool {
         .await
     }
 
-    #[tracing::instrument]
+    #[tracing::instrument(skip_all)]
     async fn get_labels_for_answers(&self) -> Result<Vec<AnswerLabelRecord>, InfraError> {
         self.read_only_transaction(|txn| {
             Box::pin(async move {
@@ -56,7 +56,7 @@ impl FormAnswerLabelDatabase for ConnectionPool {
         .await
     }
 
-    #[tracing::instrument]
+    #[tracing::instrument(skip_all, fields(label_id = %label_id))]
     async fn get_label_for_answers(
         &self,
         label_id: AnswerLabelId,
@@ -86,7 +86,7 @@ impl FormAnswerLabelDatabase for ConnectionPool {
         .await
     }
 
-    #[tracing::instrument]
+    #[tracing::instrument(skip_all)]
     async fn get_labels_for_answers_by_label_ids(
         &self,
         label_ids: Vec<AnswerLabelId>,
@@ -128,7 +128,7 @@ impl FormAnswerLabelDatabase for ConnectionPool {
         .await
     }
 
-    #[tracing::instrument]
+    #[tracing::instrument(skip_all, fields(answer_id = %answer_id))]
     async fn get_labels_for_answers_by_answer_id(
         &self,
         answer_id: AnswerId,
@@ -160,7 +160,7 @@ impl FormAnswerLabelDatabase for ConnectionPool {
             .await
     }
 
-    #[tracing::instrument]
+    #[tracing::instrument(skip_all, fields(label_id = %label_id))]
     async fn delete_label_for_answers(&self, label_id: AnswerLabelId) -> Result<(), InfraError> {
         self.read_write_transaction(|txn| {
             Box::pin(async move {
@@ -177,7 +177,7 @@ impl FormAnswerLabelDatabase for ConnectionPool {
         .await
     }
 
-    #[tracing::instrument]
+    #[tracing::instrument(skip_all)]
     async fn edit_label_for_answers(&self, label: &AnswerLabel) -> Result<(), InfraError> {
         let label_name = label.name().to_owned().into_inner();
         let label_id = label.id().to_string();
@@ -198,7 +198,7 @@ impl FormAnswerLabelDatabase for ConnectionPool {
         .await
     }
 
-    #[tracing::instrument]
+    #[tracing::instrument(skip_all, fields(answer_id = %answer_id))]
     async fn replace_answer_labels(
         &self,
         answer_id: AnswerId,
@@ -238,7 +238,7 @@ impl FormAnswerLabelDatabase for ConnectionPool {
         .await
     }
 
-    #[tracing::instrument]
+    #[tracing::instrument(skip_all)]
     async fn size(&self) -> Result<u32, InfraError> {
         self.read_only_transaction(|txn| {
             Box::pin(async move {

--- a/server/infra/resource/src/database/forms/answer_relations.rs
+++ b/server/infra/resource/src/database/forms/answer_relations.rs
@@ -53,7 +53,7 @@ fn relation_from_row(
 
 #[async_trait]
 impl FormAnswerRelationDatabase for ConnectionPool {
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip_all)]
     async fn list_for_answer(
         &self,
         source: AnswerReference,
@@ -90,7 +90,7 @@ impl FormAnswerRelationDatabase for ConnectionPool {
         .await
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip_all)]
     async fn add(&self, relation: AnswerRelation) -> Result<(), InfraError> {
         let (first_form_id, first_answer_id, second_form_id, second_answer_id) =
             relation_columns(relation);
@@ -115,7 +115,7 @@ impl FormAnswerRelationDatabase for ConnectionPool {
         .await
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip_all)]
     async fn remove(&self, relation: AnswerRelation) -> Result<(), InfraError> {
         let (first_form_id, first_answer_id, second_form_id, second_answer_id) =
             relation_columns(relation);
@@ -139,7 +139,7 @@ impl FormAnswerRelationDatabase for ConnectionPool {
         .await
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip_all, fields(answer_id = %answer_id))]
     async fn find_for_source_and_answer_id(
         &self,
         source: AnswerReference,

--- a/server/infra/resource/src/database/forms/answers.rs
+++ b/server/infra/resource/src/database/forms/answers.rs
@@ -240,7 +240,7 @@ pub(crate) fn attach_entry_children(
 
 #[async_trait]
 impl FormAnswerDatabase for ConnectionPool {
-    #[tracing::instrument]
+    #[tracing::instrument(skip_all, fields(form_id = %form_id))]
     async fn post_answer(&self, answer: &AnswerEntry, form_id: FormId) -> Result<(), InfraError> {
         let answer_id = answer.id().to_owned().into_inner().to_string();
         let form_id = form_id.into_inner().to_string();
@@ -314,7 +314,7 @@ impl FormAnswerDatabase for ConnectionPool {
         }).await
     }
 
-    #[tracing::instrument]
+    #[tracing::instrument(skip_all, fields(answer_id = %answer_id))]
     async fn get_answers(
         &self,
         answer_id: AnswerId,
@@ -380,7 +380,7 @@ impl FormAnswerDatabase for ConnectionPool {
         .await
     }
 
-    #[tracing::instrument]
+    #[tracing::instrument(skip_all)]
     async fn get_answers_by_answer_ids(
         &self,
         answer_ids: Vec<AnswerId>,
@@ -444,7 +444,7 @@ impl FormAnswerDatabase for ConnectionPool {
         .await
     }
 
-    #[tracing::instrument]
+    #[tracing::instrument(skip_all, fields(form_id = %form_id))]
     async fn update_answer_entry(
         &self,
         answer_entry: &AnswerEntry,
@@ -495,7 +495,7 @@ impl FormAnswerDatabase for ConnectionPool {
         .await
     }
 
-    #[tracing::instrument]
+    #[tracing::instrument(skip_all)]
     async fn size(&self) -> Result<u32, InfraError> {
         self.read_only_transaction(|txn| {
             Box::pin(async move {
@@ -509,7 +509,7 @@ impl FormAnswerDatabase for ConnectionPool {
         .await
     }
 
-    #[tracing::instrument]
+    #[tracing::instrument(skip_all)]
     async fn content_size(&self) -> Result<u32, InfraError> {
         self.read_only_transaction(|txn| {
             Box::pin(async move {

--- a/server/infra/resource/src/database/forms/comment.rs
+++ b/server/infra/resource/src/database/forms/comment.rs
@@ -28,7 +28,7 @@ use uuid::Uuid;
 
 #[async_trait]
 impl FormCommentDatabase for ConnectionPool {
-    #[tracing::instrument]
+    #[tracing::instrument(skip_all, fields(comment_id = %comment_id))]
     async fn get_comment(
         &self,
         comment_id: CommentId,
@@ -52,7 +52,7 @@ impl FormCommentDatabase for ConnectionPool {
         .await
     }
 
-    #[tracing::instrument]
+    #[tracing::instrument(skip_all, fields(answer_id = %answer_id))]
     async fn get_comments(&self, answer_id: AnswerId) -> Result<Vec<CommentRecord>, InfraError> {
         self.read_only_transaction(|txn| {
             Box::pin(async move {
@@ -73,7 +73,7 @@ impl FormCommentDatabase for ConnectionPool {
         .await
     }
 
-    #[tracing::instrument]
+    #[tracing::instrument(skip_all)]
     async fn get_all_comments(&self) -> Result<Vec<CommentRecord>, InfraError> {
         self.read_only_transaction(|txn| {
             Box::pin(async move {
@@ -92,7 +92,7 @@ impl FormCommentDatabase for ConnectionPool {
         .await
     }
 
-    #[tracing::instrument]
+    #[tracing::instrument(skip_all)]
     async fn create_comment_authorizing_in_transaction(
         &self,
         form: &Allowed<ActiveForm, Read>,
@@ -113,7 +113,7 @@ impl FormCommentDatabase for ConnectionPool {
         .await
     }
 
-    #[tracing::instrument]
+    #[tracing::instrument(skip_all)]
     async fn update_comment_authorizing_in_transaction(
         &self,
         form: &Allowed<ActiveForm, Read>,
@@ -143,7 +143,7 @@ impl FormCommentDatabase for ConnectionPool {
         .await
     }
 
-    #[tracing::instrument(skip(self, comment))]
+    #[tracing::instrument(skip_all)]
     async fn delete_comment_authorizing_in_transaction(
         &self,
         form: &Allowed<ActiveForm, Read>,
@@ -170,7 +170,7 @@ impl FormCommentDatabase for ConnectionPool {
         .await
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip_all, fields(answer_id = %answer_id))]
     async fn get_history(
         &self,
         answer_id: AnswerId,
@@ -277,7 +277,7 @@ impl FormCommentDatabase for ConnectionPool {
         }))
     }
 
-    #[tracing::instrument]
+    #[tracing::instrument(skip_all)]
     async fn size(&self) -> Result<u32, InfraError> {
         self.read_only_transaction(|txn| {
             Box::pin(async move {

--- a/server/infra/resource/src/database/forms/form.rs
+++ b/server/infra/resource/src/database/forms/form.rs
@@ -974,7 +974,7 @@ async fn copy_group_restriction_table(
 
 #[async_trait]
 impl FormDatabase for ConnectionPool {
-    #[tracing::instrument]
+    #[tracing::instrument(skip_all)]
     async fn create(&self, form: &ActiveForm, user: &AccountUser) -> Result<(), InfraError> {
         let form = form.clone();
         let user = user.clone();
@@ -991,7 +991,7 @@ impl FormDatabase for ConnectionPool {
         .await
     }
 
-    #[tracing::instrument]
+    #[tracing::instrument(skip_all)]
     async fn list(
         &self,
         request: PageRequest<FormPagePosition>,
@@ -1088,7 +1088,7 @@ impl FormDatabase for ConnectionPool {
         .await
     }
 
-    #[tracing::instrument]
+    #[tracing::instrument(skip_all)]
     async fn list_all(&self) -> Result<Vec<ActiveFormRecord>, InfraError> {
         self.read_only_transaction(|txn| {
             Box::pin(async move {
@@ -1146,7 +1146,7 @@ impl FormDatabase for ConnectionPool {
         .await
     }
 
-    #[tracing::instrument]
+    #[tracing::instrument(skip_all, fields(form_id = %form_id))]
     async fn get(&self, form_id: FormId) -> Result<Option<ActiveFormRecord>, InfraError> {
         self.read_only_transaction(|txn| {
             Box::pin(async move {
@@ -1159,7 +1159,7 @@ impl FormDatabase for ConnectionPool {
         .await
     }
 
-    #[tracing::instrument]
+    #[tracing::instrument(skip_all)]
     async fn list_archived(
         &self,
         request: PageRequest<ArchivedFormPagePosition>,
@@ -1328,7 +1328,7 @@ impl FormDatabase for ConnectionPool {
         .await
     }
 
-    #[tracing::instrument]
+    #[tracing::instrument(skip_all, fields(form_id = %form_id))]
     async fn get_archived(
         &self,
         form_id: FormId,
@@ -1344,7 +1344,7 @@ impl FormDatabase for ConnectionPool {
         .await
     }
 
-    #[tracing::instrument]
+    #[tracing::instrument(skip_all, fields(form_id = %form_id, answer_id = %answer_id))]
     async fn archived_answer_publication(
         &self,
         form_id: FormId,
@@ -1371,7 +1371,7 @@ impl FormDatabase for ConnectionPool {
         .await
     }
 
-    #[tracing::instrument]
+    #[tracing::instrument(skip_all)]
     async fn archive(&self, form: &ArchivedForm) -> Result<ArchivedForm, InfraError> {
         let form = form.clone();
         self.read_write_transaction(move |txn| {
@@ -1411,7 +1411,7 @@ impl FormDatabase for ConnectionPool {
         .await
     }
 
-    #[tracing::instrument]
+    #[tracing::instrument(skip_all, fields(form_id = %form_id))]
     async fn restore(&self, form_id: FormId) -> Result<(), InfraError> {
         self.read_write_transaction(move |txn| {
             Box::pin(async move {
@@ -1427,7 +1427,7 @@ impl FormDatabase for ConnectionPool {
         .await
     }
 
-    #[tracing::instrument]
+    #[tracing::instrument(skip_all)]
     async fn update(&self, form: &ActiveForm, updated_by: &AccountUser) -> Result<(), InfraError> {
         let form = form.clone();
         let updated_by = updated_by.clone();
@@ -1444,7 +1444,7 @@ impl FormDatabase for ConnectionPool {
         .await
     }
 
-    #[tracing::instrument]
+    #[tracing::instrument(skip_all)]
     async fn size(&self) -> Result<u32, InfraError> {
         self.read_only_transaction(|txn| {
             Box::pin(async move {
@@ -1458,7 +1458,7 @@ impl FormDatabase for ConnectionPool {
         .await
     }
 
-    #[tracing::instrument]
+    #[tracing::instrument(skip_all, fields(form_id = %form_id))]
     async fn list_answer_entries(
         &self,
         form_id: FormId,
@@ -1470,7 +1470,7 @@ impl FormDatabase for ConnectionPool {
         .await
     }
 
-    #[tracing::instrument]
+    #[tracing::instrument(skip_all)]
     async fn list_all_answer_entries(
         &self,
         request: PageRequest<AnswerPagePosition>,

--- a/server/infra/resource/src/database/forms/form_label.rs
+++ b/server/infra/resource/src/database/forms/form_label.rs
@@ -11,7 +11,7 @@ use crate::{
 
 #[async_trait]
 impl FormLabelDatabase for ConnectionPool {
-    #[tracing::instrument]
+    #[tracing::instrument(skip_all)]
     async fn create_label_for_forms(&self, label: &FormLabel) -> Result<(), InfraError> {
         let label_id = label.id().to_owned().into_inner().to_string();
         let label_name = label.name().to_string();
@@ -32,7 +32,7 @@ impl FormLabelDatabase for ConnectionPool {
         .await
     }
 
-    #[tracing::instrument]
+    #[tracing::instrument(skip_all)]
     async fn fetch_labels(&self) -> Result<Vec<FormLabelRecord>, InfraError> {
         self.read_only_transaction(|txn| {
             Box::pin(async move {
@@ -54,7 +54,7 @@ impl FormLabelDatabase for ConnectionPool {
         .await
     }
 
-    #[tracing::instrument]
+    #[tracing::instrument(skip_all)]
     async fn fetch_labels_by_ids(
         &self,
         ids: Vec<FormLabelId>,
@@ -96,7 +96,7 @@ impl FormLabelDatabase for ConnectionPool {
         .await
     }
 
-    #[tracing::instrument]
+    #[tracing::instrument(skip_all, fields(label_id = %label_id))]
     async fn delete_label_for_forms(&self, label_id: FormLabelId) -> Result<(), InfraError> {
         self.read_write_transaction(|txn| {
             Box::pin(async move {
@@ -113,7 +113,7 @@ impl FormLabelDatabase for ConnectionPool {
         .await
     }
 
-    #[tracing::instrument]
+    #[tracing::instrument(skip_all, fields(label_id = %id))]
     async fn fetch_label(&self, id: FormLabelId) -> Result<Option<FormLabelRecord>, InfraError> {
         self.read_only_transaction(|txn| {
             Box::pin(async move {
@@ -135,7 +135,7 @@ impl FormLabelDatabase for ConnectionPool {
         .await
     }
 
-    #[tracing::instrument]
+    #[tracing::instrument(skip_all, fields(label_id = %id))]
     async fn edit_label_for_forms(
         &self,
         id: FormLabelId,
@@ -157,7 +157,7 @@ impl FormLabelDatabase for ConnectionPool {
         .await
     }
 
-    #[tracing::instrument]
+    #[tracing::instrument(skip_all, fields(form_id = %form_id))]
     async fn fetch_labels_by_form_id(
         &self,
         form_id: FormId,
@@ -191,7 +191,7 @@ impl FormLabelDatabase for ConnectionPool {
         .await
     }
 
-    #[tracing::instrument]
+    #[tracing::instrument(skip_all)]
     async fn size(&self) -> Result<u32, InfraError> {
         self.read_only_transaction(|txn| {
             Box::pin(async move {

--- a/server/infra/resource/src/database/forms/message.rs
+++ b/server/infra/resource/src/database/forms/message.rs
@@ -18,7 +18,7 @@ use crate::{
 
 #[async_trait]
 impl FormMessageDatabase for ConnectionPool {
-    #[tracing::instrument]
+    #[tracing::instrument(skip_all, fields(answer_id = %answer_id))]
     async fn post_message(
         &self,
         message: &Message,
@@ -74,7 +74,7 @@ impl FormMessageDatabase for ConnectionPool {
         }).await
     }
 
-    #[tracing::instrument]
+    #[tracing::instrument(skip_all)]
     async fn update_message_with_history(
         &self,
         message: &Message,
@@ -148,7 +148,7 @@ impl FormMessageDatabase for ConnectionPool {
         .await
     }
 
-    #[tracing::instrument]
+    #[tracing::instrument(skip_all)]
     async fn fetch_messages_by_form_answer(
         &self,
         answers: &AnswerEntry,
@@ -174,7 +174,7 @@ impl FormMessageDatabase for ConnectionPool {
         .await
     }
 
-    #[tracing::instrument]
+    #[tracing::instrument(skip_all, fields(answer_id = %answer_id))]
     async fn fetch_messages_by_answer_id(
         &self,
         answer_id: AnswerId,
@@ -200,7 +200,7 @@ impl FormMessageDatabase for ConnectionPool {
         .await
     }
 
-    #[tracing::instrument]
+    #[tracing::instrument(skip_all, fields(message_id = %message_id))]
     async fn fetch_message(
         &self,
         message_id: &MessageId,
@@ -226,7 +226,7 @@ impl FormMessageDatabase for ConnectionPool {
         .await
     }
 
-    #[tracing::instrument]
+    #[tracing::instrument(skip_all)]
     async fn delete_message_with_history(
         &self,
         deleted: &DeletedMessage,

--- a/server/infra/resource/src/database/notification.rs
+++ b/server/infra/resource/src/database/notification.rs
@@ -12,7 +12,7 @@ use crate::{
 
 #[async_trait]
 impl NotificationDatabase for ConnectionPool {
-    #[tracing::instrument]
+    #[tracing::instrument(skip_all)]
     async fn upsert_notification_settings(
         &self,
         notification_settings: &NotificationPreference,
@@ -40,7 +40,7 @@ impl NotificationDatabase for ConnectionPool {
         .await
     }
 
-    #[tracing::instrument]
+    #[tracing::instrument(skip_all, fields(recipient_id = %recipient_id))]
     async fn fetch_notification_settings(
         &self,
         recipient_id: Uuid,

--- a/server/infra/resource/src/database/search.rs
+++ b/server/infra/resource/src/database/search.rs
@@ -163,7 +163,7 @@ fn merge_answer_hits(
 
 #[async_trait]
 impl SearchDatabase for ConnectionPool {
-    #[tracing::instrument]
+    #[tracing::instrument(skip_all)]
     async fn search_users(&self, query: &str) -> Result<Vec<UserSearchHit>, InfraError> {
         Ok(self
             .meilisearch_client
@@ -181,7 +181,7 @@ impl SearchDatabase for ConnectionPool {
             .collect_vec())
     }
 
-    #[tracing::instrument]
+    #[tracing::instrument(skip_all)]
     async fn search_forms(&self, query: &str) -> Result<Vec<FormSearchHit>, InfraError> {
         Ok(self
             .meilisearch_client
@@ -199,7 +199,7 @@ impl SearchDatabase for ConnectionPool {
             .collect_vec())
     }
 
-    #[tracing::instrument]
+    #[tracing::instrument(skip_all)]
     async fn search_labels_for_forms(
         &self,
         query: &str,
@@ -220,7 +220,7 @@ impl SearchDatabase for ConnectionPool {
             .collect_vec())
     }
 
-    #[tracing::instrument]
+    #[tracing::instrument(skip_all)]
     async fn search_labels_for_answers(
         &self,
         query: &str,
@@ -241,7 +241,7 @@ impl SearchDatabase for ConnectionPool {
             .collect_vec())
     }
 
-    #[tracing::instrument]
+    #[tracing::instrument(skip_all)]
     async fn search_answers(
         &self,
         query: &str,
@@ -281,7 +281,7 @@ impl SearchDatabase for ConnectionPool {
         ))
     }
 
-    #[tracing::instrument]
+    #[tracing::instrument(skip_all)]
     async fn search_comments(&self, query: &str) -> Result<Vec<CommentSearchHit>, InfraError> {
         Ok(self
             .meilisearch_client
@@ -300,7 +300,7 @@ impl SearchDatabase for ConnectionPool {
             .collect_vec())
     }
 
-    #[tracing::instrument]
+    #[tracing::instrument(skip_all)]
     async fn sync_search_engine(
         &self,
         data: &[SearchableFieldsWithOperation],
@@ -420,7 +420,7 @@ impl SearchDatabase for ConnectionPool {
         Ok(())
     }
 
-    #[tracing::instrument]
+    #[tracing::instrument(skip_all)]
     async fn search_engine_stats(&self) -> Result<NumberOfRecordsPerAggregate, InfraError> {
         let client = reqwest::Client::new();
 
@@ -441,7 +441,7 @@ impl SearchDatabase for ConnectionPool {
         )
     }
 
-    #[tracing::instrument]
+    #[tracing::instrument(skip_all)]
     async fn initialize_search_engine(&self) -> Result<bool, InfraError> {
         let index_with_uid = vec![
             ("form_meta_data", "id"),

--- a/server/infra/resource/src/repository/form_repository_impls/answer_entry_repository_impl.rs
+++ b/server/infra/resource/src/repository/form_repository_impls/answer_entry_repository_impl.rs
@@ -22,7 +22,7 @@ impl<Client> AnswerEntryRepository for Repository<Client>
 where
     Client: DatabaseComponents + 'static,
 {
-    #[tracing::instrument(skip(self, form))]
+    #[tracing::instrument(skip_all, fields(answer_id = %answer_id))]
     async fn get(
         &self,
         form: &Allowed<ActiveForm, Read>,
@@ -40,7 +40,7 @@ where
             .map_err(Into::into)
     }
 
-    #[tracing::instrument(skip(self, forms))]
+    #[tracing::instrument(skip_all)]
     async fn find_by_ids(
         &self,
         forms: &[Allowed<ActiveForm, Read>],
@@ -73,7 +73,7 @@ where
             .collect())
     }
 
-    #[tracing::instrument(skip(self, form))]
+    #[tracing::instrument(skip_all)]
     async fn list_by_form(
         &self,
         form: &Allowed<ActiveForm, Read>,
@@ -89,7 +89,7 @@ where
         Ok(Page::new(form.readable_entries(entries), next))
     }
 
-    #[tracing::instrument(skip(self, forms))]
+    #[tracing::instrument(skip_all)]
     async fn list_all(
         &self,
         forms: &[Allowed<ActiveForm, Read>],
@@ -117,7 +117,7 @@ where
         Ok(Page::new(authorized_entries, next))
     }
 
-    #[tracing::instrument(skip(self, _form, answer_entry))]
+    #[tracing::instrument(skip_all)]
     async fn post(
         &self,
         _form: &Allowed<ActiveForm, Read>,
@@ -130,7 +130,7 @@ where
         Ok(())
     }
 
-    #[tracing::instrument(skip(self, _form, answer_entry))]
+    #[tracing::instrument(skip_all)]
     async fn update(
         &self,
         _form: &Allowed<ActiveForm, Update>,
@@ -143,12 +143,12 @@ where
         Ok(())
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip_all)]
     async fn size(&self) -> Result<u32, Error> {
         self.client.form_answer().size().await.map_err(Into::into)
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip_all)]
     async fn content_size(&self) -> Result<u32, Error> {
         self.client
             .form_answer()

--- a/server/infra/resource/src/repository/form_repository_impls/answer_label_repository_impl.rs
+++ b/server/infra/resource/src/repository/form_repository_impls/answer_label_repository_impl.rs
@@ -14,7 +14,7 @@ use crate::{
 
 #[async_trait]
 impl<Client: DatabaseComponents + 'static> AnswerLabelRepository for Repository<Client> {
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip_all)]
     async fn create_label_for_answers(
         &self,
         label: Allowed<AnswerLabel, Create>,
@@ -26,7 +26,7 @@ impl<Client: DatabaseComponents + 'static> AnswerLabelRepository for Repository<
             .map_err(Into::into)
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip_all)]
     async fn get_labels_for_answers(
         &self,
     ) -> Result<Vec<AuthorizationGuard<AnswerLabel, Read>>, Error> {
@@ -40,7 +40,7 @@ impl<Client: DatabaseComponents + 'static> AnswerLabelRepository for Repository<
             .collect::<Result<Vec<_>, _>>()
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip_all, fields(label_id = %label_id))]
     async fn get_label_for_answers(
         &self,
         label_id: AnswerLabelId,
@@ -55,7 +55,7 @@ impl<Client: DatabaseComponents + 'static> AnswerLabelRepository for Repository<
             .map(Into::<AuthorizationGuard<AnswerLabel, Read>>::into))
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip_all)]
     async fn get_labels_for_answers_by_label_ids(
         &self,
         label_ids: Vec<AnswerLabelId>,
@@ -70,7 +70,7 @@ impl<Client: DatabaseComponents + 'static> AnswerLabelRepository for Repository<
             .collect::<Result<Vec<_>, _>>()
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip_all, fields(answer_id = %answer_id))]
     async fn get_labels_for_answers_by_answer_id(
         &self,
         answer_id: AnswerId,
@@ -85,7 +85,7 @@ impl<Client: DatabaseComponents + 'static> AnswerLabelRepository for Repository<
             .collect::<Result<Vec<_>, _>>()
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip_all)]
     async fn delete_label_for_answers(
         &self,
         label: Allowed<AnswerLabel, Delete>,
@@ -97,7 +97,7 @@ impl<Client: DatabaseComponents + 'static> AnswerLabelRepository for Repository<
             .map_err(Into::into)
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip_all)]
     async fn edit_label_for_answers(
         &self,
         label: Allowed<AnswerLabel, Update>,
@@ -109,7 +109,7 @@ impl<Client: DatabaseComponents + 'static> AnswerLabelRepository for Repository<
             .map_err(Into::into)
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip_all, fields(answer_id = %answer_id))]
     async fn replace_answer_labels(
         &self,
         answer_id: AnswerId,
@@ -127,7 +127,7 @@ impl<Client: DatabaseComponents + 'static> AnswerLabelRepository for Repository<
             .map_err(Into::into)
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip_all)]
     async fn size(&self) -> Result<u32, Error> {
         self.client
             .form_answer_label()

--- a/server/infra/resource/src/repository/form_repository_impls/answer_relation_repository_impl.rs
+++ b/server/infra/resource/src/repository/form_repository_impls/answer_relation_repository_impl.rs
@@ -172,7 +172,7 @@ impl<Client> AnswerRelationRepository for Repository<Client>
 where
     Client: DatabaseComponents + 'static,
 {
-    #[tracing::instrument(skip(self, source))]
+    #[tracing::instrument(skip_all)]
     async fn list_for_answer(
         &self,
         source: &Allowed<AnswerEntry, Read>,
@@ -185,7 +185,7 @@ where
         .await
     }
 
-    #[tracing::instrument(skip(self, source))]
+    #[tracing::instrument(skip_all)]
     async fn list_for_archived_answer(
         &self,
         source: &Allowed<ArchivedAnswerEntry, Read>,
@@ -198,7 +198,7 @@ where
         .await
     }
 
-    #[tracing::instrument(skip(self, source, target))]
+    #[tracing::instrument(skip_all)]
     async fn add(
         &self,
         relation: AnswerRelation,
@@ -213,7 +213,7 @@ where
             .map_err(Into::into)
     }
 
-    #[tracing::instrument(skip(self, source, target))]
+    #[tracing::instrument(skip_all)]
     async fn remove(
         &self,
         relation: AnswerRelation,
@@ -228,7 +228,7 @@ where
             .map_err(Into::into)
     }
 
-    #[tracing::instrument(skip(self, source))]
+    #[tracing::instrument(skip_all, fields(answer_id = %answer_id))]
     async fn find_for_source_and_answer_id(
         &self,
         source: &Allowed<AnswerEntry, Update>,

--- a/server/infra/resource/src/repository/form_repository_impls/comment_thread_repository_impl.rs
+++ b/server/infra/resource/src/repository/form_repository_impls/comment_thread_repository_impl.rs
@@ -28,7 +28,7 @@ impl<Client> CommentThreadRepository for Repository<Client>
 where
     Client: DatabaseComponents + 'static,
 {
-    #[tracing::instrument(skip(self, form, answer))]
+    #[tracing::instrument(skip_all)]
     async fn get_for_answer(
         &self,
         form: &Allowed<ActiveForm, Read>,
@@ -37,7 +37,7 @@ where
         form.comment_thread(answer).map_err(Error::from)
     }
 
-    #[tracing::instrument(skip(self, form, answer))]
+    #[tracing::instrument(skip_all)]
     async fn get_with_comments_for_answer(
         &self,
         form: &Allowed<ActiveForm, Read>,
@@ -55,7 +55,7 @@ where
             .map_err(Error::from)
     }
 
-    #[tracing::instrument(skip(self, comment))]
+    #[tracing::instrument(skip_all)]
     async fn create(
         &self,
         form: &Allowed<ActiveForm, Read>,
@@ -67,7 +67,7 @@ where
             .await
     }
 
-    #[tracing::instrument(skip(self, comment))]
+    #[tracing::instrument(skip_all)]
     async fn update(
         &self,
         form: &Allowed<ActiveForm, Read>,
@@ -80,7 +80,7 @@ where
             .await
     }
 
-    #[tracing::instrument(skip(self, comment))]
+    #[tracing::instrument(skip_all)]
     async fn delete(
         &self,
         form: &Allowed<ActiveForm, Read>,

--- a/server/infra/resource/src/repository/form_repository_impls/form_label_repository_impl.rs
+++ b/server/infra/resource/src/repository/form_repository_impls/form_label_repository_impl.rs
@@ -14,7 +14,7 @@ use crate::{
 
 #[async_trait]
 impl<Client: DatabaseComponents + 'static> FormLabelRepository for Repository<Client> {
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip_all)]
     async fn create_label_for_forms(&self, label: Allowed<FormLabel, Create>) -> Result<(), Error> {
         self.client
             .form_label()
@@ -23,7 +23,7 @@ impl<Client: DatabaseComponents + 'static> FormLabelRepository for Repository<Cl
             .map_err(Into::into)
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip_all)]
     async fn fetch_labels(&self) -> Result<Vec<AuthorizationGuard<FormLabel, Read>>, Error> {
         self.client
             .form_label()
@@ -35,7 +35,7 @@ impl<Client: DatabaseComponents + 'static> FormLabelRepository for Repository<Cl
             .collect::<Result<Vec<_>, _>>()
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip_all)]
     async fn fetch_labels_by_ids(
         &self,
         ids: Vec<FormLabelId>,
@@ -50,7 +50,7 @@ impl<Client: DatabaseComponents + 'static> FormLabelRepository for Repository<Cl
             .collect::<Result<Vec<_>, _>>()
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip_all, fields(label_id = %id))]
     async fn fetch_label(
         &self,
         id: FormLabelId,
@@ -65,7 +65,7 @@ impl<Client: DatabaseComponents + 'static> FormLabelRepository for Repository<Cl
             .map(Into::into))
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip_all)]
     async fn delete_label_for_forms(&self, label: Allowed<FormLabel, Delete>) -> Result<(), Error> {
         self.client
             .form_label()
@@ -74,7 +74,7 @@ impl<Client: DatabaseComponents + 'static> FormLabelRepository for Repository<Cl
             .map_err(Into::into)
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip_all, fields(label_id = %id))]
     async fn edit_label_for_forms(
         &self,
         id: FormLabelId,
@@ -87,7 +87,7 @@ impl<Client: DatabaseComponents + 'static> FormLabelRepository for Repository<Cl
             .map_err(Into::into)
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip_all, fields(form_id = %form_id))]
     async fn fetch_labels_by_form_id(
         &self,
         form_id: FormId,
@@ -102,7 +102,7 @@ impl<Client: DatabaseComponents + 'static> FormLabelRepository for Repository<Cl
             .collect::<Result<Vec<_>, _>>()
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip_all)]
     async fn size(&self) -> Result<u32, Error> {
         self.client.form_label().size().await.map_err(Into::into)
     }

--- a/server/infra/resource/src/repository/form_repository_impls/form_repository_impl.rs
+++ b/server/infra/resource/src/repository/form_repository_impls/form_repository_impl.rs
@@ -24,7 +24,7 @@ impl<Client> ActiveFormRepository for Repository<Client>
 where
     Client: DatabaseComponents + 'static,
 {
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip_all)]
     async fn create(
         &self,
         actor: &AccountUser,
@@ -34,7 +34,7 @@ where
         Ok(())
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip_all)]
     async fn list(
         &self,
         request: PageRequest<FormPagePosition>,
@@ -52,7 +52,7 @@ where
         Ok(Page::new(forms, next))
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip_all)]
     async fn list_all(&self) -> Result<Vec<AuthorizationGuard<ActiveForm, Read>>, Error> {
         self.client
             .form()
@@ -66,7 +66,7 @@ where
             .collect()
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip_all, fields(form_id = %id))]
     async fn get(&self, id: FormId) -> Result<Option<AuthorizationGuard<ActiveForm, Read>>, Error> {
         self.client
             .form()
@@ -79,7 +79,7 @@ where
             })
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip_all)]
     async fn update_form(
         &self,
         actor: &AccountUser,
@@ -92,7 +92,7 @@ where
         Ok(())
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip_all)]
     async fn size(&self) -> Result<u32, Error> {
         self.client.form().size().await.map_err(Into::into)
     }
@@ -103,7 +103,7 @@ impl<Client> ArchivedFormRepository for Repository<Client>
 where
     Client: DatabaseComponents + 'static,
 {
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip_all)]
     async fn list(
         &self,
         request: PageRequest<ArchivedFormPagePosition>,
@@ -122,7 +122,7 @@ where
         Ok(Page::new(forms, next))
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip_all, fields(form_id = %id))]
     async fn get(
         &self,
         id: FormId,
@@ -138,7 +138,7 @@ where
             })
     }
 
-    #[tracing::instrument(skip(self, form))]
+    #[tracing::instrument(skip_all, fields(answer_id = %answer_id))]
     async fn get_answer(
         &self,
         form: &Allowed<ArchivedForm, Read>,
@@ -158,7 +158,7 @@ where
         Ok(Some(form.read_archived_entry(answer)?))
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip_all)]
     async fn archive(
         &self,
         form: Allowed<ArchivedForm, Create>,
@@ -167,7 +167,7 @@ where
         Ok(AuthorizationGuard::<ArchivedForm, Create>::from(archived_form).into_read())
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip_all)]
     async fn restore(&self, form: Allowed<ArchivedForm, Update>) -> Result<(), Error> {
         let form_id = *form.value().form().id();
         let _restored = form.into_inner().unarchive();

--- a/server/infra/resource/src/repository/form_repository_impls/message_thread_repository_impl.rs
+++ b/server/infra/resource/src/repository/form_repository_impls/message_thread_repository_impl.rs
@@ -28,7 +28,7 @@ impl<Client> MessageThreadRepository for Repository<Client>
 where
     Client: DatabaseComponents + 'static,
 {
-    #[tracing::instrument(skip(self, answer))]
+    #[tracing::instrument(skip_all)]
     async fn get_for_answer(
         &self,
         answer: &Allowed<AnswerEntry, Read>,
@@ -45,7 +45,7 @@ where
         answer.message_thread(messages).map_err(Error::from)
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip_all)]
     async fn append(&self, post: Allowed<MessagePost, Create>) -> Result<(), Error> {
         let operated_by = account_user_snapshot(post.actor())?;
         let post = post.into_inner();

--- a/server/infra/resource/tests/tracing_instrument_audit.rs
+++ b/server/infra/resource/tests/tracing_instrument_audit.rs
@@ -1,0 +1,89 @@
+//! `#[tracing::instrument]` の引数が暗黙にスパン属性へ記録されないことを守るテスト。
+//!
+//! 引数を暗黙記録すると、認証情報・回答内容などの PII や `ConnectionPool` の
+//! Debug 出力（DB 接続情報・Meilisearch API キーを含む）がスパン属性に漏れる。
+//! そのため、すべての `#[tracing::instrument]` に `skip_all` を必須とし、
+//! 記録したい値は `fields(...)` で明示的に指定する。
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+fn server_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .expect("resource crate must be under server/infra/resource")
+        .to_path_buf()
+}
+
+fn collect_rust_files(dir: &Path, files: &mut Vec<PathBuf>) {
+    for entry in fs::read_dir(dir).expect("server directory must be readable") {
+        let path = entry.expect("directory entry must be readable").path();
+        if path.is_dir() {
+            collect_rust_files(&path, files);
+        } else if path.extension().is_some_and(|ext| ext == "rs") {
+            files.push(path);
+        }
+    }
+}
+
+/// `#[tracing::instrument` から始まる attribute 全体を、角括弧の対応を数えて取り出す。
+fn instrument_attrs(source: &str) -> Vec<(usize, String)> {
+    // この関数自身のリテラルにマッチしないよう、検索パターンは実行時に組み立てる
+    let needle = format!("#[{}", "tracing::instrument");
+
+    source
+        .match_indices(&needle)
+        .map(|(start, _)| {
+            let mut depth = 0usize;
+            let end = source[start..]
+                .char_indices()
+                .find_map(|(offset, character)| match character {
+                    '[' => {
+                        depth += 1;
+                        None
+                    }
+                    ']' => {
+                        depth -= 1;
+                        (depth == 0).then_some(start + offset + 1)
+                    }
+                    _ => None,
+                })
+                .expect("attribute brackets must be balanced");
+
+            let line = source[..start].lines().count();
+            (line, source[start..end].to_string())
+        })
+        .collect()
+}
+
+#[test]
+fn all_tracing_instruments_use_skip_all() {
+    let mut files = Vec::new();
+    collect_rust_files(&server_dir(), &mut files);
+
+    let this_file = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/tracing_instrument_audit.rs");
+
+    let violations = files
+        .iter()
+        .filter(|path| **path != this_file)
+        .flat_map(|path| {
+            let source = fs::read_to_string(path).expect("source file must be readable");
+            instrument_attrs(&source)
+                .into_iter()
+                .filter(|(_, attr)| !attr.contains("skip_all"))
+                .map(|(line, attr)| format!("{}:{line}: {attr}", path.display()))
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+
+    assert!(
+        violations.is_empty(),
+        "skip_all のない #[tracing::instrument] が見つかりました。\
+         引数の暗黙記録は PII や接続情報がスパン属性に漏れる原因になるため、\
+         skip_all を付け、記録したい値は fields(...) で明示してください:\n{}",
+        violations.join("\n")
+    );
+}


### PR DESCRIPTION
## 概要

Closes #1257

素の `#[tracing::instrument]` は引数を Debug 形式でスパン属性に記録するため、OTel 導入 (#1256) 後にそのまま Tempo へ export されると以下が漏れるリスクがありました。

- **`ConnectionPool` の Debug 出力**: 全 database 層メソッドの `&self` が記録対象になっており、`sqlx::MySqlPool` の接続情報や `meilisearch_sdk::Client`（API キー保持）が含まれる
- **PII**: フォーム回答内容 (`AnswerEntry`)・コメント・メッセージ本文・`AccountUser`（プレイヤー名）
- **ユーザー入力**: 検索クエリ (`query: &str`)
- **高カーディナリティ値**: `Vec<AnswerId>` などの ID 列挙、ページングカーソル

## 変更内容

- 全 113 箇所の `#[tracing::instrument]`（infra 層に集中）を `skip_all` に統一
- トレースで有用な**単一の ID 引数のみ** `fields(form_id = %form_id)` の形で明示的に記録（`Id<T>` は `Display(via: Uuid)` があるため素の UUID 文字列で記録される）
- ガードテスト `server/infra/resource/tests/tracing_instrument_audit.rs` を追加。`server/` 以下の全 Rust ソースを走査し、`skip_all` のない `#[tracing::instrument]` があるとテストが落ちるため、今後の追加漏れを CI で防止

## スコープ外

- HTTP レイヤーのスパン属性（`url.query` 相当）の確認は、OTel の `OtelAxumLayer` がまだ導入されていないため対象外です。#1256 / #1258 の実装時に確認します。

## 動作確認

- `cargo build` / `cargo clippy --all -- -D warnings` / `cargo test --all-features` すべて通過
- ガードテストは `skip_all` を 1 箇所外すと失敗することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)