### PR TITLE
回答一覧に対応状況フィルターを追加

### DIFF
--- a/.sqlx/query-76f92b3a46d43f6dc5540e0042a7bee4efd3d004b8bee071e0188604fae92c3a.json
+++ b/.sqlx/query-76f92b3a46d43f6dc5540e0042a7bee4efd3d004b8bee071e0188604fae92c3a.json
@@ -1,6 +1,6 @@
 {
   "db_name": "MySQL",
-  "query": "SELECT answers.form_id, answers.id AS answer_id, answers.title, answers.publication,\n            answers.status,\n            answers.author_type, answers.user, users.name AS user_name, users.role AS user_role,\n            answers.temporary_user_id, temporary_users.name AS temporary_user_name,\n            temporary_users.contact_text AS temporary_user_contact_text,\n            answers.redmine_user_id, answers.redmine_author_name,\n            redmine_reference.redmine_issue_id,\n            answers.timestamp AS `timestamp!: chrono::DateTime<chrono::Utc>`\n        FROM answers\n        LEFT JOIN users ON answers.user = users.id\n        LEFT JOIN temporary_users ON answers.temporary_user_id = temporary_users.id\n        LEFT JOIN redmine_imported_answer_references redmine_reference\n            ON redmine_reference.answer_id = answers.id\n        WHERE (? IS NULL OR answers.form_id = ?)\n            AND (\n                ? IS NULL\n                OR answers.timestamp < ?\n                OR (answers.timestamp = ? AND answers.id < ?)\n            )\n        ORDER BY answers.timestamp DESC, answers.id DESC\n        LIMIT ?",
+  "query": "SELECT answers.form_id, answers.id AS answer_id, answers.title, answers.publication,\n            answers.status,\n            answers.author_type, answers.user, users.name AS user_name, users.role AS user_role,\n            answers.temporary_user_id, temporary_users.name AS temporary_user_name,\n            temporary_users.contact_text AS temporary_user_contact_text,\n            answers.redmine_user_id, answers.redmine_author_name,\n            redmine_reference.redmine_issue_id,\n            answers.timestamp AS `timestamp!: chrono::DateTime<chrono::Utc>`\n        FROM answers\n        LEFT JOIN users ON answers.user = users.id\n        LEFT JOIN temporary_users ON answers.temporary_user_id = temporary_users.id\n        LEFT JOIN redmine_imported_answer_references redmine_reference\n            ON redmine_reference.answer_id = answers.id\n        WHERE (? IS NULL OR answers.form_id = ?)\n            AND (? IS NULL OR answers.status = ?)\n            AND (\n                ? IS NULL\n                OR answers.timestamp < ?\n                OR (answers.timestamp = ? AND answers.id < ?)\n            )\n        ORDER BY answers.timestamp DESC, answers.id DESC\n        LIMIT ?",
   "describe": {
     "columns": [
       {
@@ -261,7 +261,7 @@
       }
     ],
     "parameters": {
-      "Right": 7
+      "Right": 9
     },
     "nullable": [
       false,
@@ -282,5 +282,5 @@
       false
     ]
   },
-  "hash": "9edc036d0dc1be4ca65da7c87a7e66aeefd51b85686b02c821f61882a9cdb2d1"
+  "hash": "76f92b3a46d43f6dc5540e0042a7bee4efd3d004b8bee071e0188604fae92c3a"
 }

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -475,6 +475,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "description": "Limit results to the specified answer status",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -852,6 +861,15 @@
             "name": "cursor",
             "in": "query",
             "description": "Cursor returned by the previous page",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "description": "Limit results to the specified answer status",
             "required": false,
             "schema": {
               "type": "string"

--- a/server/domain/src/repository/form/answer_entry_repository.rs
+++ b/server/domain/src/repository/form/answer_entry_repository.rs
@@ -5,7 +5,7 @@ use mockall::automock;
 use crate::{
     form::{
         answer::{
-            AnswerEntry, AnswerId, AnswerPagePosition, AnswerStatusHistoryEntry,
+            AnswerEntry, AnswerId, AnswerPagePosition, AnswerStatus, AnswerStatusHistoryEntry,
             AnswerStatusHistoryPagePosition,
         },
         models::ActiveForm,
@@ -36,11 +36,13 @@ pub trait AnswerEntryRepository: Send + Sync + 'static {
         &self,
         form: &Allowed<ActiveForm, Read>,
         request: PageRequest<AnswerPagePosition>,
+        status: Option<AnswerStatus>,
     ) -> Result<Page<Allowed<AnswerEntry, Read>, AnswerPagePosition>, Error>;
     async fn list_all(
         &self,
         forms: &[Allowed<ActiveForm, Read>],
         request: PageRequest<AnswerPagePosition>,
+        status: Option<AnswerStatus>,
     ) -> Result<Page<Allowed<AnswerEntry, Read>, AnswerPagePosition>, Error>;
     async fn post(
         &self,

--- a/server/infra/resource/src/database/components.rs
+++ b/server/infra/resource/src/database/components.rs
@@ -101,10 +101,12 @@ pub trait FormDatabase: Send + Sync {
         &self,
         form_id: FormId,
         request: PageRequest<AnswerPagePosition>,
+        status: Option<AnswerStatus>,
     ) -> Result<Page<AnswerEntry, AnswerPagePosition>, InfraError>;
     async fn list_all_answer_entries(
         &self,
         request: PageRequest<AnswerPagePosition>,
+        status: Option<AnswerStatus>,
     ) -> Result<Page<AnswerEntry, AnswerPagePosition>, InfraError>;
 }
 

--- a/server/infra/resource/src/database/forms/form.rs
+++ b/server/infra/resource/src/database/forms/form.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use domain::account::models::UserGroupId;
 use domain::form::{
-    answer::{AnswerEntry, AnswerId, AnswerPagePosition, AnswerPublication},
+    answer::{AnswerEntry, AnswerId, AnswerPagePosition, AnswerPublication, AnswerStatus},
     models::{ArchivedFormPagePosition, FormLabelId, FormPagePosition, FormSettings},
     question::{Choice, Question, QuestionId, QuestionType},
 };
@@ -444,8 +444,10 @@ async fn fetch_answer_entries_page(
     txn: &mut DatabaseTransaction,
     form_id: Option<FormId>,
     request: PageRequest<AnswerPagePosition>,
+    status: Option<AnswerStatus>,
 ) -> Result<Page<AnswerEntry, AnswerPagePosition>, InfraError> {
     let form_id = form_id.map(|form_id| form_id.into_inner().to_string());
+    let status = status.map(|status| status.to_string());
     let (after_timestamp, after_answer_id) = request
         .after_position()
         .map(|position| {
@@ -471,6 +473,7 @@ async fn fetch_answer_entries_page(
         LEFT JOIN redmine_imported_answer_references redmine_reference
             ON redmine_reference.answer_id = answers.id
         WHERE (? IS NULL OR answers.form_id = ?)
+            AND (? IS NULL OR answers.status = ?)
             AND (
                 ? IS NULL
                 OR answers.timestamp < ?
@@ -480,6 +483,8 @@ async fn fetch_answer_entries_page(
         LIMIT ?",
         form_id.as_deref(),
         form_id.as_deref(),
+        status.as_deref(),
+        status.as_deref(),
         after_timestamp,
         after_timestamp,
         after_timestamp,
@@ -1494,9 +1499,12 @@ impl FormDatabase for ConnectionPool {
         &self,
         form_id: FormId,
         request: PageRequest<AnswerPagePosition>,
+        status: Option<AnswerStatus>,
     ) -> Result<Page<AnswerEntry, AnswerPagePosition>, InfraError> {
         self.read_only_transaction(|txn| {
-            Box::pin(async move { fetch_answer_entries_page(txn, Some(form_id), request).await })
+            Box::pin(
+                async move { fetch_answer_entries_page(txn, Some(form_id), request, status).await },
+            )
         })
         .await
     }
@@ -1505,9 +1513,10 @@ impl FormDatabase for ConnectionPool {
     async fn list_all_answer_entries(
         &self,
         request: PageRequest<AnswerPagePosition>,
+        status: Option<AnswerStatus>,
     ) -> Result<Page<AnswerEntry, AnswerPagePosition>, InfraError> {
         self.read_only_transaction(|txn| {
-            Box::pin(async move { fetch_answer_entries_page(txn, None, request).await })
+            Box::pin(async move { fetch_answer_entries_page(txn, None, request, status).await })
         })
         .await
     }

--- a/server/infra/resource/src/repository/form_repository_impls/answer_entry_repository_impl.rs
+++ b/server/infra/resource/src/repository/form_repository_impls/answer_entry_repository_impl.rs
@@ -84,6 +84,7 @@ where
         &self,
         form: &Allowed<ActiveForm, Read>,
         request: PageRequest<AnswerPagePosition>,
+        status: Option<AnswerStatus>,
     ) -> Result<Page<Allowed<AnswerEntry, Read>, AnswerPagePosition>, Error> {
         let mut scan_cursor = request.after_position().copied();
         let mut authorized_entries = Vec::new();
@@ -92,7 +93,11 @@ where
             let page = self
                 .client
                 .form()
-                .list_answer_entries(*form.id(), PageRequest::new(scan_cursor, request.limit()))
+                .list_answer_entries(
+                    *form.id(),
+                    PageRequest::new(scan_cursor, request.limit()),
+                    status,
+                )
                 .await?;
             let (entries, next_raw) = page.into_parts();
             authorized_entries.extend(
@@ -127,6 +132,7 @@ where
         &self,
         forms: &[Allowed<ActiveForm, Read>],
         request: PageRequest<AnswerPagePosition>,
+        status: Option<AnswerStatus>,
     ) -> Result<Page<Allowed<AnswerEntry, Read>, AnswerPagePosition>, Error> {
         if forms.is_empty() {
             return Ok(Page::new(Vec::new(), None));
@@ -143,7 +149,7 @@ where
             let page = self
                 .client
                 .form()
-                .list_all_answer_entries(PageRequest::new(scan_cursor, request.limit()))
+                .list_all_answer_entries(PageRequest::new(scan_cursor, request.limit()), status)
                 .await?;
             let (entries, next_raw) = page.into_parts();
             authorized_entries.extend(entries.into_iter().filter_map(|entry| {

--- a/server/presentation/src/handlers/form/answer_handler.rs
+++ b/server/presentation/src/handlers/form/answer_handler.rs
@@ -290,10 +290,11 @@ pub async fn get_all_answers(
 ) -> Result<GetAllAnswersResponse, Response> {
     let form_answer_use_case = build_answer_use_case(&repository, None);
     let Query(query) = query.map_err_to_error().map_err(handle_error)?;
+    let status = query.status;
     let request = answer_list_page_request(query).map_err(handle_error)?;
 
     let page = form_answer_use_case
-        .get_all_answers(&user, request)
+        .get_all_answers(&user, request, status)
         .await
         .map_err(handle_error)?;
     let (answers, next) = page.into_parts();
@@ -424,10 +425,11 @@ pub async fn get_answer_by_form_id_handler(
 
     let Path(form_id) = path.map_err_to_error().map_err(handle_error)?;
     let Query(query) = query.map_err_to_error().map_err(handle_error)?;
+    let status = query.status;
     let request = answer_list_page_request(query).map_err(handle_error)?;
 
     let page = form_answer_use_case
-        .get_answers_by_form_id(form_id, &user, request)
+        .get_answers_by_form_id(form_id, &user, request, status)
         .await
         .map_err(handle_error)?;
     let (answers, next) = page.into_parts();

--- a/server/presentation/src/schemas/form/form_request_schemas.rs
+++ b/server/presentation/src/schemas/form/form_request_schemas.rs
@@ -66,6 +66,9 @@ pub struct AnswerListQuery {
     pub limit: Option<u32>,
     /// Cursor returned by the previous page
     pub cursor: Option<String>,
+    /// Limit results to the specified answer status
+    #[param(value_type = Option<String>)]
+    pub status: Option<AnswerStatus>,
 }
 
 #[derive(Deserialize, Debug, utoipa::IntoParams)]

--- a/server/usecase/src/forms/answer.rs
+++ b/server/usecase/src/forms/answer.rs
@@ -376,13 +376,14 @@ impl<
         form_id: FormId,
         actor: &AccountUser,
         request: PageRequest<AnswerPagePosition>,
+        status: Option<AnswerStatus>,
     ) -> Result<Page<AnswerDetails, AnswerPagePosition>, Error> {
         let actor_ref = Actor::from(actor.clone());
         let form = self.read_form(form_id, &actor_ref).await?;
 
         let page = self
             .answer_entry_repository
-            .list_by_form(&form, request)
+            .list_by_form(&form, request, status)
             .await?;
         let (visible_answers, next) = page.into_parts();
         let author_disclosure = form.answer_settings().author_disclosure_for(&actor_ref);
@@ -427,13 +428,14 @@ impl<
         &self,
         user: &AccountUser,
         request: PageRequest<AnswerPagePosition>,
+        status: Option<AnswerStatus>,
     ) -> Result<Page<AnswerDetails, AnswerPagePosition>, Error> {
         let actor_ref = Actor::from(user.clone());
         let readable_forms = self.readable_forms(&actor_ref).await?;
 
         let page = self
             .answer_entry_repository
-            .list_all(&readable_forms, request)
+            .list_all(&readable_forms, request, status)
             .await?;
         let (visible_answers, next) = page.into_parts();
         let publication_by_form_id = readable_forms
@@ -795,7 +797,7 @@ mod tests {
             .unwrap();
         let answers = repositories
             .answer_entry_repository
-            .list_by_form(&form, PageRequest::first(PageLimit::default_limit()))
+            .list_by_form(&form, PageRequest::first(PageLimit::default_limit()), None)
             .await
             .unwrap();
 

--- a/server/usecase/src/forms/form.rs
+++ b/server/usecase/src/forms/form.rs
@@ -464,6 +464,7 @@ impl<
                 .list_by_form(
                     &current_form_read,
                     PageRequest::first(PageLimit::default_limit()),
+                    None,
                 )
                 .await?
                 .items()

--- a/server/usecase/src/search.rs
+++ b/server/usecase/src/search.rs
@@ -91,7 +91,7 @@ impl<
         loop {
             let page = self
                 .answer_entry_repository
-                .list_all(forms, request)
+                .list_all(forms, request, None)
                 .await?;
             let (items, next) = page.into_parts();
             answers.extend(items);

--- a/server/usecase/src/test_utils/repositories.rs
+++ b/server/usecase/src/test_utils/repositories.rs
@@ -8,8 +8,8 @@ use domain::{
         FormSubmissionRestriction, FormSubmissionRestrictionHistory, FormSubmissionRestrictionId,
         answer::{
             AnswerEntry, AnswerId, AnswerPagePosition, AnswerPublication, AnswerReference,
-            AnswerRelation, AnswerStatusHistoryEntry, AnswerStatusHistoryPagePosition,
-            ArchivedAnswerEntry, ReadableAnswerRelation,
+            AnswerRelation, AnswerStatus, AnswerStatusHistoryEntry,
+            AnswerStatusHistoryPagePosition, ArchivedAnswerEntry, ReadableAnswerRelation,
         },
         models::{
             ActiveForm, ArchivedForm, ArchivedFormPagePosition, FormId, FormLabel, FormLabelId,
@@ -334,6 +334,7 @@ impl AnswerEntryRepository for InMemoryAnswerEntryRepository {
         &self,
         form: &Allowed<ActiveForm, Read>,
         request: PageRequest<AnswerPagePosition>,
+        status: Option<AnswerStatus>,
     ) -> Result<Page<Allowed<AnswerEntry, Read>, AnswerPagePosition>, Error> {
         let mut answers = self
             .answers
@@ -341,6 +342,7 @@ impl AnswerEntryRepository for InMemoryAnswerEntryRepository {
             .unwrap()
             .iter()
             .filter(|answer| answer.form_id() == form.id())
+            .filter(|answer| status.is_none_or(|status| *answer.status() == status))
             .cloned()
             .filter_map(|answer| form.read_entry(answer).ok())
             .collect::<Vec<_>>();
@@ -366,6 +368,7 @@ impl AnswerEntryRepository for InMemoryAnswerEntryRepository {
         &self,
         forms: &[Allowed<ActiveForm, Read>],
         request: PageRequest<AnswerPagePosition>,
+        status: Option<AnswerStatus>,
     ) -> Result<Page<Allowed<AnswerEntry, Read>, AnswerPagePosition>, Error> {
         let forms_by_id = forms
             .iter()
@@ -377,6 +380,7 @@ impl AnswerEntryRepository for InMemoryAnswerEntryRepository {
             .unwrap()
             .iter()
             .cloned()
+            .filter(|answer| status.is_none_or(|status| *answer.status() == status))
             .filter_map(|answer| {
                 forms_by_id
                     .get(&answer.form_id().into_inner())
@@ -461,7 +465,7 @@ mod answer_entry_repository_tests {
         account::models::Role,
         auth::Actor,
         form::{
-            answer::{AnswerAuthor, AnswerTitle},
+            answer::{AnswerAuthor, AnswerStatus, AnswerTitle},
             models::{AnswerSettings, AnswerVisibility, FormDescription, FormTitle, QuestionSet},
             question::Question,
         },
@@ -504,11 +508,68 @@ mod answer_entry_repository_tests {
         }
     }
 
+    fn answer_with_status(
+        form: &ActiveForm,
+        id: u128,
+        timestamp: chrono::DateTime<Utc>,
+        status: AnswerStatus,
+    ) -> AnswerEntry {
+        unsafe {
+            AnswerEntry::from_raw_parts_with_status_and_redmine_reference(
+                Uuid::from_u128(id).into(),
+                *form.id(),
+                AnswerAuthor::AuthenticatedUser(Uuid::from_u128(id + 100).into()),
+                timestamp,
+                AnswerTitle::default(),
+                AnswerPublication::PUBLIC,
+                status,
+                Vec::new(),
+                None,
+            )
+        }
+    }
+
     fn ids(entries: Vec<Allowed<AnswerEntry, Read>>) -> Vec<Uuid> {
         entries
             .into_iter()
             .map(|entry| entry.id().into_inner())
             .collect()
+    }
+
+    #[tokio::test]
+    async fn list_filters_answers_by_status_before_paginating() {
+        let form = active_form("answers");
+        let timestamp = Utc.with_ymd_and_hms(2026, 8, 3, 12, 0, 0).unwrap();
+        let repository = InMemoryAnswerEntryRepository::new(vec![
+            answer_with_status(&form, 1, timestamp, AnswerStatus::COMPLETED),
+            answer_with_status(
+                &form,
+                2,
+                timestamp - chrono::TimeDelta::seconds(1),
+                AnswerStatus::IN_PROGRESS,
+            ),
+            answer_with_status(
+                &form,
+                3,
+                timestamp - chrono::TimeDelta::seconds(2),
+                AnswerStatus::IN_PROGRESS,
+            ),
+        ]);
+        let form = AuthorizationGuard::from(form)
+            .try_read(Actor::System)
+            .unwrap();
+
+        let page = repository
+            .list_by_form(
+                &form,
+                PageRequest::first(PageLimit::try_new(1).unwrap()),
+                Some(AnswerStatus::IN_PROGRESS),
+            )
+            .await
+            .unwrap();
+        let (entries, next) = page.into_parts();
+        assert_eq!(ids(entries), vec![Uuid::from_u128(2)]);
+        assert!(next.is_some());
     }
 
     #[tokio::test]
@@ -531,12 +592,12 @@ mod answer_entry_repository_tests {
         let limit = PageLimit::try_new(2).unwrap();
 
         let first_page = repository
-            .list_all(&forms, PageRequest::first(limit))
+            .list_all(&forms, PageRequest::first(limit), None)
             .await
             .unwrap();
         let (first_entries, next) = first_page.into_parts();
         let second_page = repository
-            .list_all(&forms, PageRequest::after(next.unwrap(), limit))
+            .list_all(&forms, PageRequest::after(next.unwrap(), limit), None)
             .await
             .unwrap();
         let (second_entries, next) = second_page.into_parts();
@@ -577,7 +638,11 @@ mod answer_entry_repository_tests {
             .unwrap();
 
         let page = repository
-            .list_all(&[form], PageRequest::first(PageLimit::try_new(10).unwrap()))
+            .list_all(
+                &[form],
+                PageRequest::first(PageLimit::try_new(10).unwrap()),
+                None,
+            )
             .await
             .unwrap();
 
@@ -606,7 +671,11 @@ mod answer_entry_repository_tests {
             .unwrap();
 
         let page = repository
-            .list_all(&[form], PageRequest::first(PageLimit::try_new(2).unwrap()))
+            .list_all(
+                &[form],
+                PageRequest::first(PageLimit::try_new(2).unwrap()),
+                None,
+            )
             .await
             .unwrap();
 
@@ -637,7 +706,11 @@ mod answer_entry_repository_tests {
             .unwrap();
 
         let page = repository
-            .list_by_form(&form, PageRequest::first(PageLimit::try_new(2).unwrap()))
+            .list_by_form(
+                &form,
+                PageRequest::first(PageLimit::try_new(2).unwrap()),
+                None,
+            )
             .await
             .unwrap();
 
@@ -663,12 +736,12 @@ mod answer_entry_repository_tests {
         let limit = PageLimit::try_new(2).unwrap();
 
         let first_page = repository
-            .list_by_form(&form, PageRequest::first(limit))
+            .list_by_form(&form, PageRequest::first(limit), None)
             .await
             .unwrap();
         let (first_entries, next) = first_page.into_parts();
         let second_page = repository
-            .list_by_form(&form, PageRequest::after(next.unwrap(), limit))
+            .list_by_form(&form, PageRequest::after(next.unwrap(), limit), None)
             .await
             .unwrap();
         let (second_entries, next) = second_page.into_parts();


### PR DESCRIPTION
## 概要

- `/forms/answers` と `/forms/{form_id}/answers` に `status` クエリを追加
- 対応状況を DB 側で絞り込んでからページングするように変更
- OpenAPI と SQLx メタデータを更新

## 確認事項

- `cargo build` 成功
- `makers pretty` 成功
- 236 テスト、doctest、clippy が成功
- OpenAPI の生成・差分確認が成功

🤖 Generated with Codex