### PR TITLE
feat: DB アクセスのスパンへ db.system 等の属性を付与する

### DIFF
--- a/server/infra/resource/src/database/connection.rs
+++ b/server/infra/resource/src/database/connection.rs
@@ -75,6 +75,7 @@ impl ConnectionPool {
         Ok(())
     }
 
+    #[tracing::instrument(skip_all, fields(otel.kind = "client", db.system = "mariadb"))]
     pub async fn read_only_transaction<F, T, E>(&self, callback: F) -> Result<T, InfraError>
     where
         F: for<'c> FnOnce(
@@ -106,6 +107,7 @@ impl ConnectionPool {
         }
     }
 
+    #[tracing::instrument(skip_all, fields(otel.kind = "client", db.system = "mariadb"))]
     pub async fn read_write_transaction<F, T, E>(&self, callback: F) -> Result<T, E>
     where
         F: for<'c> FnOnce(

--- a/server/infra/resource/src/database/minecraft_ban.rs
+++ b/server/infra/resource/src/database/minecraft_ban.rs
@@ -15,6 +15,11 @@ struct MinecraftBanRow {
 
 #[async_trait]
 impl MinecraftBanDatabase for ConnectionPool {
+    #[tracing::instrument(skip_all, fields(
+        otel.kind = "client",
+        db.system = "mariadb",
+        db.collection.name = "litebans_bans"
+    ))]
     async fn list_by_user_id(&self, user_id: UserId) -> Result<Vec<MinecraftBan>, InfraError> {
         let rows = sqlx::query_as!(
             MinecraftBanRow,

--- a/server/infra/resource/src/database/search.rs
+++ b/server/infra/resource/src/database/search.rs
@@ -163,7 +163,7 @@ fn merge_answer_hits(
 
 #[async_trait]
 impl SearchDatabase for ConnectionPool {
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(skip_all, fields(otel.kind = "client", db.system = "meilisearch", db.collection.name = "users"))]
     async fn search_users(&self, query: &str) -> Result<Vec<UserSearchHit>, InfraError> {
         Ok(self
             .meilisearch_client
@@ -181,7 +181,7 @@ impl SearchDatabase for ConnectionPool {
             .collect_vec())
     }
 
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(skip_all, fields(otel.kind = "client", db.system = "meilisearch", db.collection.name = "form_meta_data"))]
     async fn search_forms(&self, query: &str) -> Result<Vec<FormSearchHit>, InfraError> {
         Ok(self
             .meilisearch_client
@@ -199,7 +199,7 @@ impl SearchDatabase for ConnectionPool {
             .collect_vec())
     }
 
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(skip_all, fields(otel.kind = "client", db.system = "meilisearch", db.collection.name = "label_for_forms"))]
     async fn search_labels_for_forms(
         &self,
         query: &str,
@@ -220,7 +220,7 @@ impl SearchDatabase for ConnectionPool {
             .collect_vec())
     }
 
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(skip_all, fields(otel.kind = "client", db.system = "meilisearch", db.collection.name = "label_for_form_answers"))]
     async fn search_labels_for_answers(
         &self,
         query: &str,
@@ -241,7 +241,7 @@ impl SearchDatabase for ConnectionPool {
             .collect_vec())
     }
 
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(skip_all, fields(otel.kind = "client", db.system = "meilisearch"))]
     async fn search_answers(
         &self,
         query: &str,
@@ -281,7 +281,7 @@ impl SearchDatabase for ConnectionPool {
         ))
     }
 
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(skip_all, fields(otel.kind = "client", db.system = "meilisearch", db.collection.name = "form_answer_comments"))]
     async fn search_comments(&self, query: &str) -> Result<Vec<CommentSearchHit>, InfraError> {
         Ok(self
             .meilisearch_client
@@ -300,7 +300,7 @@ impl SearchDatabase for ConnectionPool {
             .collect_vec())
     }
 
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(skip_all, fields(otel.kind = "client", db.system = "meilisearch"))]
     async fn sync_search_engine(
         &self,
         data: &[SearchableFieldsWithOperation],
@@ -420,7 +420,7 @@ impl SearchDatabase for ConnectionPool {
         Ok(())
     }
 
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(skip_all, fields(otel.kind = "client", db.system = "meilisearch"))]
     async fn search_engine_stats(&self) -> Result<NumberOfRecordsPerAggregate, InfraError> {
         let client = reqwest::Client::new();
 
@@ -441,7 +441,7 @@ impl SearchDatabase for ConnectionPool {
         )
     }
 
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(skip_all, fields(otel.kind = "client", db.system = "meilisearch"))]
     async fn initialize_search_engine(&self) -> Result<bool, InfraError> {
         let index_with_uid = vec![
             ("form_meta_data", "id"),

--- a/server/infra/resource/src/database/user.rs
+++ b/server/infra/resource/src/database/user.rs
@@ -480,6 +480,7 @@ impl UserDatabase for ConnectionPool {
         .await
     }
 
+    #[tracing::instrument(skip_all, fields(otel.kind = "client", db.system = "redis"))]
     async fn start_user_session(
         &self,
         xbox_token: String,
@@ -497,6 +498,7 @@ impl UserDatabase for ConnectionPool {
         Ok(session_id)
     }
 
+    #[tracing::instrument(skip_all, fields(otel.kind = "client", db.system = "redis"))]
     async fn fetch_user_by_session_id(
         &self,
         session_id: String,
@@ -512,6 +514,7 @@ impl UserDatabase for ConnectionPool {
         self.find_by(cached_user.id().into_inner()).await
     }
 
+    #[tracing::instrument(skip_all, fields(otel.kind = "client", db.system = "redis"))]
     async fn end_user_session(&self, session_id: String) -> Result<(), InfraError> {
         let mut redis_connection = redis_connection().await;
 


### PR DESCRIPTION
## 概要

Refs #1261（作業項目 3/4: DB スパンへの属性付与）

Tempo の service graph でデータベース依存（virtual node）が可視化されるよう、DB アクセスのスパンへ `otel.kind=client` と `db.system` を付与しました。issue の方針どおり **SQL 全文・bind 値はスパンに付けません**（すべて `skip_all` 維持）。

## ライブラリ調査

sqlx の自動計装 crate として [sqlx-tracing](https://crates.io/crates/sqlx-tracing) (46k DL) と [sqlx-otel](https://crates.io/crates/sqlx-otel) (11k DL) を検討しましたが、いずれも pool/executor をラッパー型に差し替える方式で、typed query マクロ + `begin_with("START TRANSACTION READ ONLY")` を使う本リポジトリでは 100 箇所超のコールサイトに型変更が波及します。issue の要求は「transaction ヘルパーや repository スパンへの属性付与程度」なので、既存スパンへの属性付与で実装しました（クエリ単位の自動計装が必要になったら改めて検討）。

## 変更内容

- **MariaDB**: `read_only_transaction` / `read_write_transaction` ヘルパーに instrument を追加（`db.system=mariadb`）。トランザクション単位のスパンができ、既存の repository / database メソッドスパンの子として並びます
- **minecraft_bans**: `list_by_user_id` に instrument を追加（`db.system=mariadb`, `db.collection.name=litebans_bans`）
- **セッションストア (Valkey)**: `start_user_session` / `fetch_user_by_session_id` / `end_user_session` に instrument を追加（`db.system=redis`。プロトコル互換のため semconv の well-known 値 `redis` を採用）
- **Meilisearch**: `database/search.rs` の既存 instrument 9 箇所へ `db.system=meilisearch` を付与。単一 index を対象とする検索メソッドには `db.collection.name`（index 名）も付与

## 動作確認

- `cargo build` / `cargo clippy --all -- -D warnings` / `cargo test --all-features` 通過（instrument の skip_all ガードテスト含む）

## 備考

- #1274 も `database/search.rs` に触れているため、どちらかのマージ後にもう一方で小さいコンフリクトが出る可能性があります（出たらこちらで解消します）
- これで #1261 の作業項目 4 つすべてに対応する PR が揃いました（#1274: reqwest 共有化 + traceparent、#1275: consumer / ワーカーのスパン化、本 PR: DB 属性）

🤖 Generated with [Claude Code](https://claude.com/claude-code)