### PR TITLE
fix: runtime イメージに ca-certificates を追加する

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,6 +16,8 @@ RUN chmod +x /seichi-portal-backend
 FROM ubuntu:26.04
 LABEL org.opencontainers.image.source=https://github.com/GiganticMinecraft/seichi-portal-backend
 
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
+
 COPY --from=init /seichi-portal-backend /seichi-portal-backend
 
 USER ubuntu


### PR DESCRIPTION
## 概要

v0.2.0 のデプロイで backend が起動時に panic し CrashLoopBackOff になる問題の修正です。

```
thread 'main' panicked at sentry-0.48.5/src/transports/reqwest.rs:119:
Failed to build `reqwest` client as a TLS backend is not available.
→ General("No CA certificates were loaded from the system")
```

## 原因

- runtime イメージが素の `ubuntu:26.04` で `ca-certificates` が入っておらず、`/etc/ssl/certs` が空
- `ENV_NAME != local` のとき `sentry::init` が走り、sentry 0.48.5 の reqwest transport がクライアント構築時に system CA ストアを eager に読み込む（DSN が平文 `http://` でもロード自体は走る）
- CA ストアが空 → reqwest ビルダーがエラー → panic → HTTP を bind する前にプロセス死亡

旧イメージ (main-649c758) で顕在化しなかったのは、当時の sentry crate が CA を eager に読まなかったためで、0.2.0 での sentry 0.48.5 への更新により空の CA ストアが初めて致命傷になりました。

## 変更内容

最終ステージに `ca-certificates` のインストールを 1 行追加。Discord API / Minecraft Services API への HTTPS アクセスにも CA ストアは必要なため、Sentry 撤去 (#1260) 後も必要な修正です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)