### PR TITLE
回答対象の不正な組み合わせを防止

### DIFF
--- a/server/domain/src/form/answer/settings.rs
+++ b/server/domain/src/form/answer/settings.rs
@@ -5,13 +5,15 @@ use derive_getters::Getters;
 use deriving_via::DerivingVia;
 use errors::domain::DomainError;
 #[cfg(test)]
+use proptest::prelude::*;
+#[cfg(test)]
 use proptest_derive::Arbitrary;
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use strum_macros::{Display, EnumString};
 use types::non_empty_string::NonEmptyString;
 
 use crate::{
-    account::models::Role,
+    account::models::{Role, UserGroupId},
     auth::Actor,
     form::answer::{AnswerAuthor, AnswerEntry},
     form::settings::AllowedUserGroups,
@@ -150,46 +152,111 @@ impl AnswerAcceptancePeriod {
     }
 }
 
-#[cfg_attr(test, derive(Arbitrary))]
-#[derive(Serialize, Deserialize, Clone, Default, Debug, PartialEq)]
-pub struct AnswerAudience {
-    allow_temporary_answers: bool,
-    #[serde(default)]
-    answer_groups: AllowedUserGroups,
+#[derive(Clone, Debug, PartialEq, Default)]
+enum AnswerAudience {
+    Everyone,
+    #[default]
+    AuthenticatedUsers,
+    AuthenticatedUserGroups(AllowedUserGroups),
 }
 
 impl AnswerAudience {
-    fn new(allow_temporary_answers: bool) -> Self {
-        Self {
-            allow_temporary_answers,
-            answer_groups: AllowedUserGroups::unrestricted(),
+    fn try_new(
+        allow_temporary_answers: bool,
+        answer_groups: AllowedUserGroups,
+    ) -> Result<Self, DomainError> {
+        match (allow_temporary_answers, answer_groups.as_slice().is_empty()) {
+            (true, true) => Ok(Self::Everyone),
+            (false, true) => Ok(Self::AuthenticatedUsers),
+            (false, false) => Ok(Self::AuthenticatedUserGroups(answer_groups)),
+            (true, false) => Err(DomainError::InvalidEntity {
+                message: "temporary answers cannot be combined with answer groups".to_string(),
+            }),
         }
     }
 
-    fn change_allow_temporary_answers(self, allow_temporary_answers: bool) -> Self {
-        Self {
-            allow_temporary_answers,
-            ..self
+    fn allow_temporary_answers(&self) -> bool {
+        matches!(self, Self::Everyone)
+    }
+
+    fn answer_group_ids(&self) -> &[UserGroupId] {
+        match self {
+            Self::Everyone | Self::AuthenticatedUsers => &[],
+            Self::AuthenticatedUserGroups(answer_groups) => answer_groups.as_slice(),
         }
     }
 
-    fn change_answer_groups(self, answer_groups: AllowedUserGroups) -> Self {
-        Self {
-            answer_groups,
-            ..self
+    fn allows_authenticated_user(&self, actor: &Actor) -> bool {
+        match self {
+            Self::Everyone | Self::AuthenticatedUsers => true,
+            Self::AuthenticatedUserGroups(answer_groups) => answer_groups.allows(actor),
         }
     }
 
     fn allows(&self, author: &AnswerAuthor, actor: &Actor) -> bool {
         match (author, actor) {
             (AnswerAuthor::AuthenticatedUser(_), Actor::AccountUser(_)) => {
-                self.answer_groups.allows(actor)
+                self.allows_authenticated_user(actor)
             }
             (AnswerAuthor::Temporary(_), Actor::TemporaryAnswerAuthor(_)) => {
-                self.allow_temporary_answers
+                self.allow_temporary_answers()
             }
             _ => false,
         }
+    }
+}
+
+#[derive(Deserialize)]
+struct RawAnswerAudienceFields {
+    allow_temporary_answers: bool,
+    #[serde(default)]
+    answer_groups: AllowedUserGroups,
+}
+
+#[derive(Serialize)]
+struct AnswerAudienceFields<'a> {
+    allow_temporary_answers: bool,
+    answer_groups: &'a [UserGroupId],
+}
+
+impl Serialize for AnswerAudience {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        AnswerAudienceFields {
+            allow_temporary_answers: self.allow_temporary_answers(),
+            answer_groups: self.answer_group_ids(),
+        }
+        .serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for AnswerAudience {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let fields = RawAnswerAudienceFields::deserialize(deserializer)?;
+        Self::try_new(fields.allow_temporary_answers, fields.answer_groups)
+            .map_err(serde::de::Error::custom)
+    }
+}
+
+#[cfg(test)]
+impl Arbitrary for AnswerAudience {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<Self>;
+
+    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+        prop_oneof![
+            Just(Self::Everyone),
+            Just(Self::AuthenticatedUsers),
+            prop::collection::vec(any::<UserGroupId>(), 1..10).prop_map(|group_ids| {
+                Self::AuthenticatedUserGroups(AllowedUserGroups::new(group_ids))
+            }),
+        ]
+        .boxed()
     }
 }
 
@@ -198,7 +265,6 @@ impl AnswerAudience {
 /// 回答の公開範囲・受付期間・仮回答可否・デフォルトタイトルといった「ポリシー」を保持し、
 /// [`AnswerEntry`] の閲覧可否 ([`Self::can_read_entry`]) や新規受理 ([`Self::can_accept_answer`])
 /// を判断します。この値オブジェクトは [`crate::form::models::ActiveForm`] が所有します。
-#[cfg_attr(test, derive(Arbitrary))]
 #[derive(Serialize, Deserialize, Getters, Clone, Default, Debug, PartialEq)]
 pub struct AnswerSettings {
     default_answer_title: DefaultAnswerTitle,
@@ -209,6 +275,38 @@ pub struct AnswerSettings {
     audience: AnswerAudience,
     #[serde(default)]
     author_publication_policy: AnswerAuthorPublicationPolicy,
+}
+
+#[cfg(test)]
+impl Arbitrary for AnswerSettings {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<Self>;
+
+    fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
+        (
+            any::<DefaultAnswerTitle>(),
+            any::<AnswerVisibility>(),
+            any::<AnswerAcceptancePeriod>(),
+            any::<AnswerAudience>(),
+            any::<AnswerAuthorPublicationPolicy>(),
+        )
+            .prop_map(
+                |(
+                    default_answer_title,
+                    visibility,
+                    acceptance_period,
+                    audience,
+                    author_publication_policy,
+                )| Self {
+                    default_answer_title,
+                    visibility,
+                    acceptance_period,
+                    audience,
+                    author_publication_policy,
+                },
+            )
+            .boxed()
+    }
 }
 
 impl AnswerSettings {
@@ -222,9 +320,29 @@ impl AnswerSettings {
             default_answer_title,
             visibility,
             acceptance_period,
-            audience: AnswerAudience::new(allow_temporary_answers),
+            audience: AnswerAudience::try_new(
+                allow_temporary_answers,
+                AllowedUserGroups::unrestricted(),
+            )
+            .expect("an unrestricted answer audience must be valid"),
             author_publication_policy: AnswerAuthorPublicationPolicy::default(),
         }
+    }
+
+    pub fn try_new(
+        default_answer_title: DefaultAnswerTitle,
+        visibility: AnswerVisibility,
+        acceptance_period: AnswerAcceptancePeriod,
+        allow_temporary_answers: bool,
+        answer_groups: AllowedUserGroups,
+    ) -> Result<Self, DomainError> {
+        Ok(Self {
+            default_answer_title,
+            visibility,
+            acceptance_period,
+            audience: AnswerAudience::try_new(allow_temporary_answers, answer_groups)?,
+            author_publication_policy: AnswerAuthorPublicationPolicy::default(),
+        })
     }
 
     pub fn change_default_answer_title(self, default_answer_title: DefaultAnswerTitle) -> Self {
@@ -245,28 +363,27 @@ impl AnswerSettings {
         }
     }
 
-    pub fn change_allow_temporary_answers(self, allow_temporary_answers: bool) -> Self {
-        Self {
-            audience: self
-                .audience
-                .change_allow_temporary_answers(allow_temporary_answers),
+    pub fn try_change_audience(
+        self,
+        allow_temporary_answers: bool,
+        answer_groups: AllowedUserGroups,
+    ) -> Result<Self, DomainError> {
+        Ok(Self {
+            audience: AnswerAudience::try_new(allow_temporary_answers, answer_groups)?,
             ..self
-        }
+        })
     }
 
-    pub fn change_answer_groups(self, answer_groups: AllowedUserGroups) -> Self {
-        Self {
-            audience: self.audience.change_answer_groups(answer_groups),
-            ..self
-        }
+    pub fn allow_temporary_answers(&self) -> bool {
+        self.audience.allow_temporary_answers()
     }
 
-    pub fn allow_temporary_answers(&self) -> &bool {
-        &self.audience.allow_temporary_answers
+    pub fn answer_group_ids(&self) -> &[UserGroupId] {
+        self.audience.answer_group_ids()
     }
 
-    pub fn answer_groups(&self) -> &AllowedUserGroups {
-        &self.audience.answer_groups
+    pub(crate) fn allows_authenticated_user(&self, actor: &Actor) -> bool {
+        self.audience.allows_authenticated_user(actor)
     }
 
     pub fn change_author_publication_policy(
@@ -311,7 +428,7 @@ impl AnswerSettings {
             Actor::AccountUser(user) => {
                 entry.author().authenticated_user_id() == Some(*user.id())
                     || (self.visibility == AnswerVisibility::PUBLIC
-                        && self.answer_groups().allows(actor))
+                        && self.audience.allows_authenticated_user(actor))
                     || user.role() == &Role::Administrator
             }
             Actor::System => true,
@@ -348,16 +465,22 @@ mod tests {
 
     #[test]
     fn answer_settings_serialization_preserves_audience_fields() {
-        let settings = answer_settings(true, AnswerAcceptancePeriod::try_new(None, None).unwrap())
-            .change_answer_groups(AllowedUserGroups::new(vec![UserGroupId::from(
-                Uuid::from_u128(10),
-            )]));
+        let settings = answer_settings(false, AnswerAcceptancePeriod::try_new(None, None).unwrap())
+            .try_change_audience(
+                false,
+                AllowedUserGroups::new(vec![UserGroupId::from(Uuid::from_u128(10))]),
+            )
+            .unwrap();
 
         let serialized = serde_json::to_value(settings).unwrap();
 
-        assert_eq!(serialized["allow_temporary_answers"], true);
+        assert_eq!(serialized["allow_temporary_answers"], false);
         assert_eq!(serialized["answer_groups"].as_array().unwrap().len(), 1);
         assert!(serialized.get("audience").is_none());
+
+        let mut invalid_serialized = serialized;
+        invalid_serialized["allow_temporary_answers"] = serde_json::json!(true);
+        assert!(serde_json::from_value::<AnswerSettings>(invalid_serialized).is_err());
     }
 
     fn active_user(role: Role) -> AccountUser {
@@ -507,10 +630,11 @@ mod tests {
             active_user_with_groups(Role::StandardUser, vec![respondent.clone()]);
         let outsider = active_user(Role::StandardUser);
         let settings = answer_settings(false, AnswerAcceptancePeriod::try_new(None, None).unwrap())
-            .change_answer_groups(AllowedUserGroups::new(vec![
-                *observer.id(),
-                *respondent.id(),
-            ]));
+            .try_change_audience(
+                false,
+                AllowedUserGroups::new(vec![*observer.id(), *respondent.id()]),
+            )
+            .unwrap();
 
         assert!(settings.can_accept_answer(
             &AnswerAuthor::AuthenticatedUser(*observer_member.id()),
@@ -527,20 +651,42 @@ mod tests {
     }
 
     #[test]
-    fn temporary_answer_creation_is_allowed_when_answer_group_is_restricted() {
+    fn answer_audience_rejects_temporary_answers_with_restricted_groups() {
         let observer = user_group(10, "Observer");
-        let settings = answer_settings(true, AnswerAcceptancePeriod::try_new(None, None).unwrap())
-            .change_answer_groups(AllowedUserGroups::new(vec![*observer.id()]));
-        let author = AnswerAuthor::Temporary(TemporaryAnswerAuthor::new(
-            "guest".to_string(),
-            "contact".to_string(),
-        ));
-        let actor = Actor::from(TemporaryAnswerAuthor::new(
-            "guest".to_string(),
-            "contact".to_string(),
-        ));
+        let result = answer_settings(true, AnswerAcceptancePeriod::try_new(None, None).unwrap())
+            .try_change_audience(true, AllowedUserGroups::new(vec![*observer.id()]));
 
-        assert!(settings.can_accept_answer(&author, &actor));
+        assert!(matches!(result, Err(DomainError::InvalidEntity { .. })));
+    }
+
+    #[test]
+    fn answer_audience_deserialization_accepts_three_valid_combinations_and_rejects_invalid_one() {
+        let group_id = Uuid::from_u128(10);
+        let cases = vec![
+            (
+                r#"{"allow_temporary_answers":true,"answer_groups":[]}"#.to_string(),
+                true,
+            ),
+            (
+                r#"{"allow_temporary_answers":false,"answer_groups":[]}"#.to_string(),
+                true,
+            ),
+            (
+                format!(r#"{{"allow_temporary_answers":false,"answer_groups":["{group_id}"]}}"#),
+                true,
+            ),
+            (
+                format!(r#"{{"allow_temporary_answers":true,"answer_groups":["{group_id}"]}}"#),
+                false,
+            ),
+        ];
+
+        for (input, is_valid) in cases {
+            assert_eq!(
+                serde_json::from_str::<AnswerAudience>(&input).is_ok(),
+                is_valid
+            );
+        }
     }
 
     #[test]
@@ -620,7 +766,8 @@ mod tests {
             AnswerAcceptancePeriod::try_new(None, None).unwrap(),
             false,
         )
-        .change_answer_groups(AllowedUserGroups::new(vec![*observer.id()]));
+        .try_change_audience(false, AllowedUserGroups::new(vec![*observer.id()]))
+        .unwrap();
 
         assert!(settings.can_read_entry(&entry, &Actor::from(member)));
         assert!(!settings.can_read_entry(&entry, &Actor::from(outsider)));

--- a/server/domain/src/form/comment_thread.rs
+++ b/server/domain/src/form/comment_thread.rs
@@ -105,7 +105,7 @@ impl CommentThread {
                 if user.role() == &Administrator
                     || (self.answer_settings.visibility() == &AnswerVisibility::PUBLIC
                         && self.publication == AnswerPublication::PUBLIC
-                        && self.answer_settings.answer_groups().allows(actor))
+                        && self.answer_settings.allows_authenticated_user(actor))
         )
     }
 }
@@ -291,7 +291,8 @@ mod tests {
         let thread = thread(
             AnswerSettings::default()
                 .change_visibility(AnswerVisibility::PUBLIC)
-                .change_answer_groups(AllowedUserGroups::new(vec![*group.id()])),
+                .try_change_audience(false, AllowedUserGroups::new(vec![*group.id()]))
+                .unwrap(),
             AnswerPublication::PUBLIC,
         );
 

--- a/server/domain/src/form/models.rs
+++ b/server/domain/src/form/models.rs
@@ -495,8 +495,11 @@ mod tests {
 
         assert!(matches!(denied_result, Err(DomainError::Forbidden)));
 
-        let form = form
-            .change_answer_settings(AnswerSettings::default().change_allow_temporary_answers(true));
+        let form = form.change_answer_settings(
+            AnswerSettings::default()
+                .try_change_audience(true, AllowedUserGroups::unrestricted())
+                .unwrap(),
+        );
         let accepted_result = public_form_read_by(form.clone(), actor).try_accept_temporary_answer(
             temporary_user,
             AnswerTitle::new(None),

--- a/server/infra/resource/src/database/forms/comment.rs
+++ b/server/infra/resource/src/database/forms/comment.rs
@@ -527,13 +527,14 @@ async fn lock_comment_thread(
         }
         None => Vec::new(),
     };
+    let answer_settings = AnswerSettings::default()
+        .change_visibility(answer_visibility)
+        .try_change_audience(false, AllowedUserGroups::new(answer_group_ids))?;
     let thread = CommentThread::try_new(
         answer_id,
         answer_author,
         AnswerPublication::try_from(answer.publication)?,
-        AnswerSettings::default()
-            .change_visibility(answer_visibility)
-            .change_answer_groups(AllowedUserGroups::new(answer_group_ids)),
+        answer_settings,
         comments,
     )?;
     AuthorizationGuard::<_, Update>::from(thread)

--- a/server/infra/resource/src/database/forms/form.rs
+++ b/server/infra/resource/src/database/forms/form.rs
@@ -3,9 +3,7 @@ use chrono::{DateTime, Utc};
 use domain::account::models::UserGroupId;
 use domain::form::{
     answer::{AnswerEntry, AnswerId, AnswerPagePosition, AnswerPublication},
-    models::{
-        AllowedUserGroups, ArchivedFormPagePosition, FormLabelId, FormPagePosition, FormSettings,
-    },
+    models::{ArchivedFormPagePosition, FormLabelId, FormPagePosition, FormSettings},
     question::{Choice, Question, QuestionId, QuestionType},
 };
 use domain::{
@@ -611,7 +609,7 @@ async fn insert_form_root(
     let answer_settings = form.answer_settings();
     let answer_visibility = answer_settings.visibility().to_string();
     let hide_author = answer_settings.author_publication_policy().hides_author();
-    let allow_temporary_answers = *answer_settings.allow_temporary_answers();
+    let allow_temporary_answers = answer_settings.allow_temporary_answers();
     let default_answer_title = answer_settings
         .default_answer_title()
         .to_owned()
@@ -677,7 +675,7 @@ async fn update_form_root(
     let answer_settings = form.answer_settings();
     let answer_visibility = answer_settings.visibility().to_string();
     let hide_author = answer_settings.author_publication_policy().hides_author();
-    let allow_temporary_answers = *answer_settings.allow_temporary_answers();
+    let allow_temporary_answers = answer_settings.allow_temporary_answers();
     let default_answer_title = answer_settings
         .default_answer_title()
         .to_owned()
@@ -1560,14 +1558,14 @@ async fn sync_form_group_restrictions(
         txn,
         "form_allowed_user_groups",
         *form.id(),
-        form.settings().allowed_user_groups(),
+        form.settings().allowed_user_groups().as_slice(),
     )
     .await?;
     sync_group_restriction_ids(
         txn,
         "form_answer_groups",
         *form.id(),
-        form.answer_settings().answer_groups(),
+        form.answer_settings().answer_group_ids(),
     )
     .await
 }
@@ -1576,7 +1574,7 @@ async fn sync_group_restriction_ids(
     txn: &mut DatabaseTransaction,
     table_name: &str,
     form_id: FormId,
-    group_ids: &AllowedUserGroups,
+    group_ids: &[UserGroupId],
 ) -> Result<(), InfraError> {
     let form_id = form_id.into_inner().to_string();
     let delete_sql = format!("DELETE FROM {table_name} WHERE form_id = ?");
@@ -1585,16 +1583,15 @@ async fn sync_group_restriction_ids(
         .execute(&mut **txn)
         .await?;
 
-    if group_ids.as_slice().is_empty() {
+    if group_ids.is_empty() {
         return Ok(());
     }
 
     let sql = format!(
         "INSERT INTO {table_name} (form_id, group_id) VALUES {}",
-        std::iter::repeat_n("(?, ?)", group_ids.as_slice().len()).join(", ")
+        std::iter::repeat_n("(?, ?)", group_ids.len()).join(", ")
     );
     group_ids
-        .as_slice()
         .iter()
         .flat_map(|group_id| [form_id.clone(), group_id.to_string()])
         .fold(query(AssertSqlSafe(&*sql)), |query, value| {

--- a/server/infra/resource/src/records.rs
+++ b/server/infra/resource/src/records.rs
@@ -158,7 +158,7 @@ impl TryFrom<ActiveFormRecord> for ActiveForm {
             .collect::<Result<Vec<_>, _>>()?;
         let questions = NonEmptyVec::try_new(questions).map_err(Error::from)?;
 
-        let answer_settings = AnswerSettings::new(
+        let answer_settings = AnswerSettings::try_new(
             DefaultAnswerTitle::new(
                 default_answer_title
                     .map(NonEmptyString::try_new)
@@ -167,11 +167,11 @@ impl TryFrom<ActiveFormRecord> for ActiveForm {
             answer_visibility.try_into()?,
             AnswerAcceptancePeriod::try_new(acceptance_period_start_at, acceptance_period_end_at)?,
             allow_temporary_answers,
-        )
-        .change_author_publication_policy(AnswerAuthorPublicationPolicy::from_hide_author(
-            hide_author,
-        ))
-        .change_answer_groups(AllowedUserGroups::new(answer_group_ids));
+            AllowedUserGroups::new(answer_group_ids),
+        )?
+        .change_author_publication_policy(
+            AnswerAuthorPublicationPolicy::from_hide_author(hide_author),
+        );
 
         Ok(unsafe {
             ActiveForm::from_raw_parts(

--- a/server/presentation/src/schemas/form/form_response_schemas.rs
+++ b/server/presentation/src/schemas/form/form_response_schemas.rs
@@ -83,7 +83,7 @@ impl AnswerSettingsSchema {
                 start_at: answer_settings.acceptance_period().start_at().to_owned(),
                 end_at: answer_settings.acceptance_period().end_at().to_owned(),
             },
-            answer_group_ids: answer_settings.answer_groups().as_slice().to_vec(),
+            answer_group_ids: answer_settings.answer_group_ids().to_vec(),
         }
     }
 }
@@ -108,7 +108,7 @@ impl FormSettingsResponseSchema {
             discord_webhook_enabled: settings.discord_webhook_enabled(),
             visibility: settings.visibility().to_owned(),
             allowed_group_ids: settings.allowed_user_groups().as_slice().to_vec(),
-            allow_temporary_answers: *answer_settings.allow_temporary_answers(),
+            allow_temporary_answers: answer_settings.allow_temporary_answers(),
             answer_settings: AnswerSettingsSchema::from_answer_settings(answer_settings),
         }
     }

--- a/server/usecase/src/forms/answer.rs
+++ b/server/usecase/src/forms/answer.rs
@@ -603,8 +603,8 @@ mod tests {
             FormSubmissionRestriction, FormSubmissionRestrictionReason,
             answer::{AnswerLabelId, FormAnswerContentId},
             models::{
-                AnswerAuthorPublicationPolicy, AnswerSettings, DefaultAnswerTitle,
-                DiscordWebhookUrl, FormDescription, FormTitle, QuestionSet,
+                AllowedUserGroups, AnswerAuthorPublicationPolicy, AnswerSettings,
+                DefaultAnswerTitle, DiscordWebhookUrl, FormDescription, FormTitle, QuestionSet,
             },
             question::Question,
         },
@@ -744,7 +744,8 @@ mod tests {
                 .change_default_answer_title(DefaultAnswerTitle::new(Some(
                     "$form_name".to_string().try_into().unwrap(),
                 )))
-                .change_allow_temporary_answers(allow_temporary_answers),
+                .try_change_audience(allow_temporary_answers, AllowedUserGroups::unrestricted())
+                .unwrap(),
         )
     }
 

--- a/server/usecase/src/forms/form.rs
+++ b/server/usecase/src/forms/form.rs
@@ -1,6 +1,6 @@
 use chrono::Utc;
 use domain::{
-    account::models::AccountUser,
+    account::models::{AccountUser, UserGroupId},
     auth::Actor,
     form::models::{
         ActiveForm, AllowedUserGroups, AnswerAcceptancePeriod, AnswerAuthorPublicationPolicy,
@@ -126,17 +126,12 @@ impl<
             None => form_settings,
         };
 
-        let answer_settings = AnswerSettings::default();
-        let answer_settings = match allow_temporary_answers {
-            Some(allow) => answer_settings.change_allow_temporary_answers(allow),
-            None => answer_settings,
-        };
+        let answer_settings = AnswerSettings::default().try_change_audience(
+            allow_temporary_answers.unwrap_or_default(),
+            answer_groups.unwrap_or_default(),
+        )?;
         let answer_settings = match answer_visibility {
             Some(visibility) => answer_settings.change_visibility(visibility),
-            None => answer_settings,
-        };
-        let answer_settings = match answer_groups {
-            Some(groups) => answer_settings.change_answer_groups(groups),
             None => answer_settings,
         };
         let answer_settings = match acceptance_period {
@@ -499,6 +494,15 @@ impl<
             .await?
             .ok_or(Error::from(FormNotFound))?;
 
+        let current_form_read = current_form.clone().try_read(actor_user.clone())?;
+        let current_answer_settings = current_form_read.answer_settings();
+        let updated_answer_settings = current_answer_settings.clone().try_change_audience(
+            allow_temporary_answers.unwrap_or(current_answer_settings.allow_temporary_answers()),
+            answer_groups.unwrap_or_else(|| {
+                AllowedUserGroups::new(current_answer_settings.answer_group_ids().to_vec())
+            }),
+        )?;
+
         let updated_form = current_form.into_update().map(|form| {
             let current_settings = form.settings().to_owned();
             let updated_settings = match visibility {
@@ -516,14 +520,10 @@ impl<
                 }
             };
 
-            let updated_answer_settings = form.answer_settings().to_owned();
+            let updated_answer_settings = updated_answer_settings;
             let updated_answer_settings = match answer_visibility {
                 None => updated_answer_settings,
                 Some(v) => updated_answer_settings.change_visibility(v),
-            };
-            let updated_answer_settings = match answer_groups {
-                None => updated_answer_settings,
-                Some(groups) => updated_answer_settings.change_answer_groups(groups),
             };
             let updated_answer_settings = match default_answer_title {
                 None => updated_answer_settings,
@@ -532,10 +532,6 @@ impl<
             let updated_answer_settings = match acceptance_period {
                 None => updated_answer_settings,
                 Some(p) => updated_answer_settings.change_acceptance_period(p),
-            };
-            let updated_answer_settings = match allow_temporary_answers {
-                None => updated_answer_settings,
-                Some(a) => updated_answer_settings.change_allow_temporary_answers(a),
             };
             let updated_answer_settings = match author_publication_policy {
                 None => updated_answer_settings,
@@ -641,7 +637,7 @@ fn form_creation_details(form: &ActiveForm) -> Vec<EventDetail> {
         EventDetail::new("フォーム公開範囲", form.settings().visibility().to_string()),
         EventDetail::new(
             "フォーム閲覧グループ",
-            format_groups(form.settings().allowed_user_groups()),
+            format_groups(form.settings().allowed_user_groups().as_slice()),
         ),
         EventDetail::new(
             "フォーム別 Discord 通知",
@@ -653,7 +649,7 @@ fn form_creation_details(form: &ActiveForm) -> Vec<EventDetail> {
         ),
         EventDetail::new(
             "回答可能グループ",
-            format_groups(form.answer_settings().answer_groups()),
+            format_groups(form.answer_settings().answer_group_ids()),
         ),
         EventDetail::new(
             "回答受付期間",
@@ -669,7 +665,7 @@ fn form_creation_details(form: &ActiveForm) -> Vec<EventDetail> {
         ),
         EventDetail::new(
             "匿名回答",
-            format_allowed(*form.answer_settings().allow_temporary_answers()),
+            format_allowed(form.answer_settings().allow_temporary_answers()),
         ),
     ]
     .into_iter()
@@ -693,7 +689,7 @@ fn form_update_details(before: &ActiveForm, after: &ActiveForm) -> Vec<EventDeta
             || {
                 EventDetail::new(
                     "フォーム閲覧グループ",
-                    format_groups(after.settings().allowed_user_groups()),
+                    format_groups(after.settings().allowed_user_groups().as_slice()),
                 )
             },
         ),
@@ -713,14 +709,13 @@ fn form_update_details(before: &ActiveForm, after: &ActiveForm) -> Vec<EventDeta
                 )
             },
         ),
-        (before.answer_settings().answer_groups() != after.answer_settings().answer_groups()).then(
-            || {
+        (before.answer_settings().answer_group_ids() != after.answer_settings().answer_group_ids())
+            .then(|| {
                 EventDetail::new(
                     "回答可能グループ",
-                    format_groups(after.answer_settings().answer_groups()),
+                    format_groups(after.answer_settings().answer_group_ids()),
                 )
-            },
-        ),
+            }),
         (before.answer_settings().acceptance_period()
             != after.answer_settings().acceptance_period())
         .then(|| {
@@ -742,7 +737,7 @@ fn form_update_details(before: &ActiveForm, after: &ActiveForm) -> Vec<EventDeta
         .then(|| {
             EventDetail::new(
                 "匿名回答",
-                format_allowed(*after.answer_settings().allow_temporary_answers()),
+                format_allowed(after.answer_settings().allow_temporary_answers()),
             )
         }),
         (before.answer_settings().author_publication_policy()
@@ -767,8 +762,8 @@ fn form_update_details(before: &ActiveForm, after: &ActiveForm) -> Vec<EventDeta
     .collect()
 }
 
-fn format_groups(groups: &AllowedUserGroups) -> String {
-    match groups.as_slice() {
+fn format_groups(groups: &[UserGroupId]) -> String {
+    match groups {
         [] => "制限なし".to_string(),
         groups => groups
             .iter()


### PR DESCRIPTION
## 概要
- 未認証回答を許可する場合に、回答グループ制限を同時指定できない不変条件をドメインモデルへ集約しました。
- 作成・部分更新・DB復元・serde復元の各経路で `allow_temporary_answers=true` と非空グループの組み合わせを拒否します。
- HTTP/DBの既存フィールド形式と回答閲覧時のグループ判定は維持しています。

## 確認事項
- `cargo test -p domain`（113 tests + doctest）成功
- `cargo build` 成功
- `cargo clippy --workspace -- -D warnings` 成功
- `makers pretty` 成功（workspace 230 tests、doc tests、clippy を含む）
- `git diff --check` 成功
- `authorization_guard`、SQL、migration、`.sqlx` に変更なし

## 補足
- PR #1302 のマージ後に判明した、未認証回答許可と回答グループ制限の不正な組み合わせを修正する後続 PR です。

🤖 Generated with Codex