### PR TITLE
feat: ローカル観測検証環境として grafana/otel-lgtm を compose に追加する

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -10,6 +10,19 @@ args = [
     "-d"
 ]
 
+# ローカル観測検証環境 (grafana/otel-lgtm) 込みで compose を起動する。
+# backend 側は OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 を設定して
+# 起動すると、http://localhost:3000 の Grafana からトレースを確認できる。
+[tasks.up-observability]
+command = "docker"
+args = [
+    "compose",
+    "--profile",
+    "observability",
+    "up",
+    "-d"
+]
+
 [tasks.run-server]
 command = "cargo"
 args = ["run", "--package", "entrypoint"]

--- a/compose.yaml
+++ b/compose.yaml
@@ -115,6 +115,22 @@ services:
       - "5672:5672"
       - "15672:15672"
     restart: always
+  # ローカル観測検証環境。OTLP receiver + Tempo + Loki + Prometheus + Grafana がこれ 1 つで立つ。
+  # 通常の開発では不要なため observability プロファイル指定時のみ起動する (makers up-observability)。
+  # backend は OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 を設定して起動し、
+  # http://localhost:3000 の Grafana でトレースを確認する。
+  otel-lgtm:
+    image: grafana/otel-lgtm:0.30.0
+    container_name: otel-lgtm
+    profiles:
+      - observability
+    ports:
+      - "3000:3000" # Grafana UI
+      - "4317:4317" # OTLP gRPC
+      - "4318:4318" # OTLP HTTP
+    networks:
+      - seichi_portal
+    restart: always
   debezium:
     image: quay.io/debezium/server:3.6
     ports:


### PR DESCRIPTION
## 概要

Closes #1259

OTel 導入 (#1256 / PR #1266) 後の動作確認（スパン到達・trace_id ログ相関）をローカルで完結できるよう、`grafana/otel-lgtm`（OTLP receiver + Tempo + Loki + Prometheus + Grafana が 1 コンテナ）を compose に追加しました。

## 変更内容

- `compose.yaml`: `otel-lgtm` サービスを `observability` プロファイルとして追加。通常の `makers up` / `docker compose up` では起動されません
- `Makefile.toml`: `makers up-observability` タスクを追加（observability プロファイル込みで compose を起動）

## 検証手順

1. `makers up-observability` で otel-lgtm 込みのサービス群を起動
2. `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318` を設定して backend を起動（PR #1266 が前提）
3. http://localhost:3000 の Grafana (Explore → Tempo) でトレースを確認

## 動作確認

- `docker compose config` が通ること、デフォルトプロファイルに otel-lgtm が含まれないこと、`--profile observability` で含まれることを確認

## 備考

- `.env.example` への `OTEL_*` の追記は PR #1266 側に含めています（コンフリクト回避のため本 PR では触っていません）
- Grafana が 3000 番ポートを使うため、フロントエンド開発サーバー（localhost:3000）とは同時起動できません。観測検証時のみの起動を想定しています

🤖 Generated with [Claude Code](https://claude.com/claude-code)