### PR TITLE
feat: 公開投稿系APIにTurnstile検証を追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,13 @@ MINECRAFT_BANS_DATABASE_URL=mysql://user:password@localhost:3306/seichi_portal
 HTTP_PORT=9000
 FRONTEND_URL=http://localhost:3000
 
+# Turnstile は public API のセッション作成と一時回答を保護します。
+# 無効にする場合も TURNSTILE_ENABLED は明示的に設定してください。
+TURNSTILE_ENABLED=false
+# TURNSTILE_SECRET_KEY=
+# カンマ区切りの完全一致ホスト名。ワイルドカードは使いません。
+# TURNSTILE_ALLOWED_HOSTNAMES=localhost
+
 ENV_NAME=local
 
 REDIS_HOST=localhost

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2939,6 +2939,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tower",
  "tracing",
  "types",
  "usecase",

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2908,6 +2908,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "X-Seichi-Turnstile-Token",
+            "in": "header",
+            "description": "Cloudflare Turnstile token",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
@@ -2966,6 +2975,16 @@
           },
           "500": {
             "description": "Server error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "The server is temporarily unable to handle the request.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -4339,6 +4358,17 @@
         ],
         "summary": "セッションを作成する",
         "operationId": "start_session",
+        "parameters": [
+          {
+            "name": "X-Seichi-Turnstile-Token",
+            "in": "header",
+            "description": "Cloudflare Turnstile token",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -4373,6 +4403,16 @@
               }
             }
           },
+          "403": {
+            "description": "Access is forbidden.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
           "404": {
             "description": "The server cannot find the requested resource.",
             "content": {
@@ -4395,6 +4435,16 @@
           },
           "500": {
             "description": "Server error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "The server is temporarily unable to handle the request.",
             "content": {
               "application/problem+json": {
                 "schema": {

--- a/server/common/src/lib.rs
+++ b/server/common/src/lib.rs
@@ -2,3 +2,4 @@ pub mod config;
 pub mod rate_limit;
 pub mod retry;
 pub mod test_utils;
+pub mod turnstile;

--- a/server/common/src/turnstile.rs
+++ b/server/common/src/turnstile.rs
@@ -1,0 +1,25 @@
+use async_trait::async_trait;
+
+/// Siteverify のレスポンスを、外部 API の DTO ではなく検証結果として表す。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TurnstileVerification {
+    Accepted {
+        action: Option<String>,
+        hostname: Option<String>,
+    },
+    Rejected,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TurnstileVerificationError {
+    Unavailable,
+    InvalidResponse,
+}
+
+#[async_trait]
+pub trait TurnstileVerifier: Send + Sync {
+    async fn verify(
+        &self,
+        token: &str,
+    ) -> Result<TurnstileVerification, TurnstileVerificationError>;
+}

--- a/server/entrypoint/src/lib.rs
+++ b/server/entrypoint/src/lib.rs
@@ -3,3 +3,4 @@ pub mod openapi;
 pub mod panic_hook;
 pub mod profiling;
 pub mod telemetry;
+pub mod turnstile;

--- a/server/entrypoint/src/main.rs
+++ b/server/entrypoint/src/main.rs
@@ -13,7 +13,7 @@ use axum::{
 use axum_tracing_opentelemetry::middleware::{OtelAxumLayer, OtelInResponseLayer};
 use common::config::{ENV, HTTP};
 use domain::search::models::SearchableFieldsWithOperation;
-use entrypoint::{logging, openapi, panic_hook, profiling, telemetry};
+use entrypoint::{logging, openapi, panic_hook, profiling, telemetry, turnstile::TurnstileConfig};
 use futures::join;
 use hyper::header::SET_COOKIE;
 use opentelemetry::trace::TracerProvider as _;
@@ -27,7 +27,9 @@ use presentation::handlers::search_handler::{
     initialize_search_engine, start_sync, start_watch_out_of_sync,
 };
 use presentation::rate_limit::{RateLimitState, middleware as rate_limit_middleware};
+use presentation::turnstile::{TurnstileState, middleware as turnstile_middleware};
 use resource::rate_limit::ValkeyRateLimitStore;
+use resource::turnstile::TurnstileSiteverifyClient;
 use resource::{database::connection::ConnectionPool, repository::Repository};
 use serde_json::json;
 use serenity::all::ShardManager;
@@ -46,6 +48,7 @@ use utoipa_swagger_ui::SwaggerUi;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    let turnstile_config = TurnstileConfig::from_environment()?;
     let tracer_provider = telemetry::init_tracer_provider();
 
     // SQL 文の出力 (bind 値を含みうる) はログへ出さない
@@ -111,6 +114,16 @@ async fn main() -> anyhow::Result<()> {
         })?);
     let proxy_secret = std::env::var("SEICHI_PROXY_SECRET").ok();
     let rate_limit_state = RateLimitState::new(rate_limit_store, proxy_secret);
+    let turnstile_state = match turnstile_config {
+        TurnstileConfig::Disabled => TurnstileState::disabled(),
+        TurnstileConfig::Enabled {
+            secret_key,
+            allowed_hostnames,
+        } => TurnstileState::enabled(
+            Arc::new(TurnstileSiteverifyClient::new(secret_key)),
+            allowed_hostnames,
+        ),
+    };
 
     let discord_sender = resource::outgoing::connection::ConnectionPool::new().await;
     let notificator = DiscordNotificator::new(discord_sender, shared_repository.to_owned());
@@ -182,10 +195,16 @@ async fn main() -> anyhow::Result<()> {
     let (public_api, _) = openapi::public_api_router()
         .with_state(shared_repository.to_owned())
         .split_for_parts();
-    let public_api = public_api.route_layer(middleware::from_fn_with_state(
-        rate_limit_state,
-        rate_limit_middleware,
-    ));
+    let public_api = public_api
+        // route_layer は後から追加した layer が外側になるため、rate limit -> Turnstile -> handler の順にする。
+        .route_layer(middleware::from_fn_with_state(
+            turnstile_state,
+            turnstile_middleware,
+        ))
+        .route_layer(middleware::from_fn_with_state(
+            rate_limit_state,
+            rate_limit_middleware,
+        ));
 
     let app = Router::new()
         .merge(SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", openapi))
@@ -220,6 +239,7 @@ async fn main() -> anyhow::Result<()> {
                     AUTHORIZATION,
                     HeaderName::from_static("x-seichi-proxy-secret"),
                     HeaderName::from_static("x-seichi-client-ip"),
+                    HeaderName::from_static("x-seichi-turnstile-token"),
                 ])
                 .expose_headers([
                     LOCATION,

--- a/server/entrypoint/src/turnstile.rs
+++ b/server/entrypoint/src/turnstile.rs
@@ -1,0 +1,127 @@
+use std::{collections::HashSet, env};
+
+use anyhow::Result;
+
+pub enum TurnstileConfig {
+    Disabled,
+    Enabled {
+        secret_key: String,
+        allowed_hostnames: HashSet<String>,
+    },
+}
+
+impl TurnstileConfig {
+    pub fn from_environment() -> Result<Self> {
+        let enabled = env::var("TURNSTILE_ENABLED").ok();
+        let secret_key = env::var("TURNSTILE_SECRET_KEY").ok();
+        let allowed_hostnames = env::var("TURNSTILE_ALLOWED_HOSTNAMES").ok();
+
+        Self::from_values(
+            enabled.as_deref(),
+            secret_key.as_deref(),
+            allowed_hostnames.as_deref(),
+        )
+    }
+
+    fn from_values(
+        enabled: Option<&str>,
+        secret_key: Option<&str>,
+        allowed_hostnames: Option<&str>,
+    ) -> Result<Self> {
+        let enabled = enabled.ok_or_else(|| anyhow::anyhow!("TURNSTILE_ENABLED is not set"))?;
+        let enabled = enabled
+            .parse::<bool>()
+            .map_err(|_| anyhow::anyhow!("TURNSTILE_ENABLED must be true or false"))?;
+
+        if !enabled {
+            return Ok(Self::Disabled);
+        }
+
+        let secret_key = secret_key
+            .filter(|secret_key| !secret_key.is_empty())
+            .ok_or_else(|| {
+                anyhow::anyhow!("TURNSTILE_SECRET_KEY is required when Turnstile is enabled")
+            })?;
+        let allowed_hostnames = allowed_hostnames
+            .map(parse_allowed_hostnames)
+            .transpose()?
+            .filter(|allowed_hostnames| !allowed_hostnames.is_empty())
+            .ok_or_else(|| {
+                anyhow::anyhow!("TURNSTILE_ALLOWED_HOSTNAMES is required when Turnstile is enabled")
+            })?;
+
+        Ok(Self::Enabled {
+            secret_key: secret_key.to_owned(),
+            allowed_hostnames,
+        })
+    }
+}
+
+fn parse_allowed_hostnames(value: &str) -> Result<HashSet<String>> {
+    let hostnames: HashSet<String> = value
+        .split(',')
+        .map(str::trim)
+        .filter(|hostname| !hostname.is_empty())
+        .map(str::to_ascii_lowercase)
+        .collect();
+
+    if hostnames.iter().any(|hostname| hostname.contains('*')) {
+        anyhow::bail!(
+            "TURNSTILE_ALLOWED_HOSTNAMES must contain exact hostnames; wildcard is not supported"
+        );
+    }
+
+    Ok(hostnames)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn enabled_must_be_present_and_boolean() {
+        assert!(TurnstileConfig::from_values(None, None, None).is_err());
+        assert!(TurnstileConfig::from_values(Some("maybe"), None, None).is_err());
+    }
+
+    #[test]
+    fn disabled_does_not_require_secret_or_hostnames() {
+        assert!(matches!(
+            TurnstileConfig::from_values(Some("false"), None, None),
+            Ok(TurnstileConfig::Disabled)
+        ));
+    }
+
+    #[test]
+    fn enabled_requires_secret_and_hostnames() {
+        assert!(TurnstileConfig::from_values(Some("true"), None, Some("example.com")).is_err());
+        assert!(TurnstileConfig::from_values(Some("true"), Some("secret"), None).is_err());
+        assert!(TurnstileConfig::from_values(Some("true"), Some("secret"), Some(", ")).is_err());
+        assert!(
+            TurnstileConfig::from_values(Some("true"), Some("secret"), Some("*.example.com"))
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn enabled_normalizes_a_comma_separated_hostname_list() {
+        let TurnstileConfig::Enabled {
+            secret_key,
+            allowed_hostnames,
+        } = TurnstileConfig::from_values(
+            Some("true"),
+            Some("secret"),
+            Some(" Example.COM,localhost,example.com "),
+        )
+        .unwrap()
+        else {
+            panic!("expected enabled Turnstile config");
+        };
+
+        assert_eq!(secret_key, "secret");
+        assert_eq!(
+            allowed_hostnames,
+            HashSet::from(["example.com".to_owned(), "localhost".to_owned()])
+        );
+    }
+}

--- a/server/infra/resource/src/lib.rs
+++ b/server/infra/resource/src/lib.rs
@@ -6,3 +6,4 @@ pub mod outgoing;
 pub mod rate_limit;
 pub mod records;
 pub mod repository;
+pub mod turnstile;

--- a/server/infra/resource/src/turnstile.rs
+++ b/server/infra/resource/src/turnstile.rs
@@ -1,0 +1,244 @@
+use std::time::Duration;
+
+use common::turnstile::{TurnstileVerification, TurnstileVerificationError, TurnstileVerifier};
+use serde::{Deserialize, Serialize};
+
+use crate::outgoing::http::HTTP_CLIENT;
+
+pub const SITEVERIFY_URL: &str = "https://challenges.cloudflare.com/turnstile/v0/siteverify";
+const SITEVERIFY_TIMEOUT: Duration = Duration::from_secs(3);
+
+pub struct TurnstileSiteverifyClient {
+    secret_key: String,
+    siteverify_url: String,
+}
+
+impl TurnstileSiteverifyClient {
+    pub fn new(secret_key: String) -> Self {
+        Self::with_siteverify_url(secret_key, SITEVERIFY_URL)
+    }
+
+    /// Siteverify の送信先を差し替えられるため、外部 API 境界をローカルで検証できる。
+    pub fn with_siteverify_url(secret_key: String, siteverify_url: impl Into<String>) -> Self {
+        Self {
+            secret_key,
+            siteverify_url: siteverify_url.into(),
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct SiteverifyRequest<'a> {
+    secret: &'a str,
+    response: &'a str,
+}
+
+#[derive(Deserialize)]
+struct SiteverifyResponse {
+    success: bool,
+    #[serde(default, rename = "error-codes")]
+    error_codes: Vec<String>,
+    action: Option<String>,
+    hostname: Option<String>,
+}
+
+fn is_token_rejection(code: &str) -> bool {
+    matches!(
+        code,
+        "missing-input-response" | "invalid-input-response" | "timeout-or-duplicate"
+    )
+}
+
+fn is_service_failure(code: &str) -> bool {
+    matches!(
+        code,
+        "missing-input-secret" | "invalid-input-secret" | "bad-request" | "internal-error"
+    )
+}
+
+fn classify_siteverify_response(
+    response: SiteverifyResponse,
+) -> Result<TurnstileVerification, TurnstileVerificationError> {
+    if response.success {
+        return Ok(TurnstileVerification::Accepted {
+            action: response.action,
+            hostname: response.hostname,
+        });
+    }
+
+    if response.error_codes.is_empty()
+        || response
+            .error_codes
+            .iter()
+            .any(|code| is_service_failure(code))
+        || response
+            .error_codes
+            .iter()
+            .any(|code| !is_token_rejection(code))
+    {
+        return Err(TurnstileVerificationError::Unavailable);
+    }
+
+    Ok(TurnstileVerification::Rejected)
+}
+
+#[async_trait::async_trait]
+impl TurnstileVerifier for TurnstileSiteverifyClient {
+    async fn verify(
+        &self,
+        token: &str,
+    ) -> Result<TurnstileVerification, TurnstileVerificationError> {
+        let response = HTTP_CLIENT
+            .post(&self.siteverify_url)
+            .timeout(SITEVERIFY_TIMEOUT)
+            .json(&SiteverifyRequest {
+                secret: &self.secret_key,
+                response: token,
+            })
+            .send()
+            .await
+            .map_err(|_| TurnstileVerificationError::Unavailable)?
+            .error_for_status()
+            .map_err(|_| TurnstileVerificationError::Unavailable)?;
+
+        let response = response
+            .json::<SiteverifyResponse>()
+            .await
+            .map_err(|_| TurnstileVerificationError::InvalidResponse)?;
+
+        classify_siteverify_response(response)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::SocketAddr;
+
+    use common::turnstile::TurnstileVerifier;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    use super::*;
+
+    fn response(success: bool, error_codes: &[&str]) -> SiteverifyResponse {
+        SiteverifyResponse {
+            success,
+            error_codes: error_codes.iter().map(|code| (*code).to_owned()).collect(),
+            action: None,
+            hostname: None,
+        }
+    }
+
+    async fn spawn_siteverify_server(
+        response_body: String,
+    ) -> (String, tokio::task::JoinHandle<String>) {
+        let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
+            .await
+            .unwrap();
+        let address = listener.local_addr().unwrap();
+        let task = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut request = Vec::new();
+            let mut chunk = [0_u8; 4096];
+            let header_end = loop {
+                let read = socket.read(&mut chunk).await.unwrap();
+                assert!(read > 0);
+                request.extend_from_slice(&chunk[..read]);
+                if let Some(position) = request.windows(4).position(|window| window == b"\r\n\r\n")
+                {
+                    break position;
+                }
+            };
+
+            let headers = String::from_utf8_lossy(&request[..header_end]);
+            let content_length = headers
+                .lines()
+                .find_map(|line| {
+                    let (name, value) = line.split_once(':')?;
+                    name.eq_ignore_ascii_case("content-length")
+                        .then(|| value.trim().parse::<usize>().unwrap())
+                })
+                .unwrap();
+            let body_start = header_end + 4;
+            while request.len() < body_start + content_length {
+                let read = socket.read(&mut chunk).await.unwrap();
+                assert!(read > 0);
+                request.extend_from_slice(&chunk[..read]);
+            }
+
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                response_body.len(),
+                response_body
+            );
+            socket.write_all(response.as_bytes()).await.unwrap();
+
+            String::from_utf8(request[body_start..body_start + content_length].to_vec()).unwrap()
+        });
+
+        (format!("http://{address}"), task)
+    }
+
+    #[test]
+    fn token_failures_are_rejected_without_becoming_service_errors() {
+        for code in [
+            "missing-input-response",
+            "invalid-input-response",
+            "timeout-or-duplicate",
+        ] {
+            assert_eq!(
+                classify_siteverify_response(response(false, &[code])),
+                Ok(TurnstileVerification::Rejected)
+            );
+        }
+    }
+
+    #[test]
+    fn service_and_configuration_failures_are_unavailable() {
+        for code in [
+            "missing-input-secret",
+            "invalid-input-secret",
+            "bad-request",
+            "internal-error",
+            "unknown-error",
+        ] {
+            assert_eq!(
+                classify_siteverify_response(response(false, &[code])),
+                Err(TurnstileVerificationError::Unavailable)
+            );
+        }
+    }
+
+    #[test]
+    fn mixed_token_and_unknown_failures_are_unavailable() {
+        assert_eq!(
+            classify_siteverify_response(response(
+                false,
+                &["invalid-input-response", "unknown-error"]
+            )),
+            Err(TurnstileVerificationError::Unavailable)
+        );
+    }
+
+    #[tokio::test]
+    async fn siteverify_sends_only_secret_and_response() {
+        let (endpoint, request_task) = spawn_siteverify_server(
+            r#"{"success":true,"action":"session-create","hostname":"example.com"}"#.to_owned(),
+        )
+        .await;
+        let client = TurnstileSiteverifyClient::with_siteverify_url("secret".to_owned(), endpoint);
+
+        assert_eq!(
+            client.verify("token").await,
+            Ok(TurnstileVerification::Accepted {
+                action: Some("session-create".to_owned()),
+                hostname: Some("example.com".to_owned()),
+            })
+        );
+
+        let request_body = request_task.await.unwrap();
+        assert!(request_body.contains(r#""secret":"secret""#));
+        assert!(request_body.contains(r#""response":"token""#));
+        assert!(!request_body.contains("remoteip"));
+    }
+}

--- a/server/presentation/Cargo.toml
+++ b/server/presentation/Cargo.toml
@@ -24,3 +24,6 @@ base64 = { workspace = true }
 futures = { workspace = true }
 utoipa = { workspace = true }
 utoipa-axum = { workspace = true }
+
+[dev-dependencies]
+tower = { version = "0.5.3", features = ["util"] }

--- a/server/presentation/src/handlers/form/answer_handler.rs
+++ b/server/presentation/src/handlers/form/answer_handler.rs
@@ -511,6 +511,7 @@ pub async fn post_answer_handler(
     summary = "未ログイン回答の作成",
     params(
         ("form_id" = String, Path, description = "Form ID"),
+        ("X-Seichi-Turnstile-Token" = String, Header, description = "Cloudflare Turnstile token"),
     ),
     request_body = TemporaryAnswerCreateSchema,
     responses(
@@ -520,6 +521,7 @@ pub async fn post_answer_handler(
         NotFound,
         UnprocessableEntity,
         InternalServerError,
+        ServiceUnavailable,
     ),
     tag = "Answers"
 )]

--- a/server/presentation/src/handlers/user_handler.rs
+++ b/server/presentation/src/handlers/user_handler.rs
@@ -895,14 +895,19 @@ pub async fn delete_form_submission_restriction(
     post,
     path = "/session",
     summary = "セッションを作成する",
+    params(
+        ("X-Seichi-Turnstile-Token" = String, Header, description = "Cloudflare Turnstile token"),
+    ),
     request_body = super::super::schemas::session::SessionCreateSchema,
     responses(
         (status = 201, description = "The request has succeeded and a new resource has been created as a result."),
         BadRequest,
         Unauthorized,
+        Forbidden,
         NotFound,
         UnprocessableEntity,
         InternalServerError,
+        ServiceUnavailable,
     ),
     security(("bearer" = [])),
     tag = "Session"

--- a/server/presentation/src/lib.rs
+++ b/server/presentation/src/lib.rs
@@ -3,3 +3,4 @@ pub mod auth;
 pub mod handlers;
 pub mod rate_limit;
 pub mod schemas;
+pub mod turnstile;

--- a/server/presentation/src/schemas/error_responses.rs
+++ b/server/presentation/src/schemas/error_responses.rs
@@ -59,3 +59,13 @@ pub enum InternalServerError {
     )]
     InternalServerError(ErrorResponse),
 }
+
+#[derive(utoipa::IntoResponses)]
+pub enum ServiceUnavailable {
+    #[response(
+        status = 503,
+        description = "The server is temporarily unable to handle the request.",
+        content_type = "application/problem+json"
+    )]
+    ServiceUnavailable(ErrorResponse),
+}

--- a/server/presentation/src/turnstile.rs
+++ b/server/presentation/src/turnstile.rs
@@ -1,0 +1,474 @@
+use std::{collections::HashSet, sync::Arc};
+
+use axum::{
+    body::Body,
+    extract::State,
+    http::{Method, Request, StatusCode, header},
+    middleware::Next,
+    response::{IntoResponse, Response},
+};
+use common::turnstile::{TurnstileVerification, TurnstileVerificationError, TurnstileVerifier};
+
+use crate::schemas::error_response::ErrorResponse;
+
+const API_PREFIX: &str = "/api/v1";
+const MAX_TOKEN_LENGTH: usize = 2048;
+pub const TURNSTILE_TOKEN_HEADER: &str = "x-seichi-turnstile-token";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TurnstileAction {
+    SessionCreate,
+    TemporaryAnswer,
+}
+
+impl TurnstileAction {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::SessionCreate => "session-create",
+            Self::TemporaryAnswer => "temporary-answer",
+        }
+    }
+}
+
+#[derive(Clone)]
+pub enum TurnstileState {
+    Disabled,
+    Enabled {
+        verifier: Arc<dyn TurnstileVerifier>,
+        allowed_hostnames: Arc<HashSet<String>>,
+    },
+}
+
+impl TurnstileState {
+    pub fn disabled() -> Self {
+        Self::Disabled
+    }
+
+    pub fn enabled(
+        verifier: Arc<dyn TurnstileVerifier>,
+        allowed_hostnames: HashSet<String>,
+    ) -> Self {
+        Self::Enabled {
+            verifier,
+            allowed_hostnames: Arc::new(
+                allowed_hostnames
+                    .into_iter()
+                    .map(|hostname| hostname.to_ascii_lowercase())
+                    .collect(),
+            ),
+        }
+    }
+}
+
+fn request_path_without_api_prefix(path: &str) -> Option<&str> {
+    if path == API_PREFIX {
+        Some("/")
+    } else if let Some(stripped) = path.strip_prefix(API_PREFIX) {
+        stripped.starts_with('/').then_some(stripped)
+    } else if path.starts_with('/') {
+        Some(path)
+    } else {
+        None
+    }
+}
+
+fn expected_action(method: &Method, path: &str) -> Option<TurnstileAction> {
+    if *method != Method::POST {
+        return None;
+    }
+
+    let path = request_path_without_api_prefix(path)?;
+    let segments = path
+        .split('/')
+        .filter(|segment| !segment.is_empty())
+        .collect::<Vec<_>>();
+
+    match segments.as_slice() {
+        ["session"] => Some(TurnstileAction::SessionCreate),
+        ["forms", _, "temporary-answers"] => Some(TurnstileAction::TemporaryAnswer),
+        _ => None,
+    }
+}
+
+fn allowed_hostname(hostname: &str, allowed_hostnames: &HashSet<String>) -> bool {
+    allowed_hostnames.contains(&hostname.to_ascii_lowercase())
+}
+
+fn problem_response(status: StatusCode, title: &str, detail: &str, error_code: &str) -> Response {
+    (
+        status,
+        [(header::CONTENT_TYPE, "application/problem+json")],
+        axum::Json(ErrorResponse {
+            problem_type: "about:blank".to_owned(),
+            title: title.to_owned(),
+            status: status.as_u16(),
+            detail: detail.to_owned(),
+            error_code: error_code.to_owned(),
+            restriction: None,
+        }),
+    )
+        .into_response()
+}
+
+fn forbidden_response() -> Response {
+    problem_response(
+        StatusCode::FORBIDDEN,
+        "Forbidden",
+        "Turnstile verification failed.",
+        "TURNSTILE_VERIFICATION_FAILED",
+    )
+}
+
+fn unavailable_response() -> Response {
+    problem_response(
+        StatusCode::SERVICE_UNAVAILABLE,
+        "Service Unavailable",
+        "Turnstile verification service is unavailable.",
+        "TURNSTILE_UNAVAILABLE",
+    )
+}
+
+pub async fn middleware(
+    State(state): State<TurnstileState>,
+    request: Request<Body>,
+    next: Next,
+) -> Response {
+    let Some(action) = expected_action(request.method(), request.uri().path()) else {
+        return next.run(request).await;
+    };
+
+    let TurnstileState::Enabled {
+        verifier,
+        allowed_hostnames,
+    } = state
+    else {
+        return next.run(request).await;
+    };
+
+    let Some(token) = request
+        .headers()
+        .get(TURNSTILE_TOKEN_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .filter(|token| !token.is_empty() && token.len() <= MAX_TOKEN_LENGTH)
+    else {
+        return forbidden_response();
+    };
+
+    let verification = match verifier.verify(token).await {
+        Ok(verification) => verification,
+        Err(TurnstileVerificationError::Unavailable)
+        | Err(TurnstileVerificationError::InvalidResponse) => return unavailable_response(),
+    };
+
+    let TurnstileVerification::Accepted {
+        action: actual_action,
+        hostname,
+    } = verification
+    else {
+        return forbidden_response();
+    };
+
+    if actual_action.as_deref() != Some(action.as_str())
+        || !hostname.is_some_and(|hostname| allowed_hostname(&hostname, &allowed_hostnames))
+    {
+        return forbidden_response();
+    }
+
+    next.run(request).await
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        net::SocketAddr,
+        sync::{Arc, Mutex},
+    };
+
+    use async_trait::async_trait;
+    use axum::{
+        Router,
+        body::{Body, to_bytes},
+        extract::{ConnectInfo, Request},
+        http::{Method, StatusCode, header::HeaderValue},
+        routing::post,
+    };
+    use common::{
+        rate_limit::{RateLimitDecision, RateLimitQuota, RateLimitStore, RateLimitStoreError},
+        turnstile::{TurnstileVerification, TurnstileVerificationError, TurnstileVerifier},
+    };
+    use tower::ServiceExt;
+
+    use crate::rate_limit::{RateLimitState, middleware as rate_limit_middleware};
+
+    use super::*;
+
+    #[derive(Clone)]
+    struct RecordingVerifier {
+        events: Arc<Mutex<Vec<&'static str>>>,
+    }
+
+    #[async_trait]
+    impl TurnstileVerifier for RecordingVerifier {
+        async fn verify(
+            &self,
+            _token: &str,
+        ) -> Result<TurnstileVerification, TurnstileVerificationError> {
+            self.events.lock().unwrap().push("turnstile");
+            Ok(TurnstileVerification::Accepted {
+                action: Some("session-create".to_owned()),
+                hostname: Some("EXAMPLE.COM".to_owned()),
+            })
+        }
+    }
+
+    #[derive(Clone)]
+    struct FixedVerifier {
+        result: Result<TurnstileVerification, TurnstileVerificationError>,
+    }
+
+    #[async_trait]
+    impl TurnstileVerifier for FixedVerifier {
+        async fn verify(
+            &self,
+            _token: &str,
+        ) -> Result<TurnstileVerification, TurnstileVerificationError> {
+            self.result.clone()
+        }
+    }
+
+    struct RecordingRateLimitStore {
+        events: Arc<Mutex<Vec<&'static str>>>,
+    }
+
+    #[async_trait]
+    impl RateLimitStore for RecordingRateLimitStore {
+        async fn check(
+            &self,
+            _quotas: &[RateLimitQuota],
+        ) -> Result<RateLimitDecision, RateLimitStoreError> {
+            self.events.lock().unwrap().push("rate-limit");
+            Ok(RateLimitDecision {
+                allowed: true,
+                retry_after_seconds: 1,
+                remaining: 1,
+                limit: 2,
+                reset_seconds: 60,
+            })
+        }
+    }
+
+    fn state(events: Arc<Mutex<Vec<&'static str>>>) -> TurnstileState {
+        TurnstileState::enabled(
+            Arc::new(RecordingVerifier { events }),
+            ["example.com".to_owned()].into_iter().collect(),
+        )
+    }
+
+    fn fixed_verification_app(
+        result: Result<TurnstileVerification, TurnstileVerificationError>,
+    ) -> Router {
+        Router::new()
+            .route("/session", post(|| async { StatusCode::OK }))
+            .layer(axum::middleware::from_fn_with_state(
+                TurnstileState::enabled(
+                    Arc::new(FixedVerifier { result }),
+                    ["example.com".to_owned()].into_iter().collect(),
+                ),
+                middleware,
+            ))
+    }
+
+    #[test]
+    fn only_the_two_public_post_routes_have_an_action() {
+        assert_eq!(
+            expected_action(&Method::POST, "/session"),
+            Some(TurnstileAction::SessionCreate)
+        );
+        assert_eq!(
+            expected_action(
+                &Method::POST,
+                "/api/v1/forms/018f4f37-2f5e-7b39-8b39-9a2f2695d7ad/temporary-answers"
+            ),
+            Some(TurnstileAction::TemporaryAnswer)
+        );
+        assert_eq!(expected_action(&Method::GET, "/forms"), None);
+        assert_eq!(expected_action(&Method::POST, "/users"), None);
+        assert_eq!(expected_action(&Method::POST, "/api/v10/session"), None);
+    }
+
+    #[test]
+    fn hostname_matching_is_case_insensitive_but_not_wildcard_based() {
+        let allowed = ["example.com".to_owned()].into_iter().collect();
+        assert!(allowed_hostname("example.com", &allowed));
+        assert!(allowed_hostname("EXAMPLE.COM", &allowed));
+        assert!(!allowed_hostname("sub.example.com", &allowed));
+
+        let wildcard = ["*.example.com".to_owned()].into_iter().collect();
+        assert!(!allowed_hostname("sub.example.com", &wildcard));
+    }
+
+    #[tokio::test]
+    async fn enabled_middleware_validates_without_consuming_the_body() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let app = Router::new()
+            .route("/session", post(|body: String| async move { body }))
+            .layer(axum::middleware::from_fn_with_state(
+                state(events),
+                middleware,
+            ));
+        let request = Request::builder()
+            .method(Method::POST)
+            .uri("/session")
+            .header(TURNSTILE_TOKEN_HEADER, HeaderValue::from_static("token"))
+            .body(Body::from("request body"))
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            to_bytes(response.into_body(), usize::MAX).await.unwrap(),
+            "request body"
+        );
+    }
+
+    #[tokio::test]
+    async fn disabled_middleware_passes_a_request_without_a_token() {
+        let app = Router::new()
+            .route("/session", post(|body: String| async move { body }))
+            .layer(axum::middleware::from_fn_with_state(
+                TurnstileState::disabled(),
+                middleware,
+            ));
+        let request = Request::builder()
+            .method(Method::POST)
+            .uri("/session")
+            .body(Body::from("request body"))
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            to_bytes(response.into_body(), usize::MAX).await.unwrap(),
+            "request body"
+        );
+    }
+
+    #[tokio::test]
+    async fn missing_token_is_forbidden() {
+        let response = fixed_verification_app(Ok(TurnstileVerification::Accepted {
+            action: Some("session-create".to_owned()),
+            hostname: Some("example.com".to_owned()),
+        }))
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/session")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn action_or_hostname_mismatch_is_forbidden() {
+        for verification in [
+            TurnstileVerification::Accepted {
+                action: Some("temporary-answer".to_owned()),
+                hostname: Some("example.com".to_owned()),
+            },
+            TurnstileVerification::Accepted {
+                action: Some("session-create".to_owned()),
+                hostname: Some("other.example.com".to_owned()),
+            },
+            TurnstileVerification::Accepted {
+                action: Some("session-create".to_owned()),
+                hostname: None,
+            },
+        ] {
+            let response = fixed_verification_app(Ok(verification))
+                .oneshot(
+                    Request::builder()
+                        .method(Method::POST)
+                        .uri("/session")
+                        .header(TURNSTILE_TOKEN_HEADER, HeaderValue::from_static("token"))
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+
+            assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        }
+    }
+
+    #[tokio::test]
+    async fn verifier_unavailability_is_service_unavailable() {
+        let response = fixed_verification_app(Err(TurnstileVerificationError::Unavailable))
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/session")
+                    .header(TURNSTILE_TOKEN_HEADER, HeaderValue::from_static("token"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn rate_limit_runs_before_turnstile_and_handler() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let rate_limit_state = RateLimitState::new(
+            Arc::new(RecordingRateLimitStore {
+                events: events.clone(),
+            }),
+            None,
+        );
+        let handler_events = events.clone();
+        let app = Router::new()
+            .route(
+                "/session",
+                post(move |body: String| {
+                    let handler_events = handler_events.clone();
+                    async move {
+                        handler_events.lock().unwrap().push("handler");
+                        body
+                    }
+                }),
+            )
+            // route_layer は後から追加した layer が外側になるため、rate limit を最後に追加する。
+            .route_layer(axum::middleware::from_fn_with_state(
+                state(events.clone()),
+                middleware,
+            ))
+            .route_layer(axum::middleware::from_fn_with_state(
+                rate_limit_state,
+                rate_limit_middleware,
+            ));
+        let mut request = Request::builder()
+            .method(Method::POST)
+            .uri("/session")
+            .header(TURNSTILE_TOKEN_HEADER, HeaderValue::from_static("token"))
+            .body(Body::from("request body"))
+            .unwrap();
+        request
+            .extensions_mut()
+            .insert(ConnectInfo(SocketAddr::from(([127, 0, 0, 1], 8080))));
+
+        let response = app.oneshot(request).await.unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            *events.lock().unwrap(),
+            vec!["rate-limit", "turnstile", "handler"]
+        );
+    }
+}


### PR DESCRIPTION
## 概要
- Cloudflare Siteverify を利用したサーバー側 Turnstile 検証を追加
- `/api/v1/session` と `/api/v1/forms/{form_id}/temporary-answers` の POST だけを、既存の rate limit の後段で保護
- 設定、CORS、OpenAPI、403/503 エラー応答、外部 API 境界と回帰テストを追加

## 確認事項
- `cargo build` 成功
- `cargo test --all-features` 成功（265 passed、1 skipped）
- `makers pretty` 成功（nextest、doc tests、clippy、fmt）
- `cargo run --package entrypoint --bin generate-openapi` 成功
- OpenAPI 生成チェックを commit hook でも確認
- Turnstile の token、action、hostname の検証、および rate limit → Turnstile → handler の順序をテスト

## 補足
- 本番で `TURNSTILE_ENABLED=true` にする場合は `TURNSTILE_SECRET_KEY` と完全一致の `TURNSTILE_ALLOWED_HOSTNAMES` が必要
- フロントエンドは widget の token を `X-Seichi-Turnstile-Token` ヘッダーで送信し、対象 action を設定する必要があります
- 実 Cloudflare の token を使った疎通確認は未実施です

🤖 Generated with Codex