### PR TITLE
chore: MariaDB イメージを lts タグから本番と同じ 11.8 に固定する

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -123,7 +123,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       db:
-        image: mariadb:lts
+        image: mariadb:11.8
         env:
           MYSQL_INITDB_SKIP_TZINFO: 1
           MARIADB_DATABASE: seichi_portal

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: mariadb:lts
+    image: mariadb:11.8
     container_name: mariadb
     command: --log-bin --binlog-format=ROW --binlog_row_image=FULL
     environment:
@@ -69,7 +69,7 @@ services:
       - seichi_portal
     restart: "no"
   db-seed:
-    image: mariadb:lts
+    image: mariadb:11.8
     container_name: db-seed
     depends_on:
       migrate:


### PR DESCRIPTION
## 概要

CI (`ci.yaml` の sqlx-prepare-check) と開発用 compose の MariaDB が floating な `mariadb:lts` タグを使っていました。`lts` タグは MariaDB 12.3 の GA (2026-05-29) 以降 **12.3 を指すようになっており**、本番 ([seichi_infra の mariadb.yaml](https://github.com/GiganticMinecraft/seichi_infra/blob/e9f270c3ce45d7479f5fda2f4e1d7c1be0bf149f/seichi-onp-k8s/manifests/seichi-kubernetes/apps/seichi-minecraft/mariadb/mariadb.yaml#L14) = 11.8) と検証環境が知らないうちに乖離していたため、`mariadb:11.8` に固定します。

- `.github/workflows/ci.yaml`: `mariadb:lts` → `mariadb:11.8`
- `compose.yaml` (db / db-seed): `mariadb:lts` → `mariadb:11.8`

## 補足

本番の 12.3 化は mariadb-operator の 12.3 対応 ([mariadb-operator#1791](https://github.com/mariadb-operator/mariadb-operator/issues/1791)) 待ちの状態です。本番を 12.3 に上げる際に、このピンも合わせて更新してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)