### PR TITLE
feat: Valkey 分散レート制限を導入

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,9 @@ ENV_NAME=local
 
 REDIS_HOST=localhost
 REDIS_PORT=6379
+# Reverse proxy headers are trusted only when this shared secret matches.
+# Leave unset to use the TCP peer address for anonymous quotas.
+# SEICHI_PROXY_SECRET=
 
 MEILISEARCH_HOST=http://localhost:7700
 # 開発環境では以下の行を変更する必要はありません。

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,6 +64,18 @@ jobs:
     needs: [ rustfmt ]
     name: Lint and test server
     runs-on: ubuntu-latest
+    services:
+      valkey:
+        image: valkey/valkey:9-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd="valkey-cli ping"
+          --health-interval=5s
+          --health-timeout=3s
+          --health-retries=12
+    env:
+      RATE_LIMIT_VALKEY_URL: redis://127.0.0.1:6379/
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - run: echo "RUST_VERSION=$(sed -n 's/channel = "\(.*\)\"/\1/p' rust-toolchain.toml)" >> $GITHUB_ENV
@@ -116,6 +128,9 @@ jobs:
 
       - name: Cargo test
         run: cargo test --all-features
+
+      - name: Valkey rate-limit integration test
+        run: cargo test -p resource --test rate_limit_valkey -- --ignored
 
   sqlx-prepare-check:
     needs: [ rustfmt ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -719,6 +719,7 @@ dependencies = [
 name = "common"
 version = "0.2.3"
 dependencies = [
+ "async-trait",
  "chrono",
  "envy",
  "proptest",

--- a/server/common/Cargo.toml
+++ b/server/common/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+async-trait = { workspace = true }
 chrono = { workspace = true }
 envy = { workspace = true }
 proptest = { workspace = true }

--- a/server/common/src/lib.rs
+++ b/server/common/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod config;
+pub mod rate_limit;
 pub mod retry;
 pub mod test_utils;

--- a/server/common/src/rate_limit.rs
+++ b/server/common/src/rate_limit.rs
@@ -1,0 +1,47 @@
+use async_trait::async_trait;
+
+/// A single fixed-window quota evaluated by the shared rate-limit store.
+///
+/// The key is already namespaced by the caller.  The store appends the
+/// Valkey-derived window id before reading or updating the counter.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RateLimitQuota {
+    pub key: String,
+    pub limit: u64,
+    pub window_seconds: u64,
+}
+
+impl RateLimitQuota {
+    pub fn new(key: impl Into<String>, limit: u64, window_seconds: u64) -> Self {
+        Self {
+            key: key.into(),
+            limit,
+            window_seconds,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RateLimitDecision {
+    pub allowed: bool,
+    pub retry_after_seconds: u64,
+    pub remaining: u64,
+    pub limit: u64,
+    pub reset_seconds: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RateLimitStoreError {
+    /// The store could not be reached or timed out.  Callers may fail open.
+    Unavailable(String),
+    /// The store returned an invalid result or rejected the request shape.
+    Invalid(String),
+}
+
+#[async_trait]
+pub trait RateLimitStore: Send + Sync {
+    async fn check(
+        &self,
+        quotas: &[RateLimitQuota],
+    ) -> Result<RateLimitDecision, RateLimitStoreError>;
+}

--- a/server/entrypoint/src/main.rs
+++ b/server/entrypoint/src/main.rs
@@ -3,7 +3,7 @@ use std::{future::IntoFuture, net::SocketAddr, sync::Arc};
 use axum::{
     Json, Router,
     http::{
-        Method, StatusCode,
+        HeaderName, Method, StatusCode,
         header::{AUTHORIZATION, CONTENT_TYPE, LOCATION},
     },
     middleware,
@@ -26,6 +26,8 @@ use presentation::handlers::form::message_handler::{
 use presentation::handlers::search_handler::{
     initialize_search_engine, start_sync, start_watch_out_of_sync,
 };
+use presentation::rate_limit::{RateLimitState, middleware as rate_limit_middleware};
+use resource::rate_limit::ValkeyRateLimitStore;
 use resource::{database::connection::ConnectionPool, repository::Repository};
 use serde_json::json;
 use serenity::all::ShardManager;
@@ -103,6 +105,13 @@ async fn main() -> anyhow::Result<()> {
     ));
     let shared_repository = Repository::new(conn).into_shared(health_check_repo);
 
+    let rate_limit_store =
+        Arc::new(ValkeyRateLimitStore::from_environment().map_err(|error| {
+            anyhow::anyhow!("invalid Valkey rate-limit configuration: {error:?}")
+        })?);
+    let proxy_secret = std::env::var("SEICHI_PROXY_SECRET").ok();
+    let rate_limit_state = RateLimitState::new(rate_limit_store, proxy_secret);
+
     let discord_sender = resource::outgoing::connection::ConnectionPool::new().await;
     let notificator = DiscordNotificator::new(discord_sender, shared_repository.to_owned());
     let _global_discord_webhook_worker =
@@ -112,25 +121,44 @@ async fn main() -> anyhow::Result<()> {
 
     let openapi = openapi::versioned_api_router().into_openapi();
 
-    let (public_api, _) = openapi::public_api_router()
-        .with_state(shared_repository.to_owned())
-        .split_for_parts();
-
     let (optional_auth_api, _) = openapi::optional_auth_api_router()
         .with_state(shared_repository.to_owned())
         .split_for_parts();
-    let optional_auth_api = optional_auth_api.route_layer(middleware::from_fn_with_state(
-        shared_repository.to_owned(),
-        optional_auth,
-    ));
+    let optional_auth_api = optional_auth_api
+        .route_layer(middleware::from_fn_with_state(
+            rate_limit_state.clone(),
+            rate_limit_middleware,
+        ))
+        .route_layer(middleware::from_fn_with_state(
+            shared_repository.to_owned(),
+            optional_auth,
+        ));
 
     let (authenticated_api, _) = openapi::authenticated_api_router()
         .with_state(shared_repository.to_owned())
         .split_for_parts();
-    let authenticated_api = authenticated_api.route_layer(middleware::from_fn_with_state(
-        shared_repository.to_owned(),
-        auth,
-    ));
+    let authenticated_api = authenticated_api
+        .route_layer(middleware::from_fn_with_state(
+            rate_limit_state.clone(),
+            rate_limit_middleware,
+        ))
+        .route_layer(middleware::from_fn_with_state(
+            shared_repository.to_owned(),
+            auth,
+        ));
+
+    let (authenticated_session_api, _) = openapi::authenticated_session_api_router()
+        .with_state(shared_repository.to_owned())
+        .split_for_parts();
+    let authenticated_session_api = authenticated_session_api
+        .route_layer(middleware::from_fn_with_state(
+            rate_limit_state.clone(),
+            rate_limit_middleware,
+        ))
+        .route_layer(middleware::from_fn_with_state(
+            shared_repository.to_owned(),
+            auth,
+        ));
 
     // post_message_handler uses a different State type, so register it separately
     let message_post_router = Router::new()
@@ -138,6 +166,10 @@ async fn main() -> anyhow::Result<()> {
             "/forms/{form_id}/answers/{answer_id}/messages",
             post(post_message_handler),
         )
+        .route_layer(middleware::from_fn_with_state(
+            rate_limit_state.clone(),
+            rate_limit_middleware,
+        ))
         .route_layer(middleware::from_fn_with_state(
             shared_repository.to_owned(),
             auth,
@@ -147,6 +179,14 @@ async fn main() -> anyhow::Result<()> {
             notificator,
         )));
 
+    let (public_api, _) = openapi::public_api_router()
+        .with_state(shared_repository.to_owned())
+        .split_for_parts();
+    let public_api = public_api.route_layer(middleware::from_fn_with_state(
+        rate_limit_state,
+        rate_limit_middleware,
+    ));
+
     let app = Router::new()
         .merge(SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", openapi))
         .route("/health", get(health_check_handler::health_check))
@@ -155,6 +195,7 @@ async fn main() -> anyhow::Result<()> {
             public_api
                 .merge(optional_auth_api)
                 .merge(authenticated_api)
+                .merge(authenticated_session_api)
                 .merge(message_post_router),
         )
         .fallback(not_found_handler)
@@ -174,8 +215,20 @@ async fn main() -> anyhow::Result<()> {
                     Method::PUT,
                 ])
                 .allow_origin(Any) // todo: allow_originを制限する
-                .allow_headers([CONTENT_TYPE, AUTHORIZATION])
-                .expose_headers([LOCATION, SET_COOKIE]),
+                .allow_headers([
+                    CONTENT_TYPE,
+                    AUTHORIZATION,
+                    HeaderName::from_static("x-seichi-proxy-secret"),
+                    HeaderName::from_static("x-seichi-client-ip"),
+                ])
+                .expose_headers([
+                    LOCATION,
+                    SET_COOKIE,
+                    HeaderName::from_static("retry-after"),
+                    HeaderName::from_static("ratelimit-limit"),
+                    HeaderName::from_static("ratelimit-remaining"),
+                    HeaderName::from_static("ratelimit-reset"),
+                ]),
         )
         .with_state(shared_repository.to_owned());
 
@@ -191,13 +244,16 @@ async fn main() -> anyhow::Result<()> {
 
     let (_discord, _axum, _syncer, _messaging, _auto_of_sync_watcher) = join!(
         discord_connection.pool.start(),
-        axum::serve(listener, app)
-            .with_graceful_shutdown(graceful_handler(
-                shared_manager,
-                messaging_conn.clone(),
-                shutdown_notifier.clone(),
-            ))
-            .into_future(),
+        axum::serve(
+            listener,
+            app.into_make_service_with_connect_info::<SocketAddr>(),
+        )
+        .with_graceful_shutdown(graceful_handler(
+            shared_manager,
+            messaging_conn.clone(),
+            shutdown_notifier.clone(),
+        ))
+        .into_future(),
         start_sync(
             shared_repository.to_owned(),
             receiver,

--- a/server/entrypoint/src/openapi.rs
+++ b/server/entrypoint/src/openapi.rs
@@ -106,10 +106,13 @@ pub fn public_api_router() -> OpenApiRouter<RealInfrastructureRepository> {
 
     OpenApiRouter::new()
         .routes(routes!(answer_handler::post_temporary_answer_handler))
-        .routes(routes!(
-            user_handler::start_session,
-            user_handler::end_session
-        ))
+        .routes(routes!(user_handler::start_session))
+}
+
+pub fn authenticated_session_api_router() -> OpenApiRouter<RealInfrastructureRepository> {
+    use presentation::handlers::user_handler;
+
+    OpenApiRouter::new().routes(routes!(user_handler::end_session))
 }
 
 pub fn optional_auth_api_router() -> OpenApiRouter<RealInfrastructureRepository> {
@@ -229,6 +232,7 @@ pub fn authenticated_api_router() -> OpenApiRouter<RealInfrastructureRepository>
 pub fn versioned_api_router() -> OpenApiRouter<RealInfrastructureRepository> {
     let combined = OpenApiRouter::with_openapi(ManuallyRegisteredApiDoc::openapi())
         .merge(public_api_router())
+        .merge(authenticated_session_api_router())
         .merge(optional_auth_api_router())
         .merge(authenticated_api_router());
     OpenApiRouter::with_openapi(ApiMetadata::openapi()).nest("/api/v1", combined)

--- a/server/infra/resource/src/lib.rs
+++ b/server/infra/resource/src/lib.rs
@@ -3,5 +3,6 @@ pub mod external;
 pub mod health_check;
 pub mod messaging;
 pub mod outgoing;
+pub mod rate_limit;
 pub mod records;
 pub mod repository;

--- a/server/infra/resource/src/rate_limit.rs
+++ b/server/infra/resource/src/rate_limit.rs
@@ -1,0 +1,251 @@
+use std::time::Duration;
+
+use async_trait::async_trait;
+use common::rate_limit::{RateLimitDecision, RateLimitQuota, RateLimitStore, RateLimitStoreError};
+use redis::{Client, ErrorKind, Script, ServerErrorKind, aio::MultiplexedConnection};
+
+const CHECK_SCRIPT: &str = r#"
+local now = tonumber(redis.call('TIME')[1])
+local quota_count = tonumber(ARGV[1])
+local max_retry = 0
+local max_reset = 0
+local min_remaining = nil
+local min_limit = nil
+
+-- Read every counter before changing any of them.  This keeps temporary
+-- answer quotas all-or-nothing when one of the limits has been exhausted.
+for index = 1, quota_count do
+    local arg_index = 2 + ((index - 1) * 2)
+    local limit = tonumber(ARGV[arg_index])
+    local window = tonumber(ARGV[arg_index + 1])
+    local reset = window - (now % window)
+    local window_key = KEYS[index] .. ':' .. tostring(math.floor(now / window))
+    local raw_count = redis.call('GET', window_key)
+    local current = 0
+    if raw_count then
+        current = tonumber(raw_count)
+        if current == nil then
+            return { -1 }
+        end
+    end
+
+    if current >= limit and reset > max_retry then
+        max_retry = reset
+    end
+    if reset > max_reset then
+        max_reset = reset
+    end
+    local remaining = limit - current
+    if min_remaining == nil or remaining < min_remaining then
+        min_remaining = remaining
+        min_limit = limit
+    end
+end
+
+if max_retry > 0 then
+    return { 0, max_retry, 0, min_limit or 0, max_retry }
+end
+
+for index = 1, quota_count do
+    local arg_index = 2 + ((index - 1) * 2)
+    local limit = tonumber(ARGV[arg_index])
+    local window = tonumber(ARGV[arg_index + 1])
+    local reset = window - (now % window)
+    local window_key = KEYS[index] .. ':' .. tostring(math.floor(now / window))
+    local count = redis.call('INCRBY', window_key, 1)
+    redis.call('EXPIRE', window_key, reset)
+    local remaining = limit - count
+    if min_remaining == nil or remaining < min_remaining then
+        min_remaining = remaining
+        min_limit = limit
+    end
+end
+
+return { 1, 0, min_remaining or 0, min_limit or 0, max_reset }
+"#;
+
+const OPERATION_TIMEOUT: Duration = Duration::from_millis(250);
+
+#[derive(Clone, Debug)]
+pub struct ValkeyRateLimitStore {
+    client: Client,
+}
+
+impl ValkeyRateLimitStore {
+    pub fn from_environment() -> Result<Self, RateLimitStoreError> {
+        let host = std::env::var("REDIS_HOST")
+            .map_err(|_| RateLimitStoreError::Invalid("REDIS_HOST is not set".into()))?;
+        let port = std::env::var("REDIS_PORT")
+            .map_err(|_| RateLimitStoreError::Invalid("REDIS_PORT is not set".into()))?;
+        Self::from_url(format!("redis://{host}:{port}/"))
+    }
+
+    pub fn from_url(url: impl Into<String>) -> Result<Self, RateLimitStoreError> {
+        let client = Client::open(url.into())
+            .map_err(|error| RateLimitStoreError::Invalid(error.to_string()))?;
+        Ok(Self { client })
+    }
+
+    async fn connection(&self) -> Result<MultiplexedConnection, RateLimitStoreError> {
+        tokio::time::timeout(
+            OPERATION_TIMEOUT,
+            self.client.get_multiplexed_async_connection(),
+        )
+        .await
+        .map_err(|_| RateLimitStoreError::Unavailable("Valkey connection timed out".into()))?
+        .map_err(|error| RateLimitStoreError::Unavailable(error.to_string()))
+    }
+}
+
+fn classify_redis_error(error: redis::RedisError) -> RateLimitStoreError {
+    let unavailable = matches!(
+        error.kind(),
+        ErrorKind::Io
+            | ErrorKind::ClusterConnectionNotFound
+            | ErrorKind::MasterNameNotFoundBySentinel
+            | ErrorKind::NoValidReplicasFoundBySentinel
+            | ErrorKind::EmptySentinelList
+            | ErrorKind::Server(
+                ServerErrorKind::BusyLoading
+                    | ServerErrorKind::TryAgain
+                    | ServerErrorKind::ClusterDown
+                    | ServerErrorKind::MasterDown
+                    | ServerErrorKind::ReadOnly,
+            )
+    );
+
+    if unavailable {
+        RateLimitStoreError::Unavailable(error.to_string())
+    } else {
+        RateLimitStoreError::Invalid(error.to_string())
+    }
+}
+
+fn validate_quotas(quotas: &[RateLimitQuota]) -> Result<(), RateLimitStoreError> {
+    if quotas.is_empty() {
+        return Err(RateLimitStoreError::Invalid(
+            "at least one quota is required".into(),
+        ));
+    }
+    if quotas
+        .iter()
+        .any(|quota| quota.key.is_empty() || quota.limit == 0 || quota.window_seconds == 0)
+    {
+        return Err(RateLimitStoreError::Invalid(
+            "quota key, limit, and window must be non-zero".into(),
+        ));
+    }
+    if quotas
+        .iter()
+        .enumerate()
+        .any(|(index, quota)| quotas[..index].iter().any(|prior| prior.key == quota.key))
+    {
+        return Err(RateLimitStoreError::Invalid(
+            "quota keys must be unique".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn decision_from_result(result: Vec<i64>) -> Result<RateLimitDecision, RateLimitStoreError> {
+    if result.len() != 5 || !matches!(result[0], 0 | 1) {
+        return Err(RateLimitStoreError::Invalid(
+            "Valkey rate-limit script returned an invalid result".into(),
+        ));
+    }
+
+    let decision = RateLimitDecision {
+        allowed: result[0] == 1,
+        retry_after_seconds: u64::try_from(result[1])
+            .map_err(|_| RateLimitStoreError::Invalid("negative retry-after from Valkey".into()))?,
+        remaining: u64::try_from(result[2]).map_err(|_| {
+            RateLimitStoreError::Invalid("negative remaining count from Valkey".into())
+        })?,
+        limit: u64::try_from(result[3])
+            .map_err(|_| RateLimitStoreError::Invalid("negative limit from Valkey".into()))?,
+        reset_seconds: u64::try_from(result[4])
+            .map_err(|_| RateLimitStoreError::Invalid("negative reset from Valkey".into()))?,
+    };
+
+    let result_is_consistent = decision.limit > 0
+        && decision.reset_seconds > 0
+        && decision.remaining <= decision.limit
+        && if decision.allowed {
+            decision.retry_after_seconds == 0
+        } else {
+            decision.retry_after_seconds > 0 && decision.remaining == 0
+        };
+    if !result_is_consistent {
+        return Err(RateLimitStoreError::Invalid(
+            "Valkey rate-limit script returned inconsistent fields".into(),
+        ));
+    }
+    Ok(decision)
+}
+
+#[async_trait]
+impl RateLimitStore for ValkeyRateLimitStore {
+    async fn check(
+        &self,
+        quotas: &[RateLimitQuota],
+    ) -> Result<RateLimitDecision, RateLimitStoreError> {
+        validate_quotas(quotas)?;
+
+        let mut connection = self.connection().await?;
+        let script = Script::new(CHECK_SCRIPT);
+        let mut invocation = script.prepare_invoke();
+        for quota in quotas {
+            invocation.key(&quota.key);
+        }
+        invocation.arg(quotas.len() as u64);
+        for quota in quotas {
+            invocation.arg(quota.limit).arg(quota.window_seconds);
+        }
+
+        let result: Vec<i64> =
+            tokio::time::timeout(OPERATION_TIMEOUT, invocation.invoke_async(&mut connection))
+                .await
+                .map_err(|_| RateLimitStoreError::Unavailable("Valkey operation timed out".into()))?
+                .map_err(classify_redis_error)?;
+
+        decision_from_result(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{decision_from_result, validate_quotas};
+    use common::rate_limit::RateLimitQuota;
+
+    #[test]
+    fn empty_quota_list_is_rejected_before_valkey() {
+        assert!(validate_quotas(&[]).is_err());
+    }
+
+    #[test]
+    fn duplicate_keys_are_rejected_before_valkey() {
+        let quotas = [
+            RateLimitQuota::new("same", 1, 60),
+            RateLimitQuota::new("same", 2, 60),
+        ];
+        assert!(validate_quotas(&quotas).is_err());
+    }
+
+    #[test]
+    fn unknown_script_decision_flag_is_rejected() {
+        let error = decision_from_result(vec![2, 0, 0, 1, 1]).unwrap_err();
+        assert!(matches!(
+            error,
+            common::rate_limit::RateLimitStoreError::Invalid(_)
+        ));
+    }
+
+    #[test]
+    fn inconsistent_script_decision_fields_are_rejected() {
+        let error = decision_from_result(vec![1, 4, 0, 1, 1]).unwrap_err();
+        assert!(matches!(
+            error,
+            common::rate_limit::RateLimitStoreError::Invalid(_)
+        ));
+    }
+}

--- a/server/infra/resource/tests/rate_limit_valkey.rs
+++ b/server/infra/resource/tests/rate_limit_valkey.rs
@@ -1,0 +1,95 @@
+use std::time::Duration;
+
+use common::rate_limit::{RateLimitQuota, RateLimitStore};
+use resource::rate_limit::ValkeyRateLimitStore;
+use uuid::Uuid;
+
+fn test_key(name: &str) -> String {
+    format!("rl:integration:{}:{name}", Uuid::new_v4())
+}
+
+/// Run this test with a real Valkey instance:
+///
+/// `RATE_LIMIT_VALKEY_URL=redis://127.0.0.1:6379/ cargo test -p resource --test rate_limit_valkey -- --ignored`
+#[tokio::test]
+#[ignore = "requires a Valkey instance; executed by the CI Valkey job"]
+async fn valkey_rate_limit_is_atomic_shared_and_fixed_window() {
+    let url = std::env::var("RATE_LIMIT_VALKEY_URL")
+        .expect("RATE_LIMIT_VALKEY_URL must be set for the Valkey integration test");
+    let first_store = ValkeyRateLimitStore::from_url(url.clone()).unwrap();
+    let second_store = ValkeyRateLimitStore::from_url(url).unwrap();
+
+    // Separate store instances observe the same shared counter.
+    let shared_key = test_key("shared");
+    let quota = RateLimitQuota::new(shared_key, 2, 60);
+    assert!(
+        first_store
+            .check(std::slice::from_ref(&quota))
+            .await
+            .unwrap()
+            .allowed
+    );
+    let second = second_store
+        .check(std::slice::from_ref(&quota))
+        .await
+        .unwrap();
+    assert!(second.allowed);
+    assert_eq!(second.remaining, 0);
+    assert!(
+        !first_store
+            .check(std::slice::from_ref(&quota))
+            .await
+            .unwrap()
+            .allowed
+    );
+
+    // If one temporary quota is exhausted, the other quota is not consumed.
+    let exhausted_key = test_key("exhausted");
+    let untouched_key = test_key("untouched");
+    let exhausted = RateLimitQuota::new(exhausted_key, 1, 60);
+    let untouched = RateLimitQuota::new(untouched_key, 1, 60);
+    assert!(
+        first_store
+            .check(std::slice::from_ref(&exhausted))
+            .await
+            .unwrap()
+            .allowed
+    );
+    let denied = first_store
+        .check(&[exhausted.clone(), untouched.clone()])
+        .await
+        .unwrap();
+    assert!(!denied.allowed);
+    assert!(
+        first_store
+            .check(std::slice::from_ref(&untouched))
+            .await
+            .unwrap()
+            .allowed
+    );
+
+    // The server-side fixed-window decision includes a positive retry TTL and
+    // permits a new request after the window has elapsed.
+    let window_quota = RateLimitQuota::new(test_key("window"), 1, 2);
+    assert!(
+        first_store
+            .check(std::slice::from_ref(&window_quota))
+            .await
+            .unwrap()
+            .allowed
+    );
+    let denied = first_store
+        .check(std::slice::from_ref(&window_quota))
+        .await
+        .unwrap();
+    assert!(!denied.allowed);
+    assert!(denied.retry_after_seconds > 0);
+    tokio::time::sleep(Duration::from_secs(denied.retry_after_seconds + 1)).await;
+    assert!(
+        first_store
+            .check(std::slice::from_ref(&window_quota))
+            .await
+            .unwrap()
+            .allowed
+    );
+}

--- a/server/presentation/src/lib.rs
+++ b/server/presentation/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod api;
 pub mod auth;
 pub mod handlers;
+pub mod rate_limit;
 pub mod schemas;

--- a/server/presentation/src/rate_limit.rs
+++ b/server/presentation/src/rate_limit.rs
@@ -1,0 +1,515 @@
+use std::{
+    net::{IpAddr, SocketAddr},
+    sync::Arc,
+};
+
+use crate::schemas::error_response::ErrorResponse;
+use axum::{
+    body::Body,
+    extract::{ConnectInfo, State},
+    http::{HeaderMap, HeaderValue, Method, Request, StatusCode, header},
+    middleware::Next,
+    response::{IntoResponse, Response},
+};
+use common::rate_limit::{RateLimitDecision, RateLimitQuota, RateLimitStore, RateLimitStoreError};
+use domain::{account::models::AccountUser, auth::Actor};
+use uuid::Uuid;
+
+const API_PREFIX: &str = "/api/v1";
+const ANONYMOUS_GET_LIMIT: u64 = 60;
+const AUTHENTICATED_GET_LIMIT: u64 = 600;
+const AUTHENTICATED_WRITE_LIMIT: u64 = 120;
+const TEMPORARY_IP_HOURLY_LIMIT: u64 = 30;
+const TEMPORARY_FORM_HOURLY_LIMIT: u64 = 10;
+const TEMPORARY_IP_BURST_LIMIT: u64 = 5;
+const SESSION_CREATE_IP_HOURLY_LIMIT: u64 = 10;
+const MINUTE: u64 = 60;
+const HOUR: u64 = 60 * MINUTE;
+
+pub const PROXY_SECRET_HEADER: &str = "x-seichi-proxy-secret";
+pub const CLIENT_IP_HEADER: &str = "x-seichi-client-ip";
+
+#[derive(Clone)]
+pub struct RateLimitState {
+    pub store: Arc<dyn RateLimitStore>,
+    pub proxy_secret: Option<String>,
+}
+
+impl RateLimitState {
+    pub fn new(store: Arc<dyn RateLimitStore>, proxy_secret: Option<String>) -> Self {
+        Self {
+            store,
+            proxy_secret: proxy_secret.filter(|secret| !secret.is_empty()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RateLimitIdentity {
+    User(String),
+    Ip(IpAddr),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClientIpResolution {
+    Canonical(IpAddr),
+    TcpPeer(IpAddr),
+    Unavailable,
+}
+
+/// Resolve the address that may be used for an anonymous quota.  A proxy
+/// address is trusted only when both the configured shared secret and a
+/// syntactically valid client IP are present.
+pub fn resolve_client_ip(
+    headers: &HeaderMap,
+    tcp_peer: Option<IpAddr>,
+    proxy_secret: Option<&str>,
+) -> ClientIpResolution {
+    let trusted_proxy = proxy_secret.is_some_and(|expected| {
+        headers
+            .get(PROXY_SECRET_HEADER)
+            .and_then(|value| value.to_str().ok())
+            .is_some_and(|actual| actual == expected)
+    });
+
+    if trusted_proxy
+        && let Some(ip) = headers
+            .get(CLIENT_IP_HEADER)
+            .and_then(|value| value.to_str().ok())
+            .and_then(|value| value.parse::<IpAddr>().ok())
+    {
+        return ClientIpResolution::Canonical(ip);
+    }
+
+    tcp_peer
+        .map(ClientIpResolution::TcpPeer)
+        .unwrap_or(ClientIpResolution::Unavailable)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RateLimitPlan {
+    AnonymousGet { ip: IpAddr },
+    AuthenticatedGet { user_id: String },
+    AuthenticatedWrite { user_id: String },
+    TemporaryAnswer { ip: IpAddr, form_id: Uuid },
+    SessionCreate { ip: IpAddr },
+    Skip,
+}
+
+impl RateLimitPlan {
+    fn label(&self) -> &'static str {
+        match self {
+            Self::AnonymousGet { .. } => "anonymous_get",
+            Self::AuthenticatedGet { .. } => "authenticated_get",
+            Self::AuthenticatedWrite { .. } => "authenticated_write",
+            Self::TemporaryAnswer { .. } => "temporary_answer",
+            Self::SessionCreate { .. } => "session_create",
+            Self::Skip => "skip",
+        }
+    }
+
+    fn quotas(&self) -> Vec<RateLimitQuota> {
+        match self {
+            Self::AnonymousGet { ip } => {
+                vec![RateLimitQuota::new(
+                    format!("rl:v1:anon:get:{ip}"),
+                    ANONYMOUS_GET_LIMIT,
+                    MINUTE,
+                )]
+            }
+            Self::AuthenticatedGet { user_id } => {
+                vec![RateLimitQuota::new(
+                    format!("rl:v1:user:get:{user_id}"),
+                    AUTHENTICATED_GET_LIMIT,
+                    MINUTE,
+                )]
+            }
+            Self::AuthenticatedWrite { user_id } => {
+                vec![RateLimitQuota::new(
+                    format!("rl:v1:user:write:{user_id}"),
+                    AUTHENTICATED_WRITE_LIMIT,
+                    MINUTE,
+                )]
+            }
+            Self::TemporaryAnswer { ip, form_id } => vec![
+                RateLimitQuota::new(
+                    format!("rl:v1:temporary:ip:{ip}"),
+                    TEMPORARY_IP_HOURLY_LIMIT,
+                    HOUR,
+                ),
+                RateLimitQuota::new(
+                    format!("rl:v1:temporary:form:{ip}:{form_id}"),
+                    TEMPORARY_FORM_HOURLY_LIMIT,
+                    HOUR,
+                ),
+                RateLimitQuota::new(
+                    format!("rl:v1:temporary:burst:{ip}"),
+                    TEMPORARY_IP_BURST_LIMIT,
+                    10 * MINUTE,
+                ),
+            ],
+            Self::SessionCreate { ip } => vec![RateLimitQuota::new(
+                format!("rl:v1:session:create:{ip}"),
+                SESSION_CREATE_IP_HOURLY_LIMIT,
+                HOUR,
+            )],
+            Self::Skip => Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RateLimitPolicyError {
+    MissingAuthenticatedIdentity,
+}
+
+/// Pure route policy calculation.  The middleware deliberately receives the
+/// identity only after auth/optional-auth has run, so invalid credentials keep
+/// their existing 401 response and never consume a user quota.
+pub fn policy_for(
+    method: &Method,
+    path: &str,
+    identity: Option<&RateLimitIdentity>,
+) -> Result<RateLimitPlan, RateLimitPolicyError> {
+    if *method == Method::OPTIONS {
+        return Ok(RateLimitPlan::Skip);
+    }
+
+    // `Router::nest` strips its prefix from the request URI before invoking a
+    // route-layer middleware.  Unit tests and callers outside that nest may
+    // still provide the full versioned path, so accept both representations.
+    let path = if path == API_PREFIX {
+        "/"
+    } else if let Some(stripped) = path.strip_prefix(API_PREFIX) {
+        if stripped.starts_with('/') {
+            stripped
+        } else {
+            // Do not treat a similarly-prefixed endpoint such as `/api/v10`
+            // as part of this API.
+            return Ok(RateLimitPlan::Skip);
+        }
+    } else if path.starts_with('/') {
+        path
+    } else {
+        return Ok(RateLimitPlan::Skip);
+    };
+    let segments = path
+        .split('/')
+        .filter(|segment| !segment.is_empty())
+        .collect::<Vec<_>>();
+
+    if *method == Method::GET
+        && segments.first() == Some(&"forms")
+        && (segments.len() == 1 || segments.len() == 2)
+    {
+        return Ok(match identity {
+            Some(RateLimitIdentity::User(user_id)) => RateLimitPlan::AuthenticatedGet {
+                user_id: user_id.clone(),
+            },
+            Some(RateLimitIdentity::Ip(ip)) => RateLimitPlan::AnonymousGet { ip: *ip },
+            None => RateLimitPlan::Skip,
+        });
+    }
+
+    if *method == Method::POST
+        && segments.len() == 3
+        && segments[0] == "forms"
+        && segments[2] == "temporary-answers"
+    {
+        return Ok(match identity {
+            Some(RateLimitIdentity::Ip(ip)) => RateLimitPlan::TemporaryAnswer {
+                ip: *ip,
+                form_id: match Uuid::parse_str(segments[1]) {
+                    Ok(form_id) => form_id,
+                    Err(_) => return Ok(RateLimitPlan::Skip),
+                },
+            },
+            _ => RateLimitPlan::Skip,
+        });
+    }
+
+    if segments == ["session"] {
+        return match *method {
+            Method::POST => Ok(match identity {
+                Some(RateLimitIdentity::Ip(ip)) => RateLimitPlan::SessionCreate { ip: *ip },
+                _ => RateLimitPlan::Skip,
+            }),
+            Method::DELETE => match identity {
+                Some(RateLimitIdentity::User(user_id)) => Ok(RateLimitPlan::AuthenticatedWrite {
+                    user_id: user_id.clone(),
+                }),
+                _ => Err(RateLimitPolicyError::MissingAuthenticatedIdentity),
+            },
+            _ => Ok(RateLimitPlan::Skip),
+        };
+    }
+
+    if let Some(RateLimitIdentity::User(user_id)) = identity {
+        return Ok(if *method == Method::GET {
+            RateLimitPlan::AuthenticatedGet {
+                user_id: user_id.clone(),
+            }
+        } else {
+            RateLimitPlan::AuthenticatedWrite {
+                user_id: user_id.clone(),
+            }
+        });
+    }
+
+    Ok(RateLimitPlan::Skip)
+}
+
+fn identity_from_request(
+    request: &Request<Body>,
+    proxy_secret: Option<&str>,
+) -> (Option<RateLimitIdentity>, bool) {
+    if let Some(user) = request.extensions().get::<AccountUser>() {
+        return (Some(RateLimitIdentity::User(user.id().to_string())), false);
+    }
+    if let Some(actor) = request.extensions().get::<Actor>()
+        && let Actor::AccountUser(user) = actor
+    {
+        return (Some(RateLimitIdentity::User(user.id().to_string())), false);
+    }
+
+    let tcp_peer = request
+        .extensions()
+        .get::<ConnectInfo<SocketAddr>>()
+        .map(|connect_info| connect_info.0.ip());
+    match resolve_client_ip(request.headers(), tcp_peer, proxy_secret) {
+        ClientIpResolution::Canonical(ip) | ClientIpResolution::TcpPeer(ip) => {
+            (Some(RateLimitIdentity::Ip(ip)), false)
+        }
+        ClientIpResolution::Unavailable => (None, true),
+    }
+}
+
+fn problem_response(status: StatusCode, detail: &str, error_code: &str) -> Response {
+    (
+        status,
+        [(header::CONTENT_TYPE, "application/problem+json")],
+        axum::Json(ErrorResponse {
+            problem_type: "about:blank".to_owned(),
+            title: if status == StatusCode::TOO_MANY_REQUESTS {
+                "Too Many Requests".to_owned()
+            } else {
+                "Internal Server Error".to_owned()
+            },
+            status: status.as_u16(),
+            detail: detail.to_owned(),
+            error_code: error_code.to_owned(),
+            restriction: None,
+        }),
+    )
+        .into_response()
+}
+
+fn set_rate_limit_headers(response: &mut Response, decision: RateLimitDecision) {
+    let retry_after = decision.retry_after_seconds.max(1);
+    let reset = if decision.allowed {
+        decision.reset_seconds.max(1)
+    } else {
+        retry_after
+    };
+    let headers = response.headers_mut();
+    if let Ok(value) = HeaderValue::from_str(&decision.limit.to_string()) {
+        headers.insert("ratelimit-limit", value);
+    }
+    if let Ok(value) = HeaderValue::from_str(&decision.remaining.to_string()) {
+        headers.insert("ratelimit-remaining", value);
+    }
+    if let Ok(value) = HeaderValue::from_str(&reset.to_string()) {
+        headers.insert("ratelimit-reset", value);
+    }
+    if !decision.allowed
+        && let Ok(value) = HeaderValue::from_str(&retry_after.to_string())
+    {
+        headers.insert(header::RETRY_AFTER, value);
+    }
+}
+
+pub async fn middleware(
+    State(state): State<RateLimitState>,
+    request: Request<Body>,
+    next: Next,
+) -> Response {
+    let (identity, ip_unavailable) = identity_from_request(&request, state.proxy_secret.as_deref());
+    let plan = match policy_for(request.method(), request.uri().path(), identity.as_ref()) {
+        Ok(plan) => plan,
+        Err(RateLimitPolicyError::MissingAuthenticatedIdentity) => {
+            tracing::error!("rate-limit route requires an authenticated identity");
+            return problem_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Rate-limit identity could not be resolved.",
+                "INTERNAL_SERVER_ERROR",
+            );
+        }
+    };
+
+    if ip_unavailable {
+        tracing::warn!(
+            plan = plan.label(),
+            "rate limiting skipped because client IP is unavailable"
+        );
+    }
+
+    if matches!(plan, RateLimitPlan::Skip) {
+        return next.run(request).await;
+    }
+
+    let label = plan.label();
+    let quotas = plan.quotas();
+    let decision = match state.store.check(&quotas).await {
+        Ok(decision) => decision,
+        Err(RateLimitStoreError::Unavailable(error)) => {
+            tracing::warn!(plan = label, error = %error, "Valkey unavailable; rate limiting failed open");
+            return next.run(request).await;
+        }
+        Err(RateLimitStoreError::Invalid(error)) => {
+            tracing::error!(plan = label, error = %error, "invalid rate-limit store response");
+            return problem_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Rate-limit store returned an invalid response.",
+                "INTERNAL_SERVER_ERROR",
+            );
+        }
+    };
+
+    if !decision.allowed {
+        tracing::warn!(plan = label, "rate limit exceeded");
+        let mut response = problem_response(
+            StatusCode::TOO_MANY_REQUESTS,
+            "Request rate limit exceeded.",
+            "RATE_LIMIT_EXCEEDED",
+        );
+        set_rate_limit_headers(&mut response, decision);
+        return response;
+    }
+
+    let mut response = next.run(request).await;
+    set_rate_limit_headers(&mut response, decision);
+    response
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::IpAddr;
+
+    fn ip(value: &str) -> IpAddr {
+        value.parse().unwrap()
+    }
+
+    #[test]
+    fn proxy_ip_requires_matching_secret() {
+        let mut headers = HeaderMap::new();
+        headers.insert(PROXY_SECRET_HEADER, HeaderValue::from_static("secret"));
+        headers.insert(CLIENT_IP_HEADER, HeaderValue::from_static("203.0.113.4"));
+
+        assert_eq!(
+            resolve_client_ip(&headers, Some(ip("192.0.2.1")), Some("secret")),
+            ClientIpResolution::Canonical(ip("203.0.113.4"))
+        );
+        assert_eq!(
+            resolve_client_ip(&headers, Some(ip("192.0.2.1")), Some("wrong")),
+            ClientIpResolution::TcpPeer(ip("192.0.2.1"))
+        );
+        assert_eq!(
+            resolve_client_ip(&headers, Some(ip("192.0.2.1")), None),
+            ClientIpResolution::TcpPeer(ip("192.0.2.1"))
+        );
+    }
+
+    #[test]
+    fn malformed_proxy_ip_uses_tcp_peer() {
+        let mut headers = HeaderMap::new();
+        headers.insert(PROXY_SECRET_HEADER, HeaderValue::from_static("secret"));
+        headers.insert(CLIENT_IP_HEADER, HeaderValue::from_static("not-an-ip"));
+        assert_eq!(
+            resolve_client_ip(&headers, Some(ip("192.0.2.1")), Some("secret")),
+            ClientIpResolution::TcpPeer(ip("192.0.2.1"))
+        );
+    }
+
+    #[test]
+    fn temporary_answer_has_only_temporary_quotas() {
+        let form_id = "018F4F37-2F5E-7B9A-8B39-9A2F2695D7AD";
+        let canonical_form_id = form_id.to_ascii_lowercase();
+        let plan = policy_for(
+            &Method::POST,
+            &format!("/api/v1/forms/{form_id}/temporary-answers"),
+            Some(&RateLimitIdentity::Ip(ip("192.0.2.1"))),
+        )
+        .unwrap();
+        assert_eq!(plan.label(), "temporary_answer");
+        assert_eq!(plan.quotas().len(), 3);
+        assert!(
+            plan.quotas()
+                .iter()
+                .any(|quota| quota.key.contains(&canonical_form_id))
+        );
+    }
+
+    #[test]
+    fn nested_router_stripped_form_path_still_gets_anonymous_quota() {
+        let plan = policy_for(
+            &Method::GET,
+            "/forms",
+            Some(&RateLimitIdentity::Ip(ip("192.0.2.1"))),
+        )
+        .unwrap();
+        assert_eq!(plan.label(), "anonymous_get");
+    }
+
+    #[test]
+    fn nested_router_stripped_temporary_path_still_gets_temporary_quota() {
+        let plan = policy_for(
+            &Method::POST,
+            "/forms/018f4f37-2f5e-7b9a-8b39-9a2f2695d7ad/temporary-answers",
+            Some(&RateLimitIdentity::Ip(ip("192.0.2.1"))),
+        )
+        .unwrap();
+        assert_eq!(plan.label(), "temporary_answer");
+    }
+
+    #[test]
+    fn nested_router_stripped_authenticated_path_uses_user_quota() {
+        let plan = policy_for(
+            &Method::GET,
+            "/users",
+            Some(&RateLimitIdentity::User("user-id".to_owned())),
+        )
+        .unwrap();
+        assert_eq!(plan.label(), "authenticated_get");
+    }
+
+    #[test]
+    fn invalid_temporary_form_id_does_not_create_a_key() {
+        let plan = policy_for(
+            &Method::POST,
+            "/api/v1/forms/not-a-uuid/temporary-answers",
+            Some(&RateLimitIdentity::Ip(ip("192.0.2.1"))),
+        )
+        .unwrap();
+        assert_eq!(plan, RateLimitPlan::Skip);
+    }
+
+    #[test]
+    fn authenticated_delete_session_uses_user_quota() {
+        let plan = policy_for(
+            &Method::DELETE,
+            "/api/v1/session",
+            Some(&RateLimitIdentity::User("user-id".to_owned())),
+        )
+        .unwrap();
+        assert_eq!(plan.label(), "authenticated_write");
+    }
+
+    #[test]
+    fn delete_session_without_user_is_an_error() {
+        assert_eq!(
+            policy_for(&Method::DELETE, "/api/v1/session", None),
+            Err(RateLimitPolicyError::MissingAuthenticatedIdentity)
+        );
+    }
+}


### PR DESCRIPTION
## 概要
- Issue #1313 に対応し、Valkey の Lua スクリプトを使った Pod 間共有の fixed-window レート制限を追加
- 匿名リクエストは検証済みのプロキシ IP または TCP peer、認証済みリクエストはユーザー ID で制限
- 429 Problem Details、Retry-After / RateLimit ヘッダー、Valkey 障害時の fail-open を実装

Closes #1313

## 確認事項
- `cargo build` 成功
- `cargo test --all-features` 成功（249 tests passed、Valkey 実機テスト 1 件は ignored）
- `makers pretty` 成功（clippy、nextest、doctest、fmt）
- OpenAPI 生成後の `docs/openapi.json` 差分なし
- `git diff --check` 成功
- CI に Valkey service と専用 integration test を追加し、Pod 間共有・atomic quota・fixed window を検証

## 補足
- ローカル環境には Valkey 実機がないため integration test は未実行。CI の Valkey service 上で実行する構成です。
- Axum `nest` 内の stripped URI と Valkey スクリプト応答の不正値もテスト・検証対象に含めています。

🤖 Generated with Codex