### PR TITLE
feat: 回答検索に対応状況フィルターを追加

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -4167,6 +4167,15 @@
               "type": "string",
               "format": "uuid"
             }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "description": "Limit results to the specified answer status",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {

--- a/server/domain/src/repository/search_repository.rs
+++ b/server/domain/src/repository/search_repository.rs
@@ -3,7 +3,7 @@ use errors::Error;
 use mockall::automock;
 
 use crate::{
-    form::models::FormId,
+    form::{answer::AnswerStatus, models::FormId},
     search::models::{
         AnswerLabelSearchHit, AnswerSearchHit, CommentSearchHit, FormLabelSearchHit, FormSearchHit,
         NumberOfRecordsPerAggregate, SearchableFieldsWithOperation, UserSearchHit,
@@ -29,6 +29,7 @@ pub trait SearchRepository: Send + Sync + 'static {
         &self,
         query: &str,
         form_id: Option<FormId>,
+        status: Option<AnswerStatus>,
     ) -> Result<Vec<AnswerSearchHit>, Error>;
     async fn search_comments(&self, query: &str) -> Result<Vec<CommentSearchHit>, Error>;
     async fn sync_search_engine(&self, data: &[SearchableFieldsWithOperation])

--- a/server/domain/src/search/models.rs
+++ b/server/domain/src/search/models.rs
@@ -1,7 +1,7 @@
 use crate::account::models::UserId;
 use crate::form::answer::FormAnswerContentId;
 use crate::form::{
-    answer::{AnswerId, AnswerLabelId, AnswerTitle},
+    answer::{AnswerId, AnswerLabelId, AnswerStatus, AnswerTitle},
     comment::CommentId,
     models::{FormDescription, FormId, FormLabelId, FormTitle},
     question::QuestionId,
@@ -45,6 +45,8 @@ pub struct AnswerTitleSearchDocument {
     pub id: AnswerId,
     pub form_id: FormId,
     pub title: AnswerTitle,
+    #[serde(default)]
+    pub status: AnswerStatus,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -53,6 +55,8 @@ pub struct RealAnswers {
     pub answer_id: AnswerId,
     pub question_id: QuestionId,
     pub answer: String,
+    #[serde(default)]
+    pub status: AnswerStatus,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/server/infra/resource/src/database/components.rs
+++ b/server/infra/resource/src/database/components.rs
@@ -21,7 +21,8 @@ use domain::{
         FormSubmissionRestriction,
         answer::{
             AnswerEntry, AnswerId, AnswerLabel, AnswerLabelId, AnswerPagePosition,
-            AnswerPublication, AnswerReference, AnswerRelation, AnswerStatusHistoryPagePosition,
+            AnswerPublication, AnswerReference, AnswerRelation, AnswerStatus,
+            AnswerStatusHistoryPagePosition,
         },
         comment::{Comment, CommentHistoryPagePosition, CommentId, DeletedComment},
         message::{DeletedMessage, Message, MessageHistoryPagePosition, MessageId},
@@ -368,6 +369,7 @@ pub trait SearchDatabase: Send + Sync {
         &self,
         query: &str,
         form_id: Option<FormId>,
+        status: Option<AnswerStatus>,
     ) -> Result<Vec<AnswerSearchHit>, InfraError>;
     async fn search_comments(&self, query: &str) -> Result<Vec<CommentSearchHit>, InfraError>;
     async fn sync_search_engine(

--- a/server/infra/resource/src/database/search.rs
+++ b/server/infra/resource/src/database/search.rs
@@ -10,7 +10,7 @@ use async_trait::async_trait;
 use domain::{
     account::models::UserId,
     form::{
-        answer::{AnswerId, FormAnswerContentId},
+        answer::{AnswerEntry, AnswerId, AnswerStatus, FormAnswerContentId},
         models::FormId,
         question::QuestionId,
     },
@@ -36,50 +36,30 @@ struct AnswerContentSearchDocument {
     answer_id: AnswerId,
     question_id: QuestionId,
     answer: String,
+    status: AnswerStatus,
 }
 
 #[derive(Deserialize)]
 struct FormIdPresence {
     #[serde(default)]
     form_id: Option<FormId>,
+    #[serde(default)]
+    status: Option<AnswerStatus>,
 }
 
-fn form_filter(form_id: FormId) -> String {
-    format!("form_id = \"{form_id}\"")
-}
-
-fn form_ids_from_answer_titles(
-    data: &[SearchableFieldsWithOperation],
-) -> HashMap<AnswerId, FormId> {
-    data.iter()
-        .filter_map(|(fields, operation)| match (fields, operation) {
-            (SearchableFields::AnswerTitle(answer), Operation::Create | Operation::Update) => {
-                Some((answer.id, answer.form_id))
-            }
-            _ => None,
-        })
-        .collect()
-}
-
-fn unresolved_content_answer_ids(
-    data: &[SearchableFieldsWithOperation],
-    form_ids_by_answer_id: &HashMap<AnswerId, FormId>,
-) -> Vec<AnswerId> {
-    data.iter()
-        .filter_map(|(fields, operation)| match (fields, operation) {
-            (SearchableFields::RealAnswers(content), Operation::Create | Operation::Update) => {
-                Some(content.answer_id)
-            }
-            _ => None,
-        })
-        .unique()
-        .filter(|answer_id| !form_ids_by_answer_id.contains_key(answer_id))
-        .collect()
+fn answer_filter(form_id: Option<FormId>, status: Option<AnswerStatus>) -> Option<String> {
+    [
+        form_id.map(|id| format!("form_id = \"{id}\"")),
+        status.map(|status| format!("status = \"{status}\"")),
+    ]
+    .into_iter()
+    .flatten()
+    .reduce(|left, right| format!("{left} AND {right}"))
 }
 
 fn answer_content_documents(
     data: &[SearchableFieldsWithOperation],
-    form_ids_by_answer_id: &HashMap<AnswerId, FormId>,
+    metadata_by_answer_id: &HashMap<AnswerId, (FormId, AnswerStatus)>,
 ) -> Result<HashMap<FormAnswerContentId, AnswerContentSearchDocument>, InfraError> {
     data.iter()
         .filter_map(|(fields, operation)| match (fields, operation) {
@@ -89,7 +69,7 @@ fn answer_content_documents(
             _ => None,
         })
         .map(|content| {
-            let form_id = form_ids_by_answer_id
+            let (form_id, status) = metadata_by_answer_id
                 .get(&content.answer_id)
                 .copied()
                 .ok_or_else(|| InfraError::Unexpected {
@@ -107,24 +87,66 @@ fn answer_content_documents(
                     answer_id: content.answer_id,
                     question_id: content.question_id,
                     answer: content.answer.clone(),
+                    status,
                 },
             ))
         })
         .collect()
 }
 
-fn form_ids_from_answer_records(
-    records: impl IntoIterator<Item = FormAnswerRecord>,
-) -> Result<HashMap<AnswerId, FormId>, InfraError> {
+fn answer_metadata_from_records(
+    records: &[FormAnswerRecord],
+) -> Result<HashMap<AnswerId, (FormId, AnswerStatus)>, InfraError> {
     records
-        .into_iter()
+        .iter()
         .map(|record| {
+            let status = AnswerStatus::try_from(record.status.clone()).map_err(|error| {
+                InfraError::Unexpected {
+                    cause: error.to_string(),
+                }
+            })?;
             Ok((
                 Uuid::parse_str(&record.id)?.into(),
-                Uuid::parse_str(&record.form_id)?.into(),
+                (Uuid::parse_str(&record.form_id)?.into(), status),
             ))
         })
         .collect()
+}
+
+fn answer_documents_from_entry(entry: &AnswerEntry) -> Vec<SearchableFieldsWithOperation> {
+    let title = SearchableFields::AnswerTitle(AnswerTitleSearchDocument {
+        id: *entry.id(),
+        form_id: *entry.form_id(),
+        title: entry.title().clone(),
+        status: *entry.status(),
+    });
+    let contents = entry.contents().iter().map(|content| {
+        (
+            SearchableFields::RealAnswers(domain::search::models::RealAnswers {
+                id: content.id,
+                answer_id: *entry.id(),
+                question_id: content.question_id,
+                answer: content.answer.clone(),
+                status: *entry.status(),
+            }),
+            Operation::Update,
+        )
+    });
+    std::iter::once((title, Operation::Update))
+        .chain(contents)
+        .collect()
+}
+
+fn answer_documents_from_record(
+    record: FormAnswerRecord,
+) -> Result<Vec<SearchableFieldsWithOperation>, InfraError> {
+    let entry: AnswerEntry =
+        record
+            .try_into()
+            .map_err(|error: errors::Error| InfraError::Unexpected {
+                cause: error.to_string(),
+            })?;
+    Ok(answer_documents_from_entry(&entry))
 }
 
 async fn answer_documents_need_reprojection(
@@ -135,13 +157,13 @@ async fn answer_documents_need_reprojection(
             .meilisearch_client
             .index(index)
             .search()
-            .with_filter("form_id NOT EXISTS")
+            .with_filter("form_id NOT EXISTS OR status NOT EXISTS")
             .with_limit(1)
             .execute::<FormIdPresence>()
             .await?
             .hits
             .into_iter()
-            .any(|hit| hit.result.form_id.is_none());
+            .any(|hit| hit.result.form_id.is_none() || hit.result.status.is_none());
         if missing_form_id {
             return Ok(true);
         }
@@ -257,8 +279,9 @@ impl SearchDatabase for ConnectionPool {
         &self,
         query: &str,
         form_id: Option<FormId>,
+        status: Option<AnswerStatus>,
     ) -> Result<Vec<AnswerSearchHit>, InfraError> {
-        let filter = form_id.map(form_filter);
+        let filter = answer_filter(form_id, status);
         let title_search = async {
             let index = self.meilisearch_client.index("answers");
             let mut search = index.search();
@@ -316,24 +339,80 @@ impl SearchDatabase for ConnectionPool {
         &self,
         data: &[SearchableFieldsWithOperation],
     ) -> Result<(), InfraError> {
-        let indexed_form_ids = form_ids_from_answer_titles(data);
-        let unresolved_answer_ids = unresolved_content_answer_ids(data, &indexed_form_ids);
-        let database_form_ids = if unresolved_answer_ids.is_empty() {
-            HashMap::new()
-        } else {
-            form_ids_from_answer_records(
-                self.get_answers_by_answer_ids(unresolved_answer_ids)
-                    .await?,
-            )?
-        };
-        let form_ids_by_answer_id = indexed_form_ids
+        let answer_ids_to_fetch = data
+            .iter()
+            .filter_map(|(fields, operation)| match (fields, operation) {
+                (SearchableFields::AnswerTitle(answer), Operation::Create | Operation::Update) => {
+                    Some(answer.id)
+                }
+                (SearchableFields::RealAnswers(content), Operation::Create | Operation::Update) => {
+                    Some(content.answer_id)
+                }
+                _ => None,
+            })
+            .unique()
+            .collect_vec();
+        let answer_records = self.get_answers_by_answer_ids(answer_ids_to_fetch).await?;
+        let metadata_by_answer_id = answer_metadata_from_records(&answer_records)?;
+        let reprojected_documents = answer_records
             .into_iter()
-            .chain(database_form_ids)
-            .collect();
-        let content_documents = answer_content_documents(data, &form_ids_by_answer_id)?;
+            .map(answer_documents_from_record)
+            .try_fold(Vec::new(), |mut documents, result| {
+                documents.extend(result?);
+                Ok::<_, InfraError>(documents)
+            })?;
+        let content_documents = answer_content_documents(data, &metadata_by_answer_id)?;
+
+        let reproject_futures = reprojected_documents.iter().map(|(fields, _)| async {
+            match fields {
+                SearchableFields::AnswerTitle(answer) => {
+                    self.meilisearch_client
+                        .index("answers")
+                        .add_or_replace(&[answer], Some("id"))
+                        .await?;
+                    Ok::<_, InfraError>(())
+                }
+                SearchableFields::RealAnswers(content) => {
+                    self.meilisearch_client
+                        .index("real_answers")
+                        .add_or_replace(
+                        &[AnswerContentSearchDocument {
+                            id: content.id,
+                            form_id: metadata_by_answer_id
+                                .get(&content.answer_id)
+                                .map(|(form_id, _)| *form_id)
+                                .ok_or_else(|| InfraError::Unexpected {
+                                    cause: format!(
+                                        "form id for answer {} was not found while reprojecting",
+                                        content.answer_id
+                                    ),
+                                })?,
+                            answer_id: content.answer_id,
+                            question_id: content.question_id,
+                            answer: content.answer.clone(),
+                            status: content.status,
+                        }],
+                        Some("id"),
+                    )
+                    .await?;
+                    Ok::<_, InfraError>(())
+                }
+                _ => Ok(()),
+            }
+        });
+        try_join_all(reproject_futures).await?;
 
         let futures = data
             .iter()
+            .filter(|(searchable_fields, operation)| {
+                !matches!(
+                    (searchable_fields, operation),
+                    (
+                        SearchableFields::AnswerTitle(_),
+                        Operation::Create | Operation::Update
+                    )
+                )
+            })
             .map(async |(searchable_fields, operation)| match operation {
                 Operation::Create | Operation::Update => match searchable_fields {
                     SearchableFields::FormMetaData(data) => {
@@ -342,11 +421,8 @@ impl SearchDatabase for ConnectionPool {
                             .add_or_replace(&[data], Some("id"))
                             .await
                     }
-                    SearchableFields::AnswerTitle(answer) => {
-                        self.meilisearch_client
-                            .index("answers")
-                            .add_or_replace(&[answer], Some("id"))
-                            .await
+                    SearchableFields::AnswerTitle(_) => {
+                        unreachable!("answer title updates are handled by database reprojection")
                     }
                     SearchableFields::RealAnswers(answers) => {
                         self.meilisearch_client
@@ -479,7 +555,7 @@ impl SearchDatabase for ConnectionPool {
         let settings_futures = ["answers", "real_answers"].into_iter().map(async |index| {
             self.meilisearch_client
                 .index(index)
-                .set_filterable_attributes(["form_id"])
+                .set_filterable_attributes(["form_id", "status"])
                 .await?
                 .wait_for_completion(&self.meilisearch_client, None, None)
                 .await?;
@@ -495,10 +571,14 @@ impl SearchDatabase for ConnectionPool {
 #[cfg(test)]
 mod tests {
     use super::{
-        add_meilisearch_stats_auth, answer_content_documents, form_filter, merge_answer_hits,
+        add_meilisearch_stats_auth, answer_content_documents, answer_documents_from_entry,
+        answer_filter, merge_answer_hits,
     };
     use domain::{
-        form::{answer::AnswerId, models::FormId},
+        form::{
+            answer::{AnswerAuthor, AnswerEntry, AnswerId, AnswerStatus, AnswerTitle},
+            models::FormId,
+        },
         search::models::{Operation, RealAnswers, SearchableFields},
     };
     use std::collections::HashMap;
@@ -509,10 +589,16 @@ mod tests {
     }
 
     #[test]
-    fn answer_form_filter_uses_the_form_id_attribute() {
+    fn answer_filter_combines_form_id_and_status() {
         let form_id = FormId::from(Uuid::from_u128(1));
 
-        assert_eq!(form_filter(form_id), format!("form_id = \"{form_id}\""));
+        assert_eq!(
+            answer_filter(Some(form_id), Some(AnswerStatus::IN_PROGRESS)),
+            Some(format!(
+                "form_id = \"{form_id}\" AND status = \"IN_PROGRESS\""
+            ))
+        );
+        assert_eq!(answer_filter(None, None), None);
     }
 
     #[test]
@@ -543,13 +629,17 @@ mod tests {
                 answer_id,
                 question_id: Uuid::from_u128(4).into(),
                 answer: "content".to_string(),
+                status: AnswerStatus::UNADDRESSED,
             }),
             Operation::Update,
         )];
-        let document = answer_content_documents(&data, &HashMap::from([(answer_id, form_id)]))
-            .unwrap()
-            .remove(&content_id)
-            .unwrap();
+        let document = answer_content_documents(
+            &data,
+            &HashMap::from([(answer_id, (form_id, AnswerStatus::UNADDRESSED))]),
+        )
+        .unwrap()
+        .remove(&content_id)
+        .unwrap();
 
         assert_eq!(
             serde_json::to_value(document).unwrap()["form_id"],
@@ -580,5 +670,41 @@ mod tests {
 
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].answer_id, answer_id);
+    }
+
+    #[test]
+    fn status_reprojection_updates_title_and_content_documents_together() {
+        let answer_id = answer_id(1);
+        let content_id = Uuid::from_u128(2).into();
+        let question_id = Uuid::from_u128(3).into();
+        let entry = unsafe {
+            AnswerEntry::from_raw_parts_with_status_and_redmine_reference(
+                answer_id,
+                Uuid::from_u128(4).into(),
+                AnswerAuthor::AuthenticatedUser(Uuid::from_u128(5).into()),
+                chrono::Utc::now(),
+                AnswerTitle::new(None),
+                domain::form::answer::AnswerPublication::PUBLIC,
+                AnswerStatus::COMPLETED,
+                vec![domain::form::answer::FormAnswerContent {
+                    id: content_id,
+                    question_id,
+                    answer: "本文".to_string(),
+                }],
+                None,
+            )
+        };
+
+        let documents = answer_documents_from_entry(&entry);
+        assert!(matches!(
+            &documents[0].0,
+            SearchableFields::AnswerTitle(document)
+                if document.status == AnswerStatus::COMPLETED
+        ));
+        assert!(matches!(
+            &documents[1].0,
+            SearchableFields::RealAnswers(document)
+                if document.status == AnswerStatus::COMPLETED
+        ));
     }
 }

--- a/server/infra/resource/src/messaging/schema.rs
+++ b/server/infra/resource/src/messaging/schema.rs
@@ -1,6 +1,6 @@
 use std::str::FromStr;
 
-use domain::search::models::SearchableFields;
+use domain::{form::answer::AnswerStatus, search::models::SearchableFields};
 use errors::infra::InfraError;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -141,6 +141,8 @@ pub struct AnswerTitleSearchDocument {
     pub id: String,
     pub form_id: String,
     pub title: Option<NonEmptyString>,
+    #[serde(default)]
+    pub status: AnswerStatus,
 }
 
 impl From<domain::search::models::AnswerTitleSearchDocument> for AnswerTitleSearchDocument {
@@ -149,6 +151,7 @@ impl From<domain::search::models::AnswerTitleSearchDocument> for AnswerTitleSear
             id: answer.id.to_string(),
             form_id: answer.form_id.to_string(),
             title: answer.title.into_inner(),
+            status: answer.status,
         }
     }
 }
@@ -161,6 +164,7 @@ impl TryFrom<AnswerTitleSearchDocument> for domain::search::models::AnswerTitleS
             id: Uuid::from_str(&answer.id)?.into(),
             form_id: Uuid::from_str(&answer.form_id)?.into(),
             title: domain::form::answer::AnswerTitle::new(answer.title),
+            status: answer.status,
         })
     }
 }
@@ -171,6 +175,8 @@ pub struct RealAnswers {
     pub answer_id: String,
     pub question_id: String,
     pub answer: String,
+    #[serde(default)]
+    pub status: AnswerStatus,
 }
 
 impl From<domain::search::models::RealAnswers> for RealAnswers {
@@ -180,6 +186,7 @@ impl From<domain::search::models::RealAnswers> for RealAnswers {
             answer_id: real_answers.answer_id.to_string(),
             question_id: real_answers.question_id.into_inner().to_string(),
             answer: real_answers.answer,
+            status: real_answers.status,
         }
     }
 }
@@ -193,6 +200,7 @@ impl TryFrom<RealAnswers> for domain::search::models::RealAnswers {
             answer_id: Uuid::from_str(&real_answers.answer_id)?.into(),
             question_id: Uuid::from_str(&real_answers.question_id)?.into(),
             answer: real_answers.answer,
+            status: real_answers.status,
         })
     }
 }
@@ -395,8 +403,64 @@ mod tests {
         assert_eq!(document.id.into_inner(), answer_id);
         assert_eq!(document.form_id.into_inner(), form_id);
         assert_eq!(
+            document.status,
+            domain::form::answer::AnswerStatus::UNADDRESSED
+        );
+        assert_eq!(
             serde_json::to_value(document.title).unwrap(),
             json!("検索できるタイトル")
+        );
+    }
+
+    #[test]
+    fn answers_payload_preserves_status_and_old_payload_defaults_to_unaddressed() {
+        let answer_id = Uuid::from_u128(1);
+        let form_id = Uuid::from_u128(2);
+        let schema: RabbitMQSchema = serde_json::from_value(json!({
+            "payload": {
+                "op": "u",
+                "source": { "table": "answers" },
+                "before": null,
+                "after": {
+                    "id": answer_id.to_string(),
+                    "form_id": form_id.to_string(),
+                    "title": "検索できるタイトル",
+                    "status": "COMPLETED"
+                }
+            }
+        }))
+        .unwrap();
+        let actual = schema.payload.try_into_after().unwrap().unwrap();
+        let SearchableFields::AnswerTitle(document) = SearchableFields::try_from(actual).unwrap()
+        else {
+            panic!("answers payload must become a title document");
+        };
+        assert_eq!(
+            document.status,
+            domain::form::answer::AnswerStatus::COMPLETED
+        );
+
+        let old_schema: RabbitMQSchema = serde_json::from_value(json!({
+            "payload": {
+                "op": "u",
+                "source": { "table": "answers" },
+                "before": null,
+                "after": {
+                    "id": answer_id.to_string(),
+                    "form_id": form_id.to_string(),
+                    "title": "旧ペイロード"
+                }
+            }
+        }))
+        .unwrap();
+        let actual = old_schema.payload.try_into_after().unwrap().unwrap();
+        let SearchableFields::AnswerTitle(document) = SearchableFields::try_from(actual).unwrap()
+        else {
+            panic!("answers payload must become a title document");
+        };
+        assert_eq!(
+            document.status,
+            domain::form::answer::AnswerStatus::UNADDRESSED
         );
     }
 

--- a/server/infra/resource/src/repository/search_repository_impl.rs
+++ b/server/infra/resource/src/repository/search_repository_impl.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use async_trait::async_trait;
 use domain::{
-    form::models::FormId,
+    form::{answer::AnswerStatus, models::FormId},
     repository::search_repository::SearchRepository,
     search::models::{
         AnswerLabelSearchHit, AnswerSearchHit, CommentSearchHit, FormLabelSearchHit, FormSearchHit,
@@ -54,10 +54,11 @@ impl<Client: DatabaseComponents + 'static> SearchRepository for Repository<Clien
         &self,
         query: &str,
         form_id: Option<FormId>,
+        status: Option<AnswerStatus>,
     ) -> Result<Vec<AnswerSearchHit>, Error> {
         self.client
             .search()
-            .search_answers(query, form_id)
+            .search_answers(query, form_id, status)
             .await
             .map_err(Into::into)
     }

--- a/server/presentation/src/handlers/search_handler.rs
+++ b/server/presentation/src/handlers/search_handler.rs
@@ -174,6 +174,7 @@ pub async fn search_users(
     params(
         ("query" = String, Query, description = "Search query"),
         ("form_id" = Option<String>, Query, format = "uuid", description = "Limit results to the specified form"),
+        ("status" = Option<String>, Query, description = "Limit results to the specified answer status"),
     ),
     responses(
         AnswerSearchResponse,
@@ -211,7 +212,7 @@ pub async fn search_answers(
         })?;
 
     let answers = search_use_case
-        .search_answers(&user, query, search_query.form_id)
+        .search_answers(&user, query, search_query.form_id, search_query.status)
         .await
         .map_err(handle_error)?;
 

--- a/server/presentation/src/schemas/search_schemas.rs
+++ b/server/presentation/src/schemas/search_schemas.rs
@@ -1,4 +1,7 @@
-use domain::form::{answer::AnswerId, models::FormId};
+use domain::form::{
+    answer::{AnswerId, AnswerStatus},
+    models::FormId,
+};
 use serde::{Deserialize, Serialize};
 use types::non_empty_string::NonEmptyString;
 use usecase::models::{AnswerDetails, CrossSearchComment, CrossSearchOutput};
@@ -29,6 +32,9 @@ pub struct AnswerSearchQuery {
     #[serde(default)]
     #[schema(value_type = Option<String>, format = "uuid")]
     pub form_id: Option<FormId>,
+    #[serde(default)]
+    #[schema(value_type = Option<String>)]
+    pub status: Option<AnswerStatus>,
 }
 
 #[derive(Serialize, Debug, utoipa::ToSchema)]
@@ -136,10 +142,28 @@ mod tests {
         .unwrap();
 
         assert_eq!(query.form_id, Some(form_id.into()));
+        assert_eq!(query.status, None);
 
         let query_without_form: AnswerSearchQuery =
             serde_json::from_value(serde_json::json!({ "query": "keyword" })).unwrap();
         assert_eq!(query_without_form.form_id, None);
+    }
+
+    #[test]
+    fn answer_search_query_accepts_and_rejects_status() {
+        let query: AnswerSearchQuery = serde_json::from_value(serde_json::json!({
+            "query": "keyword",
+            "status": "IN_PROGRESS",
+        }))
+        .unwrap();
+        assert_eq!(query.status, Some(AnswerStatus::IN_PROGRESS));
+        assert!(
+            serde_json::from_value::<AnswerSearchQuery>(serde_json::json!({
+                "query": "keyword",
+                "status": "INVALID",
+            }))
+            .is_err()
+        );
     }
 
     #[test]

--- a/server/usecase/src/search.rs
+++ b/server/usecase/src/search.rs
@@ -14,7 +14,7 @@ use domain::{
     account::models::AccountUser,
     auth::Actor,
     form::{
-        answer::{AnswerAuthor, AnswerAuthorDisclosure, AnswerEntry, AnswerId},
+        answer::{AnswerAuthor, AnswerAuthorDisclosure, AnswerEntry, AnswerId, AnswerStatus},
         comment::Comment,
         comment_thread::CommentThread,
         models::{ActiveForm, FormId},
@@ -390,6 +390,7 @@ impl<
         account_user: &AccountUser,
         query: String,
         form_id: Option<FormId>,
+        status: Option<AnswerStatus>,
     ) -> Result<Vec<AnswerDetails>, Error> {
         let actor = Actor::from(account_user.clone());
         if let Some(form_id) = form_id {
@@ -403,7 +404,7 @@ impl<
 
         let hits = self
             .search_repository
-            .search_answers(&query, form_id)
+            .search_answers(&query, form_id, status)
             .await?;
         let answer_ids = unique_answer_ids(hits.iter().map(|hit| hit.answer_id));
         let visible_answers_by_id = self
@@ -425,7 +426,7 @@ impl<
             self.search_repository.search_users(&query),
             self.search_repository.search_labels_for_forms(&query),
             self.search_repository.search_labels_for_answers(&query),
-            self.search_repository.search_answers(&query, None),
+            self.search_repository.search_answers(&query, None, None),
             self.search_repository.search_comments(&query)
         )?;
 
@@ -743,6 +744,7 @@ fn answer_search_documents(
                     id: *entry.id(),
                     form_id: *entry.form_id(),
                     title: entry.title().clone(),
+                    status: *entry.status(),
                 }),
                 Operation::Update,
             ))
@@ -753,6 +755,7 @@ fn answer_search_documents(
                         answer_id: *entry.id(),
                         question_id: content.question_id,
                         answer: content.answer.to_owned(),
+                        status: *entry.status(),
                     }),
                     Operation::Update,
                 )
@@ -866,7 +869,7 @@ mod tests {
             .returning(|_| Ok(vec![]));
         search_repository
             .expect_search_answers()
-            .returning(|_, _| Ok(vec![]));
+            .returning(|_, _, _| Ok(vec![]));
         search_repository
             .expect_search_comments()
             .returning(|_| Ok(vec![]));
@@ -957,8 +960,8 @@ mod tests {
         let mut search_repository = MockSearchRepository::new();
         search_repository
             .expect_search_answers()
-            .withf(move |_, form_id| *form_id == Some(readable_form_id))
-            .returning(move |_, _| {
+            .withf(move |_, form_id, _| *form_id == Some(readable_form_id))
+            .returning(move |_, _, _| {
                 Ok(vec![
                     AnswerSearchHit {
                         answer_id: visible_answer_b_id,
@@ -1023,7 +1026,7 @@ mod tests {
         };
 
         let answers = use_case
-            .search_answers(&actor, "answer".to_string(), Some(readable_form_id))
+            .search_answers(&actor, "answer".to_string(), Some(readable_form_id), None)
             .await
             .unwrap();
 
@@ -1078,7 +1081,7 @@ mod tests {
         let mut search_repository = MockSearchRepository::new();
         search_repository
             .expect_search_answers()
-            .return_once(move |_, _| Ok(vec![AnswerSearchHit { answer_id }]));
+            .return_once(move |_, _, _| Ok(vec![AnswerSearchHit { answer_id }]));
         let active_form_repository = InMemoryActiveFormRepository::new(vec![form]);
         let mut answer_label_repository = MockAnswerLabelRepository::new();
         answer_label_repository
@@ -1099,7 +1102,7 @@ mod tests {
         };
 
         let answers = use_case
-            .search_answers(&actor, "answer".to_string(), Some(form_id))
+            .search_answers(&actor, "answer".to_string(), Some(form_id), None)
             .await
             .unwrap();
 
@@ -1137,7 +1140,7 @@ mod tests {
         };
 
         let answers = use_case
-            .search_answers(&actor, "answer".to_string(), Some(missing_form_id))
+            .search_answers(&actor, "answer".to_string(), Some(missing_form_id), None)
             .await
             .unwrap();
 
@@ -1174,7 +1177,7 @@ mod tests {
         };
 
         let answers = use_case
-            .search_answers(&actor, "answer".to_string(), Some(unreadable_form_id))
+            .search_answers(&actor, "answer".to_string(), Some(unreadable_form_id), None)
             .await
             .unwrap();
 
@@ -1238,7 +1241,7 @@ mod tests {
             .returning(|_| Ok(vec![]));
         search_repository
             .expect_search_answers()
-            .returning(move |_, _| {
+            .returning(move |_, _, _| {
                 Ok(vec![
                     AnswerSearchHit {
                         answer_id: missing_author_answer_id,
@@ -1348,7 +1351,7 @@ mod tests {
             .returning(|_| Ok(vec![]));
         search_repository
             .expect_search_answers()
-            .returning(move |_, _| {
+            .returning(move |_, _, _| {
                 Ok(vec![
                     AnswerSearchHit { answer_id },
                     AnswerSearchHit { answer_id },
@@ -1538,7 +1541,7 @@ mod tests {
             .returning(|_| Ok(vec![]));
         search_repository
             .expect_search_answers()
-            .returning(|_, _| Ok(vec![]));
+            .returning(|_, _, _| Ok(vec![]));
         search_repository
             .expect_search_comments()
             .returning(move |_| {
@@ -1675,7 +1678,7 @@ mod tests {
             .returning(|_| Ok(vec![]));
         search_repository
             .expect_search_answers()
-            .returning(move |_, _| Ok(vec![AnswerSearchHit { answer_id }]));
+            .returning(move |_, _, _| Ok(vec![AnswerSearchHit { answer_id }]));
         search_repository
             .expect_search_comments()
             .returning(move |_| {


### PR DESCRIPTION
## 概要
- 回答検索APIに `status` クエリを追加し、未対応・対応中・対応済みで絞り込めるようにしました。
- `form_id` と併用でき、タイトル・回答本文の両検索インデックスへ同じ条件を適用します。
- 回答ステータス変更時には、関連する検索ドキュメントを再同期してインデックス間の整合性を維持します。

## 確認事項
- `cargo check --workspace`、`cargo build`、`cargo test --all-features` が成功しています。
- `cargo fmt --all -- --check`、`git diff --check`、OpenAPI生成結果の確認が成功しています。
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` は、既存の2 lintを除外した状態で成功しています。

## 補足
- `makers pretty` は、環境上のTCP lock listener bind制限により完走できませんでした。
- 既存ドキュメントや旧形式のメッセージにステータスがない場合の互換性も考慮しています。

🤖 Generated with Codex