### PR TITLE
chore: MariaDB を 11.8 に戻し Renovate の更新対象から除外する

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -123,7 +123,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       db:
-        image: mariadb:12.3
+        image: mariadb:11.8
         env:
           MYSQL_INITDB_SKIP_TZINFO: 1
           MARIADB_DATABASE: seichi_portal

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: mariadb:12.3
+    image: mariadb:11.8
     container_name: mariadb
     command: --log-bin --binlog-format=ROW --binlog_row_image=FULL
     environment:
@@ -69,7 +69,7 @@ services:
       - seichi_portal
     restart: "no"
   db-seed:
-    image: mariadb:12.3
+    image: mariadb:11.8
     container_name: db-seed
     depends_on:
       migrate:

--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,12 @@
         "cargo"
       ],
       "rangeStrategy": "bump"
+    },
+    {
+      "matchPackageNames": [
+        "mariadb"
+      ],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## 概要

MariaDB のバージョンを、本番環境と同じ `11.8` に戻し、Renovate の更新対象から除外します。

## 変更内容

- `.github/workflows/ci.yaml` の MariaDB を `12.3` から `11.8` に変更
- `compose.yaml` の `db` と `db-seed` を `12.3` から `11.8` に変更
- `renovate.json` でパッケージ名 `mariadb` を更新対象外に設定

## 背景

PR #1294 で MariaDB を `11.8` に固定した直後、PR #1295 によって Renovate が `12.3` へ更新しました。MariaDB の更新は本番環境の対応状況に合わせて行うため、Renovate による自動更新を停止します。

## 確認

- `jq empty renovate.json`
- `docker compose config -q`
- `git diff --check`
- `cargo fmt --all -- --config-path=.cargo-husky/hooks/rustfmt.toml --check`
- コミットフック内のビルド検証: 成功