### PR TITLE
ci: アーカイブ済みの actions-rs/cargo を cross の直接実行に置き換える

### DIFF
--- a/.github/workflows/image-release.yaml
+++ b/.github/workflows/image-release.yaml
@@ -99,9 +99,12 @@ jobs:
         with:
           toolchain: ${{ env.RUST_VERSION }}
           target: ${{ matrix.cross-target }}
-      # actions-rs/cargo (アーカイブ済み + 廃止された Node ランタイム) の use-cross 相当を直接実行する
+      # actions-rs/cargo (アーカイブ済み + 廃止された Node ランタイム) の use-cross 相当を直接実行する。
+      # cross は GitHub Releases のビルド済みバイナリを導入する (cargo install よりも高速)
       - name: Install cross
-        run: cargo install cross@0.2.5
+        uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # v2.85.7
+        with:
+          tool: cross@0.2.5
       - name: Build binary using cross
         run: cross build --manifest-path Cargo.toml --target ${{ matrix.cross-target }} --release
       - name: Upload artifact to collect in next job

--- a/.github/workflows/image-release.yaml
+++ b/.github/workflows/image-release.yaml
@@ -99,12 +99,11 @@ jobs:
         with:
           toolchain: ${{ env.RUST_VERSION }}
           target: ${{ matrix.cross-target }}
+      # actions-rs/cargo (アーカイブ済み + 廃止された Node ランタイム) の use-cross 相当を直接実行する
+      - name: Install cross
+        run: cargo install cross@0.2.5
       - name: Build binary using cross
-        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1
-        with:
-          use-cross: true
-          command: build
-          args: --manifest-path Cargo.toml --target ${{ matrix.cross-target }} --release
+        run: cross build --manifest-path Cargo.toml --target ${{ matrix.cross-target }} --release
       - name: Upload artifact to collect in next job
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:


### PR DESCRIPTION
## 背景

`image-release.yaml` の cross ビルドステップが使っている `actions-rs/cargo` は 2020 年からアーカイブ済みで、GitHub が廃止を進めている古い Node ランタイムで動作しています(seichi-timed-stats-server では actionlint にも指摘されました: GiganticMinecraft/seichi-timed-stats-server#164)。

## 変更内容

`use-cross: true` の actions-rs/cargo ステップを、同等の処理の直接実行に置き換えます:

- `cargo install cross@0.2.5`(crates.io の stable 最新)
- `cross build --manifest-path Cargo.toml --target <target> --release`

ビルドコマンド・引数は従来と同一です。

## 動作確認

- actionlint をローカルで実行し、変更箇所に指摘がないことを確認しました
  - なお既存の `- parallel:` ステップ等に対する指摘が別途出ますが、本 PR とは無関係の既存箇所です(直近の main の workflow 実行は成功しているため、actionlint 側が新しい構文に追従できていないものと思われます)
- このワークフローは main への push(バージョン更新)時のみ実行されるため、実挙動はマージ後の次回リリースで確認となります

🤖 Generated with [Claude Code](https://claude.com/claude-code)
