### PR TITLE
ci: ブランチ名からラベルを自動付与するワークフローを追加する

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,14 @@
+# ブランチ名の prefix から .github/release.yml のカテゴリ分けに使うラベルを付与する。
+# どの prefix にも一致しない PR はラベルなしのまま (リリースノートでは「その他の変更」扱い)。
+feature:
+  - head-branch: ['^feat/', '^feature/']
+bug:
+  - head-branch: ['^fix/', '^hotfix/']
+refactoring:
+  - head-branch: ['^refactor/', '^refactoring/']
+ci:
+  - head-branch: ['^ci/']
+documentation:
+  - head-branch: ['^docs?/']
+dependencies:
+  - head-branch: ['^deps/', '^renovate/', '^dependabot/']

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -1,0 +1,19 @@
+name: Pull request labeler
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  labeler:
+    name: Label pull request by branch name
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13 # v7.0.0


### PR DESCRIPTION
## 概要

Closes #1268

`.github/release.yml` (#1263) のカテゴリ分けに使うラベルの付け忘れを防ぐため、ブランチ名の prefix から対応するラベルを PR に自動付与するワークフローを追加しました。

## 実装

issue の実装候補のうち、公式の **actions/labeler v7.0.0**（`head-branch` の正規表現マッチ）を採用し、SHA でピンしています。自前スクリプトは不要でした。

## prefix → ラベルのマッピング (`.github/labeler.yml`)

| ブランチ prefix | ラベル |
|---|---|
| `feat/`, `feature/` | feature |
| `fix/`, `hotfix/` | bug |
| `refactor/`, `refactoring/` | refactoring |
| `ci/` | ci |
| `doc/`, `docs/` | documentation |
| `deps/`, `renovate/`, `dependabot/` | dependencies |

## 挙動の補足

- トリガーは `pull_request_target` の opened / reopened / synchronize。permissions は `pull-requests: write` のみで、PR 側のコードは checkout しません
- `sync-labels` はデフォルト (false) のため、手動で付けたラベルが剥がされることはありません
- どの prefix にも一致しないブランチ（`chore/`, `agent/issue-NNNN-*` など）はラベルなしのままです。issue の検討事項にあるとおり、種別が prefix から判別できないブランチはリリースノート上「その他の変更」になるため、今後は `feat/` `fix/` 等の prefix を含めた命名に寄せていくのが良さそうです（agent 系ブランチも `agent/feat-...` より `feat/issue-NNNN-...` の形が labeler と相性が良いです）

## 動作確認

- YAML の構文検証のみ（labeler の実挙動は本 PR マージ後、次の PR から確認できます）

🤖 Generated with [Claude Code](https://claude.com/claude-code)