### PR TITLE
feat: stdout ログを JSON 化し trace_id/span_id を注入する

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,10 @@ MEILISEARCH_HOST=http://localhost:7700
 
 DISCORD_BOT_TOKEN=aaaaaaaaaaaaaa
 
+# stdout ログのフォーマット。未設定なら ENV_NAME=local のときだけ人間向け、それ以外は JSON。
+# JSON 出力をローカルで確認する場合は json を設定する。
+# LOG_FORMAT=json
+
 # OpenTelemetry トレーシング。OTEL_EXPORTER_OTLP_ENDPOINT 未設定なら送信は無効。
 # ローカルで検証する場合は compose の otel-lgtm を起動して以下を設定する。
 # OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1149,11 +1149,11 @@ dependencies = [
  "axum",
  "axum-tracing-opentelemetry",
  "cargo-husky",
- "chrono",
  "common",
  "domain",
  "futures",
  "hyper",
+ "json-subscriber",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
@@ -2112,6 +2112,23 @@ dependencies = [
  "cfg-if",
  "futures-util",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "json-subscriber"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1a3442048fd2d18bf39b182881bea8de640062f86cbacf6d949478af61651d6"
+dependencies = [
+ "opentelemetry",
+ "serde",
+ "serde_json",
+ "tracing",
+ "tracing-core",
+ "tracing-opentelemetry",
+ "tracing-serde",
+ "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]
@@ -4958,6 +4975,16 @@ dependencies = [
  "opentelemetry-semantic-conventions",
  "tracing",
  "tracing-opentelemetry",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1149,6 +1149,7 @@ dependencies = [
  "axum",
  "axum-tracing-opentelemetry",
  "cargo-husky",
+ "chrono",
  "common",
  "domain",
  "futures",

--- a/server/entrypoint/Cargo.toml
+++ b/server/entrypoint/Cargo.toml
@@ -8,6 +8,7 @@ default-run = "entrypoint"
 anyhow = { workspace = true }
 axum = { workspace = true }
 axum-tracing-opentelemetry = "0.38.0"
+chrono = { workspace = true }
 common = { path = "../common" }
 hyper = { version = "1.11.0", features = ["full"] }
 opentelemetry = "0.32.0"

--- a/server/entrypoint/Cargo.toml
+++ b/server/entrypoint/Cargo.toml
@@ -8,9 +8,9 @@ default-run = "entrypoint"
 anyhow = { workspace = true }
 axum = { workspace = true }
 axum-tracing-opentelemetry = "0.38.0"
-chrono = { workspace = true }
 common = { path = "../common" }
 hyper = { version = "1.11.0", features = ["full"] }
+json-subscriber = { version = "0.3.0", features = ["tracing-opentelemetry-0-33"] }
 opentelemetry = "0.32.0"
 # cross ビルドの rustls 縛りに合わせ、TLS フィーチャーなし (in-cluster http://) + blocking reqwest 構成にする
 opentelemetry-otlp = { version = "0.32.0", default-features = false, features = ["http-proto", "trace", "reqwest-blocking-client"] }

--- a/server/entrypoint/src/lib.rs
+++ b/server/entrypoint/src/lib.rs
@@ -1,2 +1,3 @@
+pub mod logging;
 pub mod openapi;
 pub mod telemetry;

--- a/server/entrypoint/src/logging.rs
+++ b/server/entrypoint/src/logging.rs
@@ -1,0 +1,280 @@
+use std::{
+    fmt,
+    sync::{Arc, OnceLock},
+};
+
+use chrono::{SecondsFormat, Utc};
+use opentelemetry::trace::TraceContextExt;
+use serde_json::Value;
+use tracing::{
+    Event, Subscriber,
+    dispatcher::WeakDispatch,
+    field::{Field, Visit},
+};
+use tracing_opentelemetry::get_otel_context;
+use tracing_subscriber::{
+    fmt::{FmtContext, FormatEvent, FormatFields, format::Writer},
+    registry::LookupSpan,
+};
+
+/// stdout ログを JSON にするかどうかを判定します。
+///
+/// `LOG_FORMAT` 環境変数 (`json` / `pretty`) が設定されていればそれに従い、
+/// 未設定ならローカル開発 (`ENV_NAME=local`) でのみ人間向けフォーマットにします。
+pub fn json_logs_enabled(env_name: &str, log_format: Option<&str>) -> bool {
+    match log_format {
+        Some(format) => format.eq_ignore_ascii_case("json"),
+        None => env_name != "local",
+    }
+}
+
+/// ログイベントを 1 行の JSON にフォーマットし、OTel の trace_id / span_id を注入する。
+///
+/// `tracing-subscriber` 標準の JSON フォーマッタは OTel の trace_id を出力できないため
+/// 自前実装している。`trace_id` / `span_id` フィールドは Grafana (Tempo の tracesToLogsV2)
+/// との契約であり、フィールド名を変える場合は seichi_infra 側の設定も直すこと。
+///
+/// span のフィールドはスパン属性として Tempo 側に送られるため、ログ行には出力しない
+/// (URL クエリなどリクエスト由来の値がログへ漏れるのを防ぐ意図もある)。
+///
+/// trace_id の解決には subscriber の [`Dispatch`](tracing::Dispatch) が必要だが、
+/// フォーマッタ実行中は tracing の再入ガードにより
+/// `Span::current()` や `dispatcher::get_default` が使えない。
+/// このため subscriber の init 後に [`JsonWithTraceId::connect_dispatch`] を呼び、
+/// trace_id 解決に使う `Dispatch` を登録する必要がある。
+#[derive(Clone, Default)]
+pub struct JsonWithTraceId {
+    dispatch: Arc<OnceLock<WeakDispatch>>,
+}
+
+impl JsonWithTraceId {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// subscriber の init 後 (またはテストでは `with_default` スコープ内) に呼び、
+    /// trace_id 解決に使う `Dispatch` を登録します。
+    /// 呼ばれないままの場合、ログは出力されるが trace_id / span_id が付かない。
+    pub fn connect_dispatch(&self) {
+        tracing::dispatcher::get_default(|dispatch| {
+            let _ = self.dispatch.set(dispatch.downgrade());
+        });
+    }
+}
+
+impl<S, N> FormatEvent<S, N> for JsonWithTraceId
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+    N: for<'a> FormatFields<'a> + 'static,
+{
+    fn format_event(
+        &self,
+        ctx: &FmtContext<'_, S, N>,
+        mut writer: Writer<'_>,
+        event: &Event<'_>,
+    ) -> fmt::Result {
+        let mut collector = FieldCollector::default();
+        event.record(&mut collector);
+
+        let mut entries = vec![
+            (
+                "timestamp",
+                Value::from(Utc::now().to_rfc3339_opts(SecondsFormat::Micros, true)),
+            ),
+            ("level", Value::from(event.metadata().level().as_str())),
+            ("target", Value::from(event.metadata().target())),
+            (
+                "message",
+                Value::from(collector.message.unwrap_or_default()),
+            ),
+        ];
+        entries.extend(
+            collector
+                .fields
+                .iter()
+                .map(|(name, value)| (*name, value.to_owned())),
+        );
+
+        let otel_context = self
+            .dispatch
+            .get()
+            .and_then(WeakDispatch::upgrade)
+            .and_then(|dispatch| {
+                let event_span = ctx.event_scope()?.next()?;
+                get_otel_context(&event_span.id(), &dispatch)
+            });
+        if let Some(otel_context) = otel_context {
+            let span_ref = otel_context.span();
+            let span_context = span_ref.span_context();
+            if span_context.is_valid() {
+                entries.push(("trace_id", Value::from(span_context.trace_id().to_string())));
+                entries.push(("span_id", Value::from(span_context.span_id().to_string())));
+            }
+        }
+
+        write!(writer, "{{")?;
+        for (index, (key, value)) in entries.iter().enumerate() {
+            if index > 0 {
+                write!(writer, ",")?;
+            }
+            write!(writer, "{}:{value}", Value::from(*key))?;
+        }
+        writeln!(writer, "}}")
+    }
+}
+
+#[derive(Default)]
+struct FieldCollector {
+    message: Option<String>,
+    fields: Vec<(&'static str, Value)>,
+}
+
+impl FieldCollector {
+    fn push(&mut self, field: &Field, value: Value) {
+        match (field.name(), value) {
+            ("message", Value::String(message)) => self.message = Some(message),
+            ("message", value) => self.message = Some(value.to_string()),
+            (name, value) => self.fields.push((name, value)),
+        }
+    }
+}
+
+impl Visit for FieldCollector {
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        self.push(field, Value::from(value));
+    }
+
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.push(field, Value::from(value));
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.push(field, Value::from(value));
+    }
+
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        self.push(field, Value::from(value));
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.push(field, Value::from(value));
+    }
+
+    fn record_error(&mut self, field: &Field, value: &(dyn std::error::Error + 'static)) {
+        self.push(field, Value::from(value.to_string()));
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+        self.push(field, Value::from(format!("{value:?}")));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        io,
+        sync::{Arc, Mutex},
+    };
+
+    use opentelemetry::trace::TracerProvider as _;
+    use tracing::info;
+    use tracing_subscriber::{fmt::MakeWriter, layer::SubscriberExt};
+
+    use super::{JsonWithTraceId, json_logs_enabled};
+
+    #[test]
+    fn json_logs_are_enabled_outside_local_unless_overridden() {
+        assert!(json_logs_enabled("production", None));
+        assert!(!json_logs_enabled("local", None));
+        assert!(json_logs_enabled("local", Some("json")));
+        assert!(!json_logs_enabled("production", Some("pretty")));
+    }
+
+    #[derive(Clone, Default)]
+    struct Capture(Arc<Mutex<Vec<u8>>>);
+
+    impl io::Write for Capture {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> MakeWriter<'a> for Capture {
+        type Writer = Capture;
+
+        fn make_writer(&'a self) -> Capture {
+            self.clone()
+        }
+    }
+
+    fn captured_json(capture: &Capture) -> serde_json::Value {
+        let bytes = capture.0.lock().unwrap();
+        let text = std::str::from_utf8(&bytes).expect("log output must be valid UTF-8");
+        serde_json::from_str(text.lines().next().expect("a log line must be written"))
+            .expect("log line must be valid JSON")
+    }
+
+    #[test]
+    fn formats_event_as_single_line_json() {
+        let capture = Capture::default();
+        let formatter = JsonWithTraceId::new();
+        let subscriber = tracing_subscriber::registry().with(
+            tracing_subscriber::fmt::layer()
+                .event_format(formatter.clone())
+                .with_writer(capture.clone()),
+        );
+
+        tracing::subscriber::with_default(subscriber, || {
+            formatter.connect_dispatch();
+            info!(form_id = "0198c6b3", "hello");
+        });
+
+        let json = captured_json(&capture);
+        assert_eq!(json["message"], "hello");
+        assert_eq!(json["level"], "INFO");
+        assert_eq!(json["form_id"], "0198c6b3");
+        assert!(
+            json.get("trace_id").is_none(),
+            "OTel の span がなければ trace_id は出力しない"
+        );
+    }
+
+    #[test]
+    fn injects_trace_and_span_id_inside_otel_span() {
+        let capture = Capture::default();
+        let formatter = JsonWithTraceId::new();
+        let provider = opentelemetry_sdk::trace::SdkTracerProvider::builder().build();
+        let subscriber = tracing_subscriber::registry()
+            .with(tracing_opentelemetry::layer().with_tracer(provider.tracer("test")))
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .event_format(formatter.clone())
+                    .with_writer(capture.clone()),
+            );
+
+        tracing::subscriber::with_default(subscriber, || {
+            formatter.connect_dispatch();
+            let span = tracing::info_span!("request");
+            let _guard = span.enter();
+            info!("with trace");
+        });
+
+        let json = captured_json(&capture);
+        let trace_id = json["trace_id"].as_str().expect("trace_id must be present");
+        assert_eq!(trace_id.len(), 32);
+        assert!(trace_id.chars().all(|c| c.is_ascii_hexdigit()));
+        assert_ne!(
+            trace_id,
+            "0".repeat(32),
+            "trace_id must be valid (non-zero)"
+        );
+
+        let span_id = json["span_id"].as_str().expect("span_id must be present");
+        assert_eq!(span_id.len(), 16);
+    }
+}

--- a/server/entrypoint/src/logging.rs
+++ b/server/entrypoint/src/logging.rs
@@ -1,21 +1,5 @@
-use std::{
-    fmt,
-    sync::{Arc, OnceLock},
-};
-
-use chrono::{SecondsFormat, Utc};
-use opentelemetry::trace::TraceContextExt;
-use serde_json::Value;
-use tracing::{
-    Event, Subscriber,
-    dispatcher::WeakDispatch,
-    field::{Field, Visit},
-};
-use tracing_opentelemetry::get_otel_context;
-use tracing_subscriber::{
-    fmt::{FmtContext, FormatEvent, FormatFields, format::Writer},
-    registry::LookupSpan,
-};
+use tracing::Subscriber;
+use tracing_subscriber::registry::LookupSpan;
 
 /// stdout ログを JSON にするかどうかを判定します。
 ///
@@ -28,145 +12,28 @@ pub fn json_logs_enabled(env_name: &str, log_format: Option<&str>) -> bool {
     }
 }
 
-/// ログイベントを 1 行の JSON にフォーマットし、OTel の trace_id / span_id を注入する。
+/// stdout ログを 1 行 JSON で出力するレイヤーを作ります。
 ///
-/// `tracing-subscriber` 標準の JSON フォーマッタは OTel の trace_id を出力できないため
-/// 自前実装している。`trace_id` / `span_id` フィールドは Grafana (Tempo の tracesToLogsV2)
-/// との契約であり、フィールド名を変える場合は seichi_infra 側の設定も直すこと。
+/// `tracing-subscriber` 標準の JSON フォーマッタは OTel の trace_id を出力できないため、
+/// [`json_subscriber`] を使う。
 ///
-/// span のフィールドはスパン属性として Tempo 側に送られるため、ログ行には出力しない
-/// (URL クエリなどリクエスト由来の値がログへ漏れるのを防ぐ意図もある)。
-///
-/// trace_id の解決には subscriber の [`Dispatch`](tracing::Dispatch) が必要だが、
-/// フォーマッタ実行中は tracing の再入ガードにより
-/// `Span::current()` や `dispatcher::get_default` が使えない。
-/// このため subscriber の init 後に [`JsonWithTraceId::connect_dispatch`] を呼び、
-/// trace_id 解決に使う `Dispatch` を登録する必要がある。
-#[derive(Clone, Default)]
-pub struct JsonWithTraceId {
-    dispatch: Arc<OnceLock<WeakDispatch>>,
-}
-
-impl JsonWithTraceId {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// subscriber の init 後 (またはテストでは `with_default` スコープ内) に呼び、
-    /// trace_id 解決に使う `Dispatch` を登録します。
-    /// 呼ばれないままの場合、ログは出力されるが trace_id / span_id が付かない。
-    pub fn connect_dispatch(&self) {
-        tracing::dispatcher::get_default(|dispatch| {
-            let _ = self.dispatch.set(dispatch.downgrade());
-        });
-    }
-}
-
-impl<S, N> FormatEvent<S, N> for JsonWithTraceId
+/// - OTel の span コンテキストが有効な場合、`openTelemetry.traceId` / `openTelemetry.spanId`
+///   フィールドが付く (Tempo の tracesToLogsV2 でトレース→ログ相関に使う。
+///   このフィールド名は seichi_infra 側の Grafana/Loki 設定との契約であり、
+///   変更する場合は両方直すこと)
+/// - イベントのフィールドはトップレベルへフラットに出力される
+///   (`panic=true` のような LogQL の `| json` パースを前提としたフィールドの契約を保つ)
+/// - span のフィールドはスパン属性として Tempo 側へ送られるため、ログ行には出力しない
+///   (URL クエリなどリクエスト由来の値がログへ漏れるのを防ぐ意図もある)
+pub fn json_log_layer<S>() -> json_subscriber::fmt::Layer<S>
 where
     S: Subscriber + for<'a> LookupSpan<'a>,
-    N: for<'a> FormatFields<'a> + 'static,
 {
-    fn format_event(
-        &self,
-        ctx: &FmtContext<'_, S, N>,
-        mut writer: Writer<'_>,
-        event: &Event<'_>,
-    ) -> fmt::Result {
-        let mut collector = FieldCollector::default();
-        event.record(&mut collector);
-
-        let mut entries = vec![
-            (
-                "timestamp",
-                Value::from(Utc::now().to_rfc3339_opts(SecondsFormat::Micros, true)),
-            ),
-            ("level", Value::from(event.metadata().level().as_str())),
-            ("target", Value::from(event.metadata().target())),
-            (
-                "message",
-                Value::from(collector.message.unwrap_or_default()),
-            ),
-        ];
-        entries.extend(
-            collector
-                .fields
-                .iter()
-                .map(|(name, value)| (*name, value.to_owned())),
-        );
-
-        let otel_context = self
-            .dispatch
-            .get()
-            .and_then(WeakDispatch::upgrade)
-            .and_then(|dispatch| {
-                let event_span = ctx.event_scope()?.next()?;
-                get_otel_context(&event_span.id(), &dispatch)
-            });
-        if let Some(otel_context) = otel_context {
-            let span_ref = otel_context.span();
-            let span_context = span_ref.span_context();
-            if span_context.is_valid() {
-                entries.push(("trace_id", Value::from(span_context.trace_id().to_string())));
-                entries.push(("span_id", Value::from(span_context.span_id().to_string())));
-            }
-        }
-
-        write!(writer, "{{")?;
-        for (index, (key, value)) in entries.iter().enumerate() {
-            if index > 0 {
-                write!(writer, ",")?;
-            }
-            write!(writer, "{}:{value}", Value::from(*key))?;
-        }
-        writeln!(writer, "}}")
-    }
-}
-
-#[derive(Default)]
-struct FieldCollector {
-    message: Option<String>,
-    fields: Vec<(&'static str, Value)>,
-}
-
-impl FieldCollector {
-    fn push(&mut self, field: &Field, value: Value) {
-        match (field.name(), value) {
-            ("message", Value::String(message)) => self.message = Some(message),
-            ("message", value) => self.message = Some(value.to_string()),
-            (name, value) => self.fields.push((name, value)),
-        }
-    }
-}
-
-impl Visit for FieldCollector {
-    fn record_f64(&mut self, field: &Field, value: f64) {
-        self.push(field, Value::from(value));
-    }
-
-    fn record_i64(&mut self, field: &Field, value: i64) {
-        self.push(field, Value::from(value));
-    }
-
-    fn record_u64(&mut self, field: &Field, value: u64) {
-        self.push(field, Value::from(value));
-    }
-
-    fn record_bool(&mut self, field: &Field, value: bool) {
-        self.push(field, Value::from(value));
-    }
-
-    fn record_str(&mut self, field: &Field, value: &str) {
-        self.push(field, Value::from(value));
-    }
-
-    fn record_error(&mut self, field: &Field, value: &(dyn std::error::Error + 'static)) {
-        self.push(field, Value::from(value.to_string()));
-    }
-
-    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
-        self.push(field, Value::from(format!("{value:?}")));
-    }
+    json_subscriber::layer()
+        .flatten_event(true)
+        .with_current_span(false)
+        .with_span_list(false)
+        .with_opentelemetry_ids(true)
 }
 
 #[cfg(test)]
@@ -180,7 +47,7 @@ mod tests {
     use tracing::info;
     use tracing_subscriber::{fmt::MakeWriter, layer::SubscriberExt};
 
-    use super::{JsonWithTraceId, json_logs_enabled};
+    use super::{json_log_layer, json_logs_enabled};
 
     #[test]
     fn json_logs_are_enabled_outside_local_unless_overridden() {
@@ -222,59 +89,52 @@ mod tests {
     #[test]
     fn formats_event_as_single_line_json() {
         let capture = Capture::default();
-        let formatter = JsonWithTraceId::new();
-        let subscriber = tracing_subscriber::registry().with(
-            tracing_subscriber::fmt::layer()
-                .event_format(formatter.clone())
-                .with_writer(capture.clone()),
-        );
+        let subscriber =
+            tracing_subscriber::registry().with(json_log_layer().with_writer(capture.clone()));
 
         tracing::subscriber::with_default(subscriber, || {
-            formatter.connect_dispatch();
             info!(form_id = "0198c6b3", "hello");
         });
 
         let json = captured_json(&capture);
         assert_eq!(json["message"], "hello");
         assert_eq!(json["level"], "INFO");
-        assert_eq!(json["form_id"], "0198c6b3");
+        assert_eq!(
+            json["form_id"], "0198c6b3",
+            "イベントフィールドはトップレベルへフラットに出力される"
+        );
+        assert!(json.get("timestamp").is_some());
         assert!(
-            json.get("trace_id").is_none(),
-            "OTel の span がなければ trace_id は出力しない"
+            json.get("openTelemetry").is_none(),
+            "OTel の span がなければ traceId は出力しない"
         );
     }
 
     #[test]
     fn injects_trace_and_span_id_inside_otel_span() {
         let capture = Capture::default();
-        let formatter = JsonWithTraceId::new();
         let provider = opentelemetry_sdk::trace::SdkTracerProvider::builder().build();
         let subscriber = tracing_subscriber::registry()
             .with(tracing_opentelemetry::layer().with_tracer(provider.tracer("test")))
-            .with(
-                tracing_subscriber::fmt::layer()
-                    .event_format(formatter.clone())
-                    .with_writer(capture.clone()),
-            );
+            .with(json_log_layer().with_writer(capture.clone()));
 
         tracing::subscriber::with_default(subscriber, || {
-            formatter.connect_dispatch();
             let span = tracing::info_span!("request");
             let _guard = span.enter();
             info!("with trace");
         });
 
         let json = captured_json(&capture);
-        let trace_id = json["trace_id"].as_str().expect("trace_id must be present");
+        let trace_id = json["openTelemetry"]["traceId"]
+            .as_str()
+            .expect("traceId must be present");
         assert_eq!(trace_id.len(), 32);
         assert!(trace_id.chars().all(|c| c.is_ascii_hexdigit()));
-        assert_ne!(
-            trace_id,
-            "0".repeat(32),
-            "trace_id must be valid (non-zero)"
-        );
+        assert_ne!(trace_id, "0".repeat(32), "traceId must be valid (non-zero)");
 
-        let span_id = json["span_id"].as_str().expect("span_id must be present");
+        let span_id = json["openTelemetry"]["spanId"]
+            .as_str()
+            .expect("spanId must be present");
         assert_eq!(span_id.len(), 16);
     }
 }

--- a/server/entrypoint/src/main.rs
+++ b/server/entrypoint/src/main.rs
@@ -13,7 +13,7 @@ use axum::{
 use axum_tracing_opentelemetry::middleware::{OtelAxumLayer, OtelInResponseLayer};
 use common::config::{ENV, HTTP};
 use domain::search::models::SearchableFieldsWithOperation;
-use entrypoint::{openapi, telemetry};
+use entrypoint::{logging, openapi, telemetry};
 use futures::join;
 use hyper::header::SET_COOKIE;
 use opentelemetry::trace::TracerProvider as _;
@@ -44,17 +44,44 @@ use utoipa_swagger_ui::SwaggerUi;
 async fn main() -> anyhow::Result<()> {
     let tracer_provider = telemetry::init_tracer_provider();
 
+    // SQL 文の出力 (bind 値を含みうる) はログへ出さない
+    let stdout_log_filter = || {
+        tracing_subscriber::EnvFilter::new(
+            std::env::var("RUST_LOG").unwrap_or_else(|_| "info".into()),
+        )
+        .add_directive("sqlx::query=off".parse().expect("directive must be valid"))
+    };
+    let json_logs_enabled = logging::json_logs_enabled(
+        ENV.name.as_str(),
+        std::env::var("LOG_FORMAT").ok().as_deref(),
+    );
+    let json_log_formatter = logging::JsonWithTraceId::new();
+    let (json_log_layer, pretty_log_layer) = if json_logs_enabled {
+        (
+            Some(
+                tracing_subscriber::fmt::layer()
+                    .event_format(json_log_formatter.clone())
+                    .with_filter(stdout_log_filter()),
+            ),
+            None,
+        )
+    } else {
+        (
+            None,
+            Some(tracing_subscriber::fmt::layer().with_filter(stdout_log_filter())),
+        )
+    };
+
     tracing_subscriber::registry()
         .with(tracer_provider.as_ref().map(|provider| {
             tracing_opentelemetry::layer().with_tracer(provider.tracer("seichi-portal-backend"))
         }))
         .with(sentry::integrations::tracing::layer())
-        .with(
-            tracing_subscriber::fmt::layer().with_filter(tracing_subscriber::EnvFilter::new(
-                std::env::var("RUST_LOG").unwrap_or_else(|_| "info".into()),
-            )),
-        )
+        .with(json_log_layer)
+        .with(pretty_log_layer)
         .init();
+    // フォーマッタが trace_id を解決できるよう、init 済みの subscriber を登録する
+    json_log_formatter.connect_dispatch();
 
     let _guard = if ENV.name != "local" {
         let _guard = sentry::init((

--- a/server/entrypoint/src/main.rs
+++ b/server/entrypoint/src/main.rs
@@ -55,14 +55,9 @@ async fn main() -> anyhow::Result<()> {
         ENV.name.as_str(),
         std::env::var("LOG_FORMAT").ok().as_deref(),
     );
-    let json_log_formatter = logging::JsonWithTraceId::new();
     let (json_log_layer, pretty_log_layer) = if json_logs_enabled {
         (
-            Some(
-                tracing_subscriber::fmt::layer()
-                    .event_format(json_log_formatter.clone())
-                    .with_filter(stdout_log_filter()),
-            ),
+            Some(logging::json_log_layer().with_filter(stdout_log_filter())),
             None,
         )
     } else {
@@ -80,8 +75,6 @@ async fn main() -> anyhow::Result<()> {
         .with(json_log_layer)
         .with(pretty_log_layer)
         .init();
-    // フォーマッタが trace_id を解決できるよう、init 済みの subscriber を登録する
-    json_log_formatter.connect_dispatch();
 
     let _guard = if ENV.name != "local" {
         let _guard = sentry::init((


### PR DESCRIPTION
## 概要

Closes #1258

Tempo の tracesToLogsV2（トレース → ログのジャンプ）を機能させるため、stdout のログ行に OTel の trace ID / span ID を注入します。

issue には「既製の定番 crate は存在しない」とありましたが、調査したところ **[json-subscriber](https://crates.io/crates/json-subscriber)**（2026-07 更新・720 万 DL・`tracing-opentelemetry 0.33` 対応 feature あり）がまさにこの用途をカバーしていたため、自前フォーマッタではなくこれを採用しました。初版コミットでは自前フォーマッタを実装しましたが、2 コミット目で json-subscriber に置き換えています。

## 変更内容

### JSON ログレイヤー (`server/entrypoint/src/logging.rs`)

- `json_subscriber::layer()` + `with_opentelemetry_ids(true)` で構成
- 出力形式: `timestamp` / `level` / `target` / `message` + イベントフィールド（フラット展開）+ `openTelemetry.traceId` / `openTelemetry.spanId`
- **`openTelemetry.traceId` / `openTelemetry.spanId` は json-subscriber の固定キーで、seichi_infra 側の Grafana/Loki 設定（tracesToLogsV2, seichi_infra#5618）との契約になります**
- イベントフィールドはトップレベルにフラット展開されるため、#1260 の panic hook が出す `panic=true` は LogQL の `| json | panic="true"` でそのままパースできます
- span のフィールドはログ行に出力しません（スパン属性として Tempo 側へ送られるため二重を避ける + URL クエリ等の漏えい防止。issue の「request line に URL クエリを出さない」に対応）

### フォーマット切り替え

- `ENV_NAME=local` では従来の人間向けフォーマットを維持、それ以外は JSON（`LOG_FORMAT=json|pretty` で明示上書き可能、`.env.example` に追記済み）

### sqlx クエリログ抑制

- `EnvFilter` に `sqlx::query=off` ディレクティブを追加し、SQL 文（bind 値を含みうる）が `RUST_LOG` の設定によらずログへ出ないようにしました

## 動作確認

- `cargo build` / `cargo clippy --all -- -D warnings` / `cargo test --all-features` 通過
- ユニットテスト 3 件:
  - JSON 1 行出力・フィールドのフラット展開の検証
  - OTel span 内のイベントに 32 桁 hex の `openTelemetry.traceId` / 16 桁 hex の `spanId` が付与されること
  - OTel span がない場合に `openTelemetry` キーを出力しないこと

## 備考

- フォーマッタ実行中は tracing の再入ガードで `Span::current()` が使えないため、issue 記載の `OpenTelemetrySpanExt` 方式は成立しません（実測で確認）。json-subscriber も内部では tracing-opentelemetry 0.33 の `get_otel_context(span_id, dispatch)` を使っており、同じ結論でした
- panic hook (`panic=true` フィールド) は #1260 (Sentry 撤去) 側の作業です

🤖 Generated with [Claude Code](https://claude.com/claude-code)