### PR TITLE
feat: OpenTelemetry トレーシングを導入する

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,11 @@ MEILISEARCH_HOST=http://localhost:7700
 
 DISCORD_BOT_TOKEN=aaaaaaaaaaaaaa
 
+# OpenTelemetry トレーシング。OTEL_EXPORTER_OTLP_ENDPOINT 未設定なら送信は無効。
+# ローカルで検証する場合は compose の otel-lgtm を起動して以下を設定する。
+# OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+# OTEL_SDK_DISABLED=true
+
 RABBITMQ_USER=user
 RABBITMQ_PASSWORD=password
 RABBITMQ_HOST=localhost

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -394,6 +394,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-tracing-opentelemetry"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c938150bbecf4b43a24964bea0780f99d538b6654455e45b1784d410f122822"
+dependencies = [
+ "axum",
+ "futures-core",
+ "futures-util",
+ "http",
+ "opentelemetry",
+ "opentelemetry-semantic-conventions",
+ "pin-project-lite",
+ "tower",
+ "tracing",
+ "tracing-opentelemetry",
+ "tracing-opentelemetry-instrumentation-sdk",
+]
+
+[[package]]
 name = "backon"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1128,11 +1147,15 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "axum",
+ "axum-tracing-opentelemetry",
  "cargo-husky",
  "common",
  "domain",
  "futures",
  "hyper",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "presentation",
  "resource",
  "sentry",
@@ -1142,6 +1165,7 @@ dependencies = [
  "tower",
  "tower-http 0.7.0",
  "tracing",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "usecase",
  "utoipa",
@@ -2643,6 +2667,82 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "opentelemetry"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.19",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "opentelemetry",
+ "reqwest 0.13.4",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
+dependencies = [
+ "http",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "reqwest 0.13.4",
+ "thiserror 2.0.19",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c913ac17a6c451661ee255f4625d143e51647ae78ebd969b75e41c4442f4fe47"
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "portable-atomic",
+ "rand 0.9.5",
+ "thiserror 2.0.19",
+]
+
+[[package]]
 name = "os_info"
 version = "3.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2963,6 +3063,29 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c57924a81864dddafba92e1bf92f9bf82f97096c44489548a60e888e1547549b"
 dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -4805,6 +4928,35 @@ dependencies = [
  "log",
  "once_cell",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
+dependencies = [
+ "js-sys",
+ "opentelemetry",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
+]
+
+[[package]]
+name = "tracing-opentelemetry-instrumentation-sdk"
+version = "0.38.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a10464b0f9cac62a3e26c08c7c9b93c5ae62f5165792b2e7e90c52940eaabef5"
+dependencies = [
+ "http",
+ "opentelemetry",
+ "opentelemetry-semantic-conventions",
+ "tracing",
+ "tracing-opentelemetry",
 ]
 
 [[package]]

--- a/server/entrypoint/Cargo.toml
+++ b/server/entrypoint/Cargo.toml
@@ -7,8 +7,13 @@ default-run = "entrypoint"
 [dependencies]
 anyhow = { workspace = true }
 axum = { workspace = true }
+axum-tracing-opentelemetry = "0.38.0"
 common = { path = "../common" }
 hyper = { version = "1.11.0", features = ["full"] }
+opentelemetry = "0.32.0"
+# cross ビルドの rustls 縛りに合わせ、TLS フィーチャーなし (in-cluster http://) + blocking reqwest 構成にする
+opentelemetry-otlp = { version = "0.32.0", default-features = false, features = ["http-proto", "trace", "reqwest-blocking-client"] }
+opentelemetry_sdk = "0.32.1"
 presentation = { path = "../presentation" }
 resource = { path = "../infra/resource" }
 # default featureは推移的にnative-tls featureを有効しているため、native-tls (LinuxではOpenSSL) を連れてくる。これをオプトアウトするためにrustlsを使う。
@@ -17,6 +22,7 @@ tokio = { workspace = true }
 tower = "0.5.3"
 tower-http = { version = "0.7.0", features = ["cors"] }
 tracing = { workspace = true }
+tracing-opentelemetry = "0.33.0"
 tracing-subscriber = { version = "0.3.23", features = ["std", "registry", "env-filter"] }
 serde_json = { workspace = true }
 futures = { workspace = true }

--- a/server/entrypoint/src/lib.rs
+++ b/server/entrypoint/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod openapi;
+pub mod telemetry;

--- a/server/entrypoint/src/main.rs
+++ b/server/entrypoint/src/main.rs
@@ -10,11 +10,13 @@ use axum::{
     response::IntoResponse,
     routing::{get, post},
 };
+use axum_tracing_opentelemetry::middleware::{OtelAxumLayer, OtelInResponseLayer};
 use common::config::{ENV, HTTP};
 use domain::search::models::SearchableFieldsWithOperation;
-use entrypoint::openapi;
+use entrypoint::{openapi, telemetry};
 use futures::join;
 use hyper::header::SET_COOKIE;
+use opentelemetry::trace::TracerProvider as _;
 use presentation::api::global_discord_webhook::start_global_discord_webhook_worker;
 use presentation::api::notificator_impl::DiscordNotificator;
 use presentation::auth::{auth, optional_auth};
@@ -40,7 +42,12 @@ use utoipa_swagger_ui::SwaggerUi;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    let tracer_provider = telemetry::init_tracer_provider();
+
     tracing_subscriber::registry()
+        .with(tracer_provider.as_ref().map(|provider| {
+            tracing_opentelemetry::layer().with_tracer(provider.tracer("seichi-portal-backend"))
+        }))
         .with(sentry::integrations::tracing::layer())
         .with(
             tracing_subscriber::fmt::layer().with_filter(tracing_subscriber::EnvFilter::new(
@@ -145,6 +152,10 @@ async fn main() -> anyhow::Result<()> {
         )
         .fallback(not_found_handler)
         .layer(layer)
+        // レスポンスヘッダーへの trace context 挿入 (OtelAxumLayer より内側に置く)
+        .layer(OtelInResponseLayer)
+        // リクエストごとの OTel スパン開始。/health はトレース対象外
+        .layer(OtelAxumLayer::default().filter(|path| !path.starts_with("/health")))
         .layer(
             CorsLayer::new()
                 .allow_methods([
@@ -187,6 +198,16 @@ async fn main() -> anyhow::Result<()> {
         messaging_conn.consumer(),
         start_watch_out_of_sync(shared_repository.to_owned(), shutdown_notifier.clone())
     );
+
+    if let Some(provider) = tracer_provider {
+        // provider.shutdown() は残りのスパンを blocking export するため専用スレッドで行う
+        tokio::task::spawn_blocking(move || {
+            if let Err(error) = provider.shutdown() {
+                info!("failed to shutdown OpenTelemetry tracer provider: {error}");
+            }
+        })
+        .await?;
+    }
 
     Ok(())
 }

--- a/server/entrypoint/src/telemetry.rs
+++ b/server/entrypoint/src/telemetry.rs
@@ -1,0 +1,96 @@
+use opentelemetry::global;
+use opentelemetry_otlp::{Protocol, SpanExporter, WithExportConfig};
+use opentelemetry_sdk::{Resource, propagation::TraceContextPropagator, trace::SdkTracerProvider};
+
+const SERVICE_NAME: &str = "seichi-portal-backend";
+
+/// OpenTelemetry のトレーシングを初期化します。
+///
+/// `OTEL_SDK_DISABLED=true` または `OTEL_EXPORTER_OTLP_ENDPOINT` 未設定の場合は
+/// 初期化をスキップして `None` を返します
+/// (`OTEL_SDK_DISABLED` は Rust SDK 未実装のため自前でゲートしています)。
+///
+/// エクスポートは OTLP http/protobuf で、endpoint やその他の設定は
+/// `OTEL_*` 環境変数から自動で読み込まれます。
+pub fn init_tracer_provider() -> Option<SdkTracerProvider> {
+    let sdk_disabled =
+        std::env::var("OTEL_SDK_DISABLED").is_ok_and(|value| value.eq_ignore_ascii_case("true"));
+    let endpoint_configured =
+        std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT").is_ok_and(|value| !value.is_empty());
+
+    if sdk_disabled || !endpoint_configured {
+        return None;
+    }
+
+    global::set_text_map_propagator(TraceContextPropagator::new());
+
+    let exporter = SpanExporter::builder()
+        .with_http()
+        .with_protocol(Protocol::HttpBinary)
+        .build()
+        .expect("failed to build OTLP span exporter");
+
+    // Resource::builder() は OTEL_SERVICE_NAME / OTEL_RESOURCE_ATTRIBUTES を
+    // 自動で読むため、service.name は環境変数未設定時のみデフォルト値を与える
+    let resource = if std::env::var("OTEL_SERVICE_NAME").is_ok() {
+        Resource::builder().build()
+    } else {
+        Resource::builder().with_service_name(SERVICE_NAME).build()
+    };
+
+    let provider = SdkTracerProvider::builder()
+        .with_batch_exporter(exporter)
+        .with_resource(resource)
+        .build();
+
+    global::set_tracer_provider(provider.clone());
+
+    Some(provider)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::init_tracer_provider;
+
+    /// 環境変数の設定はプロセス全体に影響するため、
+    /// 競合しないよう 1 つのテストで順に検証する。
+    #[test]
+    fn tracer_provider_is_gated_by_environment_variables() {
+        // SAFETY: このテストバイナリ内で環境変数を読み書きするのはこのテストだけ
+        unsafe {
+            std::env::remove_var("OTEL_EXPORTER_OTLP_ENDPOINT");
+            std::env::remove_var("OTEL_SDK_DISABLED");
+        }
+        assert!(
+            init_tracer_provider().is_none(),
+            "OTEL_EXPORTER_OTLP_ENDPOINT 未設定なら初期化をスキップする"
+        );
+
+        unsafe {
+            std::env::set_var("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4318");
+            std::env::set_var("OTEL_SDK_DISABLED", "true");
+        }
+        assert!(
+            init_tracer_provider().is_none(),
+            "OTEL_SDK_DISABLED=true なら endpoint が設定されていてもスキップする"
+        );
+
+        unsafe {
+            std::env::remove_var("OTEL_SDK_DISABLED");
+        }
+        let provider = init_tracer_provider();
+        assert!(
+            provider.is_some(),
+            "endpoint 設定時は tracer provider が初期化される"
+        );
+
+        if let Some(provider) = provider {
+            provider
+                .shutdown()
+                .expect("tracer provider must shut down cleanly");
+        }
+        unsafe {
+            std::env::remove_var("OTEL_EXPORTER_OTLP_ENDPOINT");
+        }
+    }
+}


### PR DESCRIPTION
## 概要

Closes #1256

issue のスペックに沿って OpenTelemetry トレーシングを導入しました。エクスポートは OTLP **http/protobuf**、cross ビルドの rustls 縛りに合わせて TLS フィーチャーなし + blocking reqwest 構成です。

## 変更内容

### 依存追加 (`server/entrypoint/Cargo.toml`)

- `opentelemetry 0.32` / `opentelemetry_sdk 0.32` / `opentelemetry-otlp 0.32`（`http-proto`, `trace`, `reqwest-blocking-client`、default-features off）
- `tracing-opentelemetry 0.33` / `axum-tracing-opentelemetry 0.38`
- `opentelemetry-semantic-conventions` は未使用になるため追加していません（`Resource::builder().with_service_name()` で足りるため）

### telemetry モジュール新設 (`server/entrypoint/src/telemetry.rs`)

- `OTEL_SDK_DISABLED=true` または `OTEL_EXPORTER_OTLP_ENDPOINT` 未設定なら初期化をスキップして `None` を返す（`OTEL_SDK_DISABLED` は Rust SDK 未実装のため自前ゲート）
- W3C `TraceContextPropagator` を global 設定（inbound `traceparent` を親として採用）
- `SpanExporter::builder().with_http().with_protocol(Protocol::HttpBinary)` + `SdkTracerProvider::builder().with_batch_exporter(...)`（batch processor は専用スレッド式のため blocking client で問題なし）
- endpoint / resource は `OTEL_*` env から自動読込。`service.name` は `OTEL_SERVICE_NAME` 未設定時のみ `seichi-portal-backend` をデフォルト設定

### main.rs

- subscriber の registry に `tracing_opentelemetry::layer()` を追加（`Option<Layer>` なので未初期化時は no-op）
- tower スタックに `OtelAxumLayer::default().filter(|p| !p.starts_with("/health"))` + `OtelInResponseLayer` を追加。app Router の最外層に掛けているため、`/api/v1` 配下にマージされる `post_message_handler` の別 Router にも適用されます
- graceful shutdown（`join!` 完了後）に `provider.shutdown()` を `spawn_blocking` 経由で実行

### その他

- `.env.example` に `OTEL_*` を追記

## 動作確認

- `cargo build` / `cargo clippy --all -- -D warnings` / `cargo test` 通過
- 環境変数ゲート（未設定でスキップ / `OTEL_SDK_DISABLED` / 設定時に初期化）のユニットテストを追加
- Tempo への実スパン到達確認はローカル観測環境 (#1259) とインフラ側 (seichi_infra#5609, #5607) が揃ってからになります

## 備考

- #1257（instrument 引数の PII 監査）が別 PR #1265 にあります。本番でスパン export を開始する前にそちらを先にマージしてください

🤖 Generated with [Claude Code](https://claude.com/claude-code)