### PR TITLE
feat: reqwest を共有 Client に集約し outbound へ traceparent を注入する

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1219,6 +1219,7 @@ dependencies = [
  "meilisearch-sdk",
  "redis",
  "reqwest 0.13.4",
+ "reqwest-middleware",
  "serde_json",
  "serenity",
  "sqlx",
@@ -3454,6 +3455,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest-middleware"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bc3f1384cffa4f274dad2d4ddd73aed32fed8f786d96c6be8aa4e5fd3c3b58"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http",
+ "reqwest 0.13.4",
+ "serde",
+ "thiserror 2.0.19",
+ "tower-service",
+]
+
+[[package]]
+name = "reqwest-tracing"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e5af0cd6fc3d3c8f703d597af70b6e4e62432c63157b49419fa1ffaf481702"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "getrandom 0.2.17",
+ "http",
+ "matchit",
+ "opentelemetry",
+ "reqwest 0.13.4",
+ "reqwest-middleware",
+ "tracing",
+ "tracing-opentelemetry",
+]
+
+[[package]]
 name = "resolv-conf"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3479,6 +3513,8 @@ dependencies = [
  "redis",
  "regex",
  "reqwest 0.13.4",
+ "reqwest-middleware",
+ "reqwest-tracing",
  "serde",
  "serde_json",
  "serenity",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,9 @@ futures = "0.3.33"
 uuid = { version = "1.24.0", features = ["v4", "v7"] }
 deriving_via = "2.2.0"
 reqwest = { version = "0.13.4", default-features = false, features = ["rustls", "json"] }
+reqwest-middleware = { version = "0.5.2", features = ["json"] }
+# opentelemetry_0_32 feature は opentelemetry 0.32 + tracing-opentelemetry 0.33 の組 (entrypoint と揃える)
+reqwest-tracing = { version = "0.7.1", features = ["opentelemetry_0_32"] }
 regex = "1.13.1"
 redis = { version = "1.5.0", features = ["tokio-comp"] }
 meilisearch-sdk = "0.33.0"

--- a/server/errors/Cargo.toml
+++ b/server/errors/Cargo.toml
@@ -12,6 +12,7 @@ thiserror = "2.0.19"
 uuid = { workspace = true }
 redis = { workspace = true }
 reqwest = { workspace = true }
+reqwest-middleware = { workspace = true }
 meilisearch-sdk = { workspace = true }
 serde_json = { workspace = true }
 serenity = { workspace = true }

--- a/server/errors/src/infra.rs
+++ b/server/errors/src/infra.rs
@@ -142,3 +142,14 @@ impl From<reqwest::Error> for InfraError {
         }
     }
 }
+
+impl From<reqwest_middleware::Error> for InfraError {
+    fn from(value: reqwest_middleware::Error) -> Self {
+        match value {
+            reqwest_middleware::Error::Reqwest(error) => error.into(),
+            error @ reqwest_middleware::Error::Middleware(_) => InfraError::Reqwest {
+                cause: error.to_string(),
+            },
+        }
+    }
+}

--- a/server/infra/resource/Cargo.toml
+++ b/server/infra/resource/Cargo.toml
@@ -24,6 +24,8 @@ redis = { workspace = true }
 sha256 = "1.6.0"
 common = { path = "../../common" }
 reqwest = { workspace = true }
+reqwest-middleware = { workspace = true }
+reqwest-tracing = { workspace = true }
 serde_json = { workspace = true }
 meilisearch-sdk = { workspace = true }
 serenity = { workspace = true }

--- a/server/infra/resource/src/database/search.rs
+++ b/server/infra/resource/src/database/search.rs
@@ -4,6 +4,7 @@ use crate::database::{
     components::{FormAnswerDatabase, SearchDatabase},
     connection::ConnectionPool,
 };
+use crate::outgoing::http::HTTP_CLIENT;
 use crate::records::FormAnswerRecord;
 use async_trait::async_trait;
 use domain::{
@@ -422,11 +423,9 @@ impl SearchDatabase for ConnectionPool {
 
     #[tracing::instrument(skip_all)]
     async fn search_engine_stats(&self) -> Result<NumberOfRecordsPerAggregate, InfraError> {
-        let client = reqwest::Client::new();
-
         let MeiliSearch { host, api_key } = &*MEILISEARCH;
 
-        let mut request = client.get(format!("{}/stats", host));
+        let mut request = HTTP_CLIENT.get(format!("{}/stats", host));
 
         if let Some(api_key) = api_key {
             request = request.header("X-Meili-API-Key", api_key);

--- a/server/infra/resource/src/external/discord_api_impl.rs
+++ b/server/infra/resource/src/external/discord_api_impl.rs
@@ -4,13 +4,13 @@ use errors::infra::InfraError;
 use crate::{
     database::connection::ConnectionPool,
     external::{discord_api::DiscordAPI, discord_api_schema::DiscordUserSchema},
+    outgoing::http::HTTP_CLIENT,
 };
 
 #[async_trait]
 impl DiscordAPI for ConnectionPool {
     async fn fetch_user(&self, token: String) -> Result<DiscordUserSchema, InfraError> {
-        let client = reqwest::Client::new();
-        let response = client
+        let response = HTTP_CLIENT
             .get("https://discord.com/api/users/@me")
             .header("Authorization", format!("Bearer {}", token))
             .send()

--- a/server/infra/resource/src/outgoing.rs
+++ b/server/infra/resource/src/outgoing.rs
@@ -2,3 +2,4 @@ mod config;
 pub mod connection;
 pub mod discord_sender_impl;
 pub mod discord_webhook_sender;
+pub mod http;

--- a/server/infra/resource/src/outgoing/discord_webhook_sender.rs
+++ b/server/infra/resource/src/outgoing/discord_webhook_sender.rs
@@ -5,6 +5,8 @@ use errors::infra::InfraError;
 use reqwest::StatusCode;
 use serde::Serialize;
 
+use crate::outgoing::http::HTTP_CLIENT;
+
 const DISCORD_EMBED_COLOR_LIME: i32 = 65_280;
 const DISCORD_MAX_EMBED_FIELDS: usize = 25;
 const DISCORD_MAX_EMBEDS: usize = 10;
@@ -39,15 +41,11 @@ pub struct DiscordWebhookMessage {
 }
 
 #[derive(Clone)]
-pub struct DiscordWebhookSender {
-    client: reqwest::Client,
-}
+pub struct DiscordWebhookSender;
 
 impl DiscordWebhookSender {
     pub fn new() -> Self {
-        Self {
-            client: reqwest::Client::new(),
-        }
+        Self
     }
 
     pub fn retry_policy() -> RetryPolicy {
@@ -71,8 +69,7 @@ impl DiscordWebhookSender {
     async fn send(&self, message: DiscordWebhookMessage) -> Result<(), DiscordWebhookSendError> {
         let discord_webhook_url = message.discord_webhook_url.clone();
         let request = DiscordWebhookRequest::from(message);
-        let response = self
-            .client
+        let response = HTTP_CLIENT
             .post(discord_webhook_url)
             .json(&request)
             .send()

--- a/server/infra/resource/src/outgoing/http.rs
+++ b/server/infra/resource/src/outgoing/http.rs
@@ -1,0 +1,19 @@
+use std::sync::LazyLock;
+
+use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
+use reqwest_tracing::TracingMiddleware;
+
+/// アプリ全体で共有する HTTP クライアント。
+///
+/// reqwest の `Client` は内部にコネクションプールを持つため、
+/// コールサイトごとに生成せずこれを使い回す。
+///
+/// [`TracingMiddleware`] がリクエストごとにクライアントスパン
+/// (OTel semantic conventions 準拠の HTTP 属性付き) を作り、
+/// 現在のスパンの trace context (W3C `traceparent`) を outbound リクエストへ注入する。
+/// OTel が初期化されていない場合は global propagator が no-op のため何も注入されない。
+pub static HTTP_CLIENT: LazyLock<ClientWithMiddleware> = LazyLock::new(|| {
+    ClientBuilder::new(reqwest::Client::new())
+        .with(TracingMiddleware::default())
+        .build()
+});

--- a/server/infra/resource/src/repository/user_repository_impl.rs
+++ b/server/infra/resource/src/repository/user_repository_impl.rs
@@ -16,6 +16,7 @@ use uuid::Uuid;
 use crate::{
     database::components::{DatabaseComponents, UserDatabase},
     external::discord_api::DiscordAPI,
+    outgoing::http::HTTP_CLIENT,
     repository::Repository,
 };
 
@@ -147,9 +148,7 @@ impl<Client: DatabaseComponents + 'static> UserRepository for Repository<Client>
     }
 
     async fn fetch_user_by_xbox_token(&self, token: String) -> Result<Option<AccountUser>, Error> {
-        let client = reqwest::Client::new();
-
-        let response = client
+        let response = HTTP_CLIENT
             .get("https://api.minecraftservices.com/minecraft/profile")
             .bearer_auth(token.to_owned())
             .header(CONTENT_TYPE, HeaderValue::from_static("application/json"))


### PR DESCRIPTION
## 概要

Refs #1261（作業項目 1/4: reqwest の共有 Client 化 + traceparent 注入）

コールサイトごとに `reqwest::Client::new()` されていた 4 箇所を共有クライアントに集約し、outbound リクエストへ trace context を伝播するようにしました。

## ライブラリ選定

自前実装ではなく **[reqwest-middleware](https://crates.io/crates/reqwest-middleware)** (0.5.2) + **[reqwest-tracing](https://crates.io/crates/reqwest-tracing)** (0.7.1, TrueLayer 製・2760 万 DL) を採用しました。

- `reqwest-tracing` の `opentelemetry_0_32` feature は **opentelemetry 0.32 + tracing-opentelemetry 0.33 の組**で、既存の OTel スタック (#1256) とバージョンが完全に一致します
- `TracingMiddleware` がリクエストごとに OTel semantic conventions 準拠のクライアントスパン（method / URL / status 属性、`otel.kind=client`）を生成し、W3C `traceparent` を自動注入します。これによりクライアントスパンの自作も trace 注入ヘルパーの自作も不要になりました
- OTel 未初期化（ローカル開発）時は global propagator が no-op のため挙動は変わりません

## 変更内容

- `resource::outgoing::http::HTTP_CLIENT`（`LazyLock<ClientWithMiddleware>`）を新設
- 以下 4 箇所を共有クライアントへ移行:
  - `database/search.rs` — Meilisearch `/stats`
  - `repository/user_repository_impl.rs` — Minecraft Services API
  - `external/discord_api_impl.rs` — Discord API
  - `outgoing/discord_webhook_sender.rs` — Discord webhook（保持していた専用 Client フィールドを削除）
- `errors`: `From<reqwest_middleware::Error> for InfraError` を追加（既存の `Reqwest` variant へ変換）

## 動作確認

- `cargo build` / `cargo clippy --all -- -D warnings` / `cargo test --all-features` 通過

## 残作業（別 PR 予定）

- RabbitMQ consumer の delivery ごとのルートスパン + ワーカーのスパン化
- DB スパンへの db.system / operation / table 属性付与

🤖 Generated with [Claude Code](https://claude.com/claude-code)