### PR TITLE
fix: Meilisearch /stats の Bearer 認証に対応

### DIFF
--- a/server/infra/resource/src/database/search.rs
+++ b/server/infra/resource/src/database/search.rs
@@ -162,6 +162,16 @@ fn merge_answer_hits(
         .collect()
 }
 
+fn add_meilisearch_stats_auth(
+    request: reqwest_middleware::RequestBuilder,
+    api_key: Option<&str>,
+) -> reqwest_middleware::RequestBuilder {
+    match api_key {
+        Some(api_key) => request.bearer_auth(api_key),
+        None => request,
+    }
+}
+
 #[async_trait]
 impl SearchDatabase for ConnectionPool {
     #[tracing::instrument(skip_all, fields(otel.kind = "client", db.system = "meilisearch", db.collection.name = "users"))]
@@ -425,13 +435,12 @@ impl SearchDatabase for ConnectionPool {
     async fn search_engine_stats(&self) -> Result<NumberOfRecordsPerAggregate, InfraError> {
         let MeiliSearch { host, api_key } = &*MEILISEARCH;
 
-        let mut request = HTTP_CLIENT.get(format!("{}/stats", host));
-
-        if let Some(api_key) = api_key {
-            request = request.header("X-Meili-API-Key", api_key);
-        }
-
-        let response = request.send().await?;
+        let response = add_meilisearch_stats_auth(
+            HTTP_CLIENT.get(format!("{}/stats", host)),
+            api_key.as_deref(),
+        )
+        .send()
+        .await?;
 
         Ok(
             serde_json::from_str::<MeilisearchStatsSchema>(response.text().await?.as_str())?
@@ -485,7 +494,9 @@ impl SearchDatabase for ConnectionPool {
 
 #[cfg(test)]
 mod tests {
-    use super::{answer_content_documents, form_filter, merge_answer_hits};
+    use super::{
+        add_meilisearch_stats_auth, answer_content_documents, form_filter, merge_answer_hits,
+    };
     use domain::{
         form::{answer::AnswerId, models::FormId},
         search::models::{Operation, RealAnswers, SearchableFields},
@@ -502,6 +513,23 @@ mod tests {
         let form_id = FormId::from(Uuid::from_u128(1));
 
         assert_eq!(form_filter(form_id), format!("form_id = \"{form_id}\""));
+    }
+
+    #[test]
+    fn meilisearch_stats_uses_bearer_authorization() {
+        let client = reqwest_middleware::ClientBuilder::new(reqwest::Client::new()).build();
+        let request =
+            add_meilisearch_stats_auth(client.get("http://localhost/stats"), Some("sentinel"))
+                .build()
+                .unwrap();
+
+        assert!(
+            request
+                .headers()
+                .get(reqwest::header::AUTHORIZATION)
+                .is_some_and(|value| value.as_bytes() == b"Bearer sentinel")
+        );
+        assert!(request.headers().get("X-Meili-API-Key").is_none());
     }
 
     #[test]

--- a/server/usecase/src/search.rs
+++ b/server/usecase/src/search.rs
@@ -575,7 +575,9 @@ impl<
                     break
                 },
                 _ = interval.tick() => {
-                    self.check_and_resync_search_engine().await?;
+                    if let Err(error) = self.check_and_resync_search_engine().await {
+                        tracing::error!(error = %error, "failed to check search engine synchronization");
+                    }
                 }
             }
         }


### PR DESCRIPTION
## 概要
- Meilisearch の `/stats` 呼び出しを `X-Meili-API-Key` から `Authorization: Bearer <API_KEY>` に変更しました。既存の `MEILISEARCH_API_KEY` 設定は維持しています。
- 再同期監視タスクは、統計取得または再同期の一時的なエラーを記録して次の60秒周期へ継続します。
- HTTPリクエストのBearerヘッダーと旧ヘッダー不在を検証する回帰テストを追加しました。

## 確認事項
- `cargo test -p resource`: 15 unit tests、tracing監査1件が成功しました。
- `cargo test -p usecase`: 41 testsが成功しました。
- `cargo build`: 成功しました。
- `makers pretty`: workspaceのclippy、nextest 215件、doc tests、rustfmtが成功しました。
- `cargo fmt --all -- --check`: 成功しました。
- API Keyはヘッダーへ渡すだけで、ログやテスト失敗メッセージへ値を出力していないことを差分と検索で確認しました。

## 補足
- 実際の本番Meilisearchへの疎通は行っていませんが、テストで実際に構築したHTTPリクエストのAuthorizationヘッダーを検査しています。

🤖 Generated with Codex