### PR TITLE
feat: RabbitMQ consumer とバックグラウンドワーカーをスパン化する

### DIFF
--- a/server/infra/resource/src/messaging/connection.rs
+++ b/server/infra/resource/src/messaging/connection.rs
@@ -9,6 +9,7 @@ use lapin::{
     types::FieldTable,
 };
 use tokio::sync::{Notify, mpsc};
+use tracing::Instrument;
 
 use crate::messaging::{
     config::{RABBITMQ, RabbitMQ},
@@ -88,28 +89,43 @@ impl MessagingConnectionPool {
                         },
                         _ = async {
                             if let Some(Ok(delivery)) = consumer.next().await {
-                                let data = String::from_utf8_lossy(&delivery.data);
-                                let payload = serde_json::from_str::<RabbitMQSchema>(&data)?.payload;
+                                // Debezium CDC 由来のメッセージには trace context がないため、
+                                // delivery ごとに新しいルートスパンを作る
+                                let span = tracing::info_span!(
+                                    parent: None,
+                                    "cdc.process",
+                                    otel.kind = "consumer",
+                                    messaging.system = "rabbitmq",
+                                    messaging.operation.type = "process",
+                                    messaging.destination.name = %RABBITMQ.routing_key,
+                                );
+                                async {
+                                    let data = String::from_utf8_lossy(&delivery.data);
+                                    let payload = serde_json::from_str::<RabbitMQSchema>(&data)?.payload;
 
-                                let operation = match payload.op.to_owned() {
-                                    Operation::Create => domain::search::models::Operation::Create,
-                                    Operation::Update => domain::search::models::Operation::Update,
-                                    Operation::Delete => domain::search::models::Operation::Delete,
-                                };
-                                let data_fields = match operation {
-                                    domain::search::models::Operation::Create | domain::search::models::Operation::Update => {
-                                        payload.try_into_after()?
-                                    }
-                                    domain::search::models::Operation::Delete => {
-                                        payload.try_into_before()?
-                                    }
-                                };
+                                    let operation = match payload.op.to_owned() {
+                                        Operation::Create => domain::search::models::Operation::Create,
+                                        Operation::Update => domain::search::models::Operation::Update,
+                                        Operation::Delete => domain::search::models::Operation::Delete,
+                                    };
+                                    let data_fields = match operation {
+                                        domain::search::models::Operation::Create | domain::search::models::Operation::Update => {
+                                            payload.try_into_after()?
+                                        }
+                                        domain::search::models::Operation::Delete => {
+                                            payload.try_into_before()?
+                                        }
+                                    };
 
-                                if let Some(data_fields) = data_fields {
-                                    sender.send((SearchableFields::try_from(data_fields)?, operation)).await?;
+                                    if let Some(data_fields) = data_fields {
+                                        sender.send((SearchableFields::try_from(data_fields)?, operation)).await?;
+                                    }
+
+                                    delivery.ack(BasicAckOptions::default()).await?;
+                                    Ok::<_, InfraError>(())
                                 }
-
-                                delivery.ack(BasicAckOptions::default()).await?;
+                                .instrument(span)
+                                .await?;
                             }
                             Ok::<_, InfraError>(())
                         } => {}

--- a/server/presentation/src/api/global_discord_webhook.rs
+++ b/server/presentation/src/api/global_discord_webhook.rs
@@ -66,30 +66,42 @@ pub fn start_global_discord_webhook_worker(
                 Err(RecvError::Closed) => break,
             };
 
-            let setting = match repository.global_discord_webhook_repository().get().await {
-                Ok(setting) => match setting.try_read(Actor::System) {
-                    Ok(setting) => setting.into_inner(),
-                    Err(error) => {
-                        warn!(%error, "failed to authorize global Discord webhook setting read");
-                        continue;
-                    }
-                },
-                Err(error) => {
-                    warn!(%error, "failed to load global Discord webhook setting");
-                    continue;
-                }
-            };
-            let Some(url) = setting.url() else {
-                continue;
-            };
-
-            let operation = operation_name(&event);
-            let message = message_from_event(event, url.as_str().to_owned(), &frontend_url);
-            if let Err(error) = sender.send_with_retry(message).await {
-                warn!(%error, operation, "failed to send global Discord webhook after retries");
-            }
+            handle_event(&repository, &sender, &frontend_url, event).await;
         }
     })
+}
+
+/// イベント発生元とはチャンネル越しに分離されているため、通知 1 件ごとに
+/// 新しいルートスパンを作る。
+#[tracing::instrument(name = "discord_webhook.notify", parent = None, skip_all)]
+async fn handle_event(
+    repository: &RealInfrastructureRepository,
+    sender: &DiscordWebhookSender,
+    frontend_url: &str,
+    event: ApplicationEvent,
+) {
+    let setting = match repository.global_discord_webhook_repository().get().await {
+        Ok(setting) => match setting.try_read(Actor::System) {
+            Ok(setting) => setting.into_inner(),
+            Err(error) => {
+                warn!(%error, "failed to authorize global Discord webhook setting read");
+                return;
+            }
+        },
+        Err(error) => {
+            warn!(%error, "failed to load global Discord webhook setting");
+            return;
+        }
+    };
+    let Some(url) = setting.url() else {
+        return;
+    };
+
+    let operation = operation_name(&event);
+    let message = message_from_event(event, url.as_str().to_owned(), frontend_url);
+    if let Err(error) = sender.send_with_retry(message).await {
+        warn!(%error, operation, "failed to send global Discord webhook after retries");
+    }
 }
 
 fn actor_fields(actor: ApplicationActor) -> Vec<DiscordWebhookField> {

--- a/server/usecase/src/search.rs
+++ b/server/usecase/src/search.rs
@@ -42,6 +42,7 @@ use std::{
 };
 use tokio::sync::{Notify, mpsc::Receiver};
 use tokio::time;
+use tracing::Instrument;
 
 const SEARCH_DETAIL_FETCH_CONCURRENCY: usize = 10;
 
@@ -546,7 +547,12 @@ impl<
                 },
                 _ = async {
                     if let Some(data) = receiver.recv().await {
-                        self.search_repository.sync_search_engine(&[data]).await?
+                        // CDC consumer からチャンネル越しに受け取るため trace context はなく、
+                        // 同期 1 件ごとに新しいルートスパンを作る
+                        self.search_repository
+                            .sync_search_engine(&[data])
+                            .instrument(tracing::info_span!(parent: None, "search_engine.sync"))
+                            .await?
                     }
 
                     Ok::<_, Error>(())
@@ -569,137 +575,134 @@ impl<
                     break
                 },
                 _ = interval.tick() => {
-                    let search_engine_records = self.search_repository.fetch_search_engine_stats().await?;
-
-                    let repository_records = NumberOfRecordsPerAggregate {
-                        form_meta_data: NumberOfRecords(self.active_form_repository.size().await?),
-                        answers: NumberOfRecords(self.answer_entry_repository.size().await?),
-                        real_answers: NumberOfRecords(
-                            self.answer_entry_repository.content_size().await?,
-                        ),
-                        form_answer_comments: NumberOfRecords(
-                            self.comment_thread_repository.size().await?,
-                        ),
-                        label_for_form_answers: NumberOfRecords(
-                            self.form_answer_label_repository.size().await?,
-                        ),
-                        label_for_forms: NumberOfRecords(self.form_label_repository.size().await?),
-                        users: NumberOfRecords(self.user_repository.size().await?),
-                    };
-
-                    let sync_rate = search_engine_records.try_into_sync_rate(&repository_records)?;
-
-                    if sync_rate.is_out_of_sync() {
-                        let system = Actor::System;
-
-                        let form_guards = self
-                            .list_all_form_guards()
-                            .await?
-                            .into_iter()
-                            .map(|guard| guard.try_read(system.clone()).map_err(Into::into))
-                            .collect::<Result<Vec<_>, Error>>()?;
-
-                        let forms = form_guards
-                            .iter()
-                            .map(|form| {
-                                Ok((
-                                    SearchableFields::FormMetaData(
-                                        FormMetaData {
-                                            id: form.value().id().to_owned(),
-                                            title: form.value().title().to_owned(),
-                                            description: form.value().description().to_owned(),
-                                        },
-                                    ),
-                                    Operation::Update,
-                                ))
-                            })
-                            .collect::<Result<Vec<_>, Error>>()?;
-
-                        let answer_entries = self.list_all_answer_entries(&form_guards).await?;
-
-                        let answer_documents = answer_search_documents(&answer_entries);
-
-                        let comments = self
-                            .comment_search_documents(&form_guards, &answer_entries)
-                            .await?;
-
-                        let labels_for_forms = self
-                            .form_label_repository
-                            .fetch_labels()
-                            .await?
-                            .into_iter()
-                            .map(|guard| {
-                                let label = guard.try_read(system.clone())?.into_inner();
-
-                                Ok((
-                                    SearchableFields::LabelForForms(
-                                        LabelForForms {
-                                            id: label.id().to_owned(),
-                                            name: label.name().to_owned().into_inner().into_inner(),
-                                        },
-                                    ),
-                                    Operation::Update,
-                                ))
-                            })
-                            .collect::<Result<Vec<_>, Error>>()?;
-
-                        let labels_for_answers = self
-                            .form_answer_label_repository
-                            .get_labels_for_answers()
-                            .await?
-                            .into_iter()
-                            .map(|guard| {
-                                let label = guard.try_read(system.clone())?.into_inner();
-
-                                Ok((
-                                    SearchableFields::LabelForFormAnswers(
-                                        LabelForFormAnswers {
-                                            id: label.id().to_owned(),
-                                            name: label.name().to_owned().into_inner(),
-                                        },
-                                    ),
-                                    Operation::Update,
-                                ))
-                            })
-                            .collect::<Result<Vec<_>, Error>>()?;
-
-                        let users = self
-                            .user_repository
-                            .fetch_all_users()
-                            .await?
-                            .into_iter()
-                            .map(|guard| {
-                                let user = guard.try_read(system.clone())?.into_inner();
-
-                                Ok((
-                                    SearchableFields::Users(
-                                        Users {
-                                            id: user.id().into_inner(),
-                                            name: user.name().to_owned(),
-                                        },
-                                    ),
-                                    Operation::Update,
-                                ))
-                            })
-                            .collect::<Result<Vec<_>, Error>>()?;
-
-                        let data = forms
-                            .into_iter()
-                            .chain(answer_documents)
-                            .chain(comments)
-                            .chain(labels_for_forms)
-                            .chain(labels_for_answers)
-                            .chain(users)
-                            .collect::<Vec<_>>();
-
-                        self.search_repository
-                            .sync_search_engine(data.as_slice())
-                            .await?;
-                    }
+                    self.check_and_resync_search_engine().await?;
                 }
             }
         }
 
+        Ok(())
+    }
+
+    /// 検索エンジンとリポジトリのレコード数を比較し、乖離があれば全件再同期する。
+    ///
+    /// 定期実行タスクのため、実行ごとに新しいルートスパンを作る。
+    #[tracing::instrument(name = "search_engine.watch_out_of_sync", parent = None, skip_all)]
+    async fn check_and_resync_search_engine(&self) -> Result<(), Error> {
+        let search_engine_records = self.search_repository.fetch_search_engine_stats().await?;
+
+        let repository_records = NumberOfRecordsPerAggregate {
+            form_meta_data: NumberOfRecords(self.active_form_repository.size().await?),
+            answers: NumberOfRecords(self.answer_entry_repository.size().await?),
+            real_answers: NumberOfRecords(self.answer_entry_repository.content_size().await?),
+            form_answer_comments: NumberOfRecords(self.comment_thread_repository.size().await?),
+            label_for_form_answers: NumberOfRecords(
+                self.form_answer_label_repository.size().await?,
+            ),
+            label_for_forms: NumberOfRecords(self.form_label_repository.size().await?),
+            users: NumberOfRecords(self.user_repository.size().await?),
+        };
+
+        let sync_rate = search_engine_records.try_into_sync_rate(&repository_records)?;
+
+        if sync_rate.is_out_of_sync() {
+            let system = Actor::System;
+
+            let form_guards = self
+                .list_all_form_guards()
+                .await?
+                .into_iter()
+                .map(|guard| guard.try_read(system.clone()).map_err(Into::into))
+                .collect::<Result<Vec<_>, Error>>()?;
+
+            let forms = form_guards
+                .iter()
+                .map(|form| {
+                    Ok((
+                        SearchableFields::FormMetaData(FormMetaData {
+                            id: form.value().id().to_owned(),
+                            title: form.value().title().to_owned(),
+                            description: form.value().description().to_owned(),
+                        }),
+                        Operation::Update,
+                    ))
+                })
+                .collect::<Result<Vec<_>, Error>>()?;
+
+            let answer_entries = self.list_all_answer_entries(&form_guards).await?;
+
+            let answer_documents = answer_search_documents(&answer_entries);
+
+            let comments = self
+                .comment_search_documents(&form_guards, &answer_entries)
+                .await?;
+
+            let labels_for_forms = self
+                .form_label_repository
+                .fetch_labels()
+                .await?
+                .into_iter()
+                .map(|guard| {
+                    let label = guard.try_read(system.clone())?.into_inner();
+
+                    Ok((
+                        SearchableFields::LabelForForms(LabelForForms {
+                            id: label.id().to_owned(),
+                            name: label.name().to_owned().into_inner().into_inner(),
+                        }),
+                        Operation::Update,
+                    ))
+                })
+                .collect::<Result<Vec<_>, Error>>()?;
+
+            let labels_for_answers = self
+                .form_answer_label_repository
+                .get_labels_for_answers()
+                .await?
+                .into_iter()
+                .map(|guard| {
+                    let label = guard.try_read(system.clone())?.into_inner();
+
+                    Ok((
+                        SearchableFields::LabelForFormAnswers(LabelForFormAnswers {
+                            id: label.id().to_owned(),
+                            name: label.name().to_owned().into_inner(),
+                        }),
+                        Operation::Update,
+                    ))
+                })
+                .collect::<Result<Vec<_>, Error>>()?;
+
+            let users = self
+                .user_repository
+                .fetch_all_users()
+                .await?
+                .into_iter()
+                .map(|guard| {
+                    let user = guard.try_read(system.clone())?.into_inner();
+
+                    Ok((
+                        SearchableFields::Users(Users {
+                            id: user.id().into_inner(),
+                            name: user.name().to_owned(),
+                        }),
+                        Operation::Update,
+                    ))
+                })
+                .collect::<Result<Vec<_>, Error>>()?;
+
+            let data = forms
+                .into_iter()
+                .chain(answer_documents)
+                .chain(comments)
+                .chain(labels_for_forms)
+                .chain(labels_for_answers)
+                .chain(users)
+                .collect::<Vec<_>>();
+
+            self.search_repository
+                .sync_search_engine(data.as_slice())
+                .await?;
+        }
         Ok(())
     }
 


### PR DESCRIPTION
## 概要

Refs #1261（作業項目 2/4 + 4/4: RabbitMQ consumer のルートスパン + ワーカーのスパン化）

trace context を持たない境界ごとに新しいルートスパンを作り、バックグラウンド処理をトレースで追えるようにしました。

## ライブラリ調査

lapin 向けの確立された tracing/OTel 統合 crate は現状存在しません（最有力の lapin-tower-worker も約 4,000 DL・2024 年から更新停止で、consumer を tower ベースに作り直す必要がある）。delivery ごとのスパン生成は tracing の通常の利用範囲のため、アプリコードで実装しています。

## 変更内容

- **RabbitMQ consumer** (`resource/src/messaging/connection.rs`): Debezium CDC 由来のメッセージには trace context がないため、delivery ごとに `parent: None` のルートスパン `cdc.process` を作成（`otel.kind=consumer`、`messaging.system=rabbitmq` 等の semconv 属性付き）。consumer の待ち時間はスパンに含めず、受信後の処理のみを覆います
- **検索エンジン同期** (`usecase/src/search.rs` `start_sync`): consumer からチャンネル越しに受け取るため、同期 1 件ごとにルートスパン `search_engine.sync` を作成
- **検索エンジン乖離チェック** (`start_watch_out_of_sync`): 60 秒 tick ごとの処理を `check_and_resync_search_engine()` メソッドへ抽出し、`#[tracing::instrument(parent = None, skip_all)]` でスパン化（select! アーム内の巨大なインライン処理の切り出しなので、ロジック自体は無変更）
- **Discord webhook worker** (`presentation/src/api/global_discord_webhook.rs`): 通知 1 件ごとの処理を `handle_event()` 関数へ抽出しスパン化（`continue` を `return` に置き換えた以外ロジック無変更）

各スパンの配下では、既存の `#[tracing::instrument]` 付き repository / database メソッドが子スパンとしてぶら下がります。

## 動作確認

- `cargo build` / `cargo clippy --all -- -D warnings` / `cargo test --all-features` 通過

## 備考

- consumer → 同期タスクはチャンネルで分離されているため、現状 CDC 1 件につき「受信処理」と「同期処理」の 2 トレースになります。1 トレースに繋ぐにはチャンネルのペイロードに trace context を載せる必要があり、必要になったら別途検討します

🤖 Generated with [Claude Code](https://claude.com/claude-code)