### PR TITLE
fix(ci): リリースイメージにCosign署名を追加する

### DIFF
--- a/.github/workflows/image-release.yaml
+++ b/.github/workflows/image-release.yaml
@@ -116,6 +116,10 @@ jobs:
     needs: [prepare, build]
     if: needs.prepare.outputs.publish == 'true' && needs.build.result == 'success'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+      id-token: write
     steps:
       - parallel:
           - name: Checkout
@@ -147,6 +151,7 @@ jobs:
         run: echo "name=ghcr.io/${OWNER,,}/seichi-portal-backend" >> "$GITHUB_OUTPUT"
       - name: Build and push
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        id: build-and-push
         with:
           context: docker
           platforms: linux/amd64,linux/arm64/v8
@@ -154,6 +159,20 @@ jobs:
           tags: |
             ${{ steps.image.outputs.name }}:${{ needs.prepare.outputs.version }}
             ${{ steps.image.outputs.name }}:${{ github.sha }}
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v4.1.0
+        with:
+          cosign-release: v3.0.6
+      - name: Sign image
+        env:
+          IMAGE: ${{ steps.image.outputs.name }}
+          DIGEST: ${{ steps.build-and-push.outputs.digest }}
+        run: |
+          cosign sign \
+            --yes \
+            --new-bundle-format=false \
+            --use-signing-config=false \
+            "${IMAGE}@${DIGEST}"
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## 概要

- GitHub Actions の OIDC を使い、リリースする multi-platform Docker イメージを Cosign keyless 署名します。
- Buildx が出力する manifest digest を署名対象にします。
- 署名に必要な `id-token: write` 権限を `release-all` job に追加します。

## 確認事項

- `git diff --check` を実行し、成功しました。
- pre-commit フックの Rust チェックおよび OpenAPI 差分チェックが完了しました。
- `actionlint` は既存の独自 `parallel:` step を構文エラーとして扱い、変更前から同じエラーになることを確認しました。

## 補足

- 既存の GitHub Release 作成に必要な `contents: write` と、コンテナ公開に必要な `packages: write` は維持しています。

🤖 Generated with Codex