### PR TITLE
refactor: Discord Webhook通知の表示内容を人間向けに整理

### DIFF
--- a/server/presentation/src/api/global_discord_webhook.rs
+++ b/server/presentation/src/api/global_discord_webhook.rs
@@ -105,19 +105,11 @@ async fn handle_event(
 }
 
 fn actor_fields(actor: ApplicationActor) -> Vec<DiscordWebhookField> {
-    [
-        Some(DiscordWebhookField::new(
-            "実行者".to_string(),
-            actor.display_name,
-            true,
-        )),
-        actor
-            .account_id
-            .map(|id| DiscordWebhookField::new("実行者ID".to_string(), id, true)),
-    ]
-    .into_iter()
-    .flatten()
-    .collect()
+    vec![DiscordWebhookField::new(
+        "実行者".to_string(),
+        actor.display_name,
+        true,
+    )]
 }
 
 fn answer_submission_actor_fields(actor: AnswerSubmissionActor) -> Vec<DiscordWebhookField> {
@@ -138,60 +130,16 @@ fn detail_fields(details: Vec<EventDetail>) -> Vec<DiscordWebhookField> {
         .collect()
 }
 
-fn form_fields(
-    actor: ApplicationActor,
-    form_id: String,
-    form_title: String,
-) -> Vec<DiscordWebhookField> {
-    [
-        actor_fields(actor),
-        vec![
-            DiscordWebhookField::new("フォーム".to_string(), form_title, false),
-            DiscordWebhookField::new("フォームID".to_string(), form_id, true),
-        ],
-    ]
-    .concat()
-}
-
-fn answer_submission_form_fields(
-    actor: AnswerSubmissionActor,
-    form_id: String,
-    form_title: String,
-) -> Vec<DiscordWebhookField> {
-    [
-        answer_submission_actor_fields(actor),
-        vec![
-            DiscordWebhookField::new("フォーム".to_string(), form_title, false),
-            DiscordWebhookField::new("フォームID".to_string(), form_id, true),
-        ],
-    ]
-    .concat()
-}
-
-fn answer_target_fields(
-    actor: ApplicationActor,
-    form_id: String,
-    answer_id: String,
-) -> Vec<DiscordWebhookField> {
-    [
-        actor_fields(actor),
-        vec![
-            DiscordWebhookField::new("フォームID".to_string(), form_id, true),
-            DiscordWebhookField::new("回答ID".to_string(), answer_id, true),
-        ],
-    ]
-    .concat()
-}
-
+/// ID はポータル API 等で使う内部情報のため通知本文には含めず、`link_url` に集約する。
 pub(crate) fn message_from_event(
     event: ApplicationEvent,
     discord_webhook_url: String,
     frontend_url: &str,
 ) -> DiscordWebhookMessage {
     let frontend = frontend_url.trim_end_matches('/');
-    let event_title = operation_display_name(&event);
+    let event_suffix = operation_display_name(&event);
 
-    let (title, link_url, fields) = match event {
+    let (form_title, link_url, fields) = match event {
         ApplicationEvent::FormCreated {
             actor,
             form_id,
@@ -199,12 +147,8 @@ pub(crate) fn message_from_event(
             details,
         } => {
             let link_url = format!("{frontend}/forms/{form_id}");
-            let fields = [
-                form_fields(actor, form_id, form_title),
-                detail_fields(details),
-            ]
-            .concat();
-            ("フォームが作成されました", link_url, fields)
+            let fields = [actor_fields(actor), detail_fields(details)].concat();
+            (form_title, link_url, fields)
         }
         ApplicationEvent::FormUpdated {
             actor,
@@ -213,12 +157,8 @@ pub(crate) fn message_from_event(
             changes,
         } => {
             let link_url = format!("{frontend}/forms/{form_id}");
-            let fields = [
-                form_fields(actor, form_id, form_title),
-                detail_fields(changes),
-            ]
-            .concat();
-            ("フォームが更新されました", link_url, fields)
+            let fields = [actor_fields(actor), detail_fields(changes)].concat();
+            (form_title, link_url, fields)
         }
         ApplicationEvent::FormArchived {
             actor,
@@ -226,8 +166,7 @@ pub(crate) fn message_from_event(
             form_title,
         } => {
             let link_url = format!("{frontend}/forms/{form_id}");
-            let fields = form_fields(actor, form_id, form_title);
-            ("フォームがアーカイブされました", link_url, fields)
+            (form_title, link_url, actor_fields(actor))
         }
         ApplicationEvent::FormRestored {
             actor,
@@ -235,8 +174,7 @@ pub(crate) fn message_from_event(
             form_title,
         } => {
             let link_url = format!("{frontend}/forms/{form_id}");
-            let fields = form_fields(actor, form_id, form_title);
-            ("フォームが復元されました", link_url, fields)
+            (form_title, link_url, actor_fields(actor))
         }
         ApplicationEvent::AnswerSubmitted {
             actor,
@@ -247,86 +185,81 @@ pub(crate) fn message_from_event(
         } => {
             let link_url = format!("{frontend}/forms/{form_id}/answers/{answer_id}");
             let fields = [
-                answer_submission_form_fields(actor, form_id, form_title),
-                vec![DiscordWebhookField::new(
-                    "回答ID".to_string(),
-                    answer_id,
-                    true,
-                )],
+                answer_submission_actor_fields(actor),
                 detail_fields(details),
             ]
             .concat();
-            ("回答が投稿されました", link_url, fields)
+            (form_title, link_url, fields)
         }
         ApplicationEvent::CommentCreated {
             actor,
             form_id,
+            form_title,
             answer_id,
-            comment_id,
+            comment_id: _,
             content,
         }
         | ApplicationEvent::CommentUpdated {
             actor,
             form_id,
+            form_title,
             answer_id,
-            comment_id,
+            comment_id: _,
             content,
         }
         | ApplicationEvent::CommentDeleted {
             actor,
             form_id,
+            form_title,
             answer_id,
-            comment_id,
+            comment_id: _,
             content,
         } => {
             let link_url = format!("{frontend}/forms/{form_id}/answers/{answer_id}");
             let fields = [
-                answer_target_fields(actor, form_id, answer_id),
-                vec![
-                    DiscordWebhookField::new("コメントID".to_string(), comment_id, true),
-                    DiscordWebhookField::new("内容".to_string(), content, false),
-                ],
+                actor_fields(actor),
+                vec![DiscordWebhookField::new("内容".to_string(), content, false)],
             ]
             .concat();
-            (event_title, link_url, fields)
+            (form_title, link_url, fields)
         }
         ApplicationEvent::MessageCreated {
             actor,
             form_id,
+            form_title,
             answer_id,
-            message_id,
+            message_id: _,
             body,
         }
         | ApplicationEvent::MessageUpdated {
             actor,
             form_id,
+            form_title,
             answer_id,
-            message_id,
+            message_id: _,
             body,
         }
         | ApplicationEvent::MessageDeleted {
             actor,
             form_id,
+            form_title,
             answer_id,
-            message_id,
+            message_id: _,
             body,
         } => {
             let link_url = format!("{frontend}/forms/{form_id}/answers/{answer_id}/messages");
             let fields = [
-                answer_target_fields(actor, form_id, answer_id),
-                vec![
-                    DiscordWebhookField::new("メッセージID".to_string(), message_id, true),
-                    DiscordWebhookField::new("内容".to_string(), body, false),
-                ],
+                actor_fields(actor),
+                vec![DiscordWebhookField::new("内容".to_string(), body, false)],
             ]
             .concat();
-            (event_title, link_url, fields)
+            (form_title, link_url, fields)
         }
     };
 
     DiscordWebhookMessage {
         discord_webhook_url,
-        title: title.to_string(),
+        title: format!("「{form_title}」{event_suffix}"),
         link_url,
         fields,
     }
@@ -348,19 +281,20 @@ fn operation_name(event: &ApplicationEvent) -> &'static str {
     }
 }
 
+/// メッセージタイトルは `「フォーム名」{接尾辞}` の形で組み立てる。
 fn operation_display_name(event: &ApplicationEvent) -> &'static str {
     match event {
-        ApplicationEvent::FormCreated { .. } => "フォームが作成されました",
-        ApplicationEvent::FormUpdated { .. } => "フォームが更新されました",
-        ApplicationEvent::FormArchived { .. } => "フォームがアーカイブされました",
-        ApplicationEvent::FormRestored { .. } => "フォームが復元されました",
-        ApplicationEvent::AnswerSubmitted { .. } => "回答が投稿されました",
-        ApplicationEvent::CommentCreated { .. } => "コメントが投稿されました",
-        ApplicationEvent::CommentUpdated { .. } => "コメントが更新されました",
-        ApplicationEvent::CommentDeleted { .. } => "コメントが削除されました",
-        ApplicationEvent::MessageCreated { .. } => "メッセージが投稿されました",
-        ApplicationEvent::MessageUpdated { .. } => "メッセージが更新されました",
-        ApplicationEvent::MessageDeleted { .. } => "メッセージが削除されました",
+        ApplicationEvent::FormCreated { .. } => "が作成されました",
+        ApplicationEvent::FormUpdated { .. } => "が更新されました",
+        ApplicationEvent::FormArchived { .. } => "がアーカイブされました",
+        ApplicationEvent::FormRestored { .. } => "が復元されました",
+        ApplicationEvent::AnswerSubmitted { .. } => "に回答が投稿されました",
+        ApplicationEvent::CommentCreated { .. } => "にコメントが投稿されました",
+        ApplicationEvent::CommentUpdated { .. } => "のコメントが更新されました",
+        ApplicationEvent::CommentDeleted { .. } => "のコメントが削除されました",
+        ApplicationEvent::MessageCreated { .. } => "にメッセージが投稿されました",
+        ApplicationEvent::MessageUpdated { .. } => "のメッセージが更新されました",
+        ApplicationEvent::MessageDeleted { .. } => "のメッセージが削除されました",
     }
 }
 
@@ -386,6 +320,38 @@ mod tests {
         );
 
         assert_eq!(message.link_url, "https://portal.example.com/forms/form-id");
+        assert_eq!(message.title, "「Form」が復元されました");
+    }
+
+    #[test]
+    fn message_from_event_omits_internal_ids_from_fields() {
+        let message = message_from_event(
+            ApplicationEvent::CommentCreated {
+                actor: ApplicationActor {
+                    display_name: "administrator".to_string(),
+                    account_id: Some("account-id".to_string()),
+                },
+                form_id: "form-id".to_string(),
+                form_title: "Form".to_string(),
+                answer_id: "answer-id".to_string(),
+                comment_id: "comment-id".to_string(),
+                content: "content".to_string(),
+            },
+            "https://discord.com/api/webhooks/123/token".to_string(),
+            "https://portal.example.com/",
+        );
+
+        assert_eq!(message.title, "「Form」にコメントが投稿されました");
+        assert!(message.fields.iter().all(|field| {
+            ![
+                "フォームID",
+                "実行者ID",
+                "回答ID",
+                "コメントID",
+                "メッセージID",
+            ]
+            .contains(&field.name.as_str())
+        }));
     }
 
     #[test]

--- a/server/usecase/src/application_event.rs
+++ b/server/usecase/src/application_event.rs
@@ -80,6 +80,7 @@ pub enum ApplicationEvent {
     CommentCreated {
         actor: ApplicationActor,
         form_id: String,
+        form_title: String,
         answer_id: String,
         comment_id: String,
         content: String,
@@ -87,6 +88,7 @@ pub enum ApplicationEvent {
     CommentUpdated {
         actor: ApplicationActor,
         form_id: String,
+        form_title: String,
         answer_id: String,
         comment_id: String,
         content: String,
@@ -94,6 +96,7 @@ pub enum ApplicationEvent {
     CommentDeleted {
         actor: ApplicationActor,
         form_id: String,
+        form_title: String,
         answer_id: String,
         comment_id: String,
         content: String,
@@ -101,6 +104,7 @@ pub enum ApplicationEvent {
     MessageCreated {
         actor: ApplicationActor,
         form_id: String,
+        form_title: String,
         answer_id: String,
         message_id: String,
         body: String,
@@ -108,6 +112,7 @@ pub enum ApplicationEvent {
     MessageUpdated {
         actor: ApplicationActor,
         form_id: String,
+        form_title: String,
         answer_id: String,
         message_id: String,
         body: String,
@@ -115,6 +120,7 @@ pub enum ApplicationEvent {
     MessageDeleted {
         actor: ApplicationActor,
         form_id: String,
+        form_title: String,
         answer_id: String,
         message_id: String,
         body: String,

--- a/server/usecase/src/forms/answer.rs
+++ b/server/usecase/src/forms/answer.rs
@@ -151,12 +151,13 @@ impl<
         let form_id = form.id().into_inner().to_string();
         let answer_id = answer_entry.id().into_inner().to_string();
         let answer_url = format!("{}/forms/{form_id}/answers/{answer_id}", FRONTEND.url);
+        let form_title = form.title().to_owned().into_inner().into_inner();
         let title = answer_entry
             .title()
             .to_owned()
             .into_inner()
             .map(|title| title.into_inner())
-            .unwrap_or_else(|| "回答が送信されました".to_string());
+            .unwrap_or_else(|| format!("「{form_title}」への回答"));
         let questions = form.questions().as_slice();
         let answer_fields = answer_entry
             .contents()
@@ -173,10 +174,7 @@ impl<
             .collect::<Vec<_>>();
         let fields = [
             vec![
-                DiscordAnswerWebhookField::new(
-                    "フォーム名".to_string(),
-                    form.title().to_owned().into_inner().into_inner(),
-                ),
+                DiscordAnswerWebhookField::new("フォーム名".to_string(), form_title),
                 DiscordAnswerWebhookField::new(
                     "回答者".to_string(),
                     match author_disclosure {

--- a/server/usecase/src/forms/comment.rs
+++ b/server/usecase/src/forms/comment.rs
@@ -177,6 +177,7 @@ impl<
             .create_comment(content)?;
         let comment_id = comment.comment_id().to_string();
         let content = comment.content().to_owned().into_inner().into_inner();
+        let form_title = form.title().to_owned().into_inner().into_inner();
         self.comment_thread_repository
             .create(&form, comment)
             .await?;
@@ -184,6 +185,7 @@ impl<
             publisher.publish(ApplicationEvent::CommentCreated {
                 actor: ApplicationActor::from(actor),
                 form_id: form_id.to_string(),
+                form_title,
                 answer_id: answer_id.to_string(),
                 comment_id,
                 content,
@@ -236,6 +238,7 @@ impl<
             }
             let content = updated.content().to_owned().into_inner().into_inner();
             let comment_id = updated.comment_id().to_string();
+            let form_title = form.title().to_owned().into_inner().into_inner();
             self.comment_thread_repository
                 .update(&form, updated, Utc::now())
                 .await?;
@@ -243,6 +246,7 @@ impl<
                 publisher.publish(ApplicationEvent::CommentUpdated {
                     actor: ApplicationActor::from(actor),
                     form_id: form_id.to_string(),
+                    form_title,
                     answer_id: answer_id.to_string(),
                     comment_id,
                     content,
@@ -275,6 +279,7 @@ impl<
             .to_owned()
             .into_inner()
             .into_inner();
+        let form_title = form.title().to_owned().into_inner().into_inner();
         self.comment_thread_repository
             .delete(&form, comment)
             .await?;
@@ -282,6 +287,7 @@ impl<
             publisher.publish(ApplicationEvent::CommentDeleted {
                 actor: ApplicationActor::from(actor),
                 form_id: form_id.to_string(),
+                form_title,
                 answer_id: answer_id.to_string(),
                 comment_id: comment_id.to_string(),
                 content,

--- a/server/usecase/src/forms/message.rs
+++ b/server/usecase/src/forms/message.rs
@@ -1,6 +1,6 @@
 use chrono::Utc;
 use common::config::FRONTEND;
-use domain::form::models::FormId;
+use domain::form::models::{ActiveForm, FormId};
 use domain::notification::models::{NotificationContent, NotificationType};
 use domain::notification::notificator::Notificator;
 use domain::{
@@ -84,12 +84,12 @@ impl<
     R5: MessageThreadRepository,
 > MessageUseCase<'_, R1, R2, R3, R4, R5>
 {
-    async fn read_answer_entry(
+    async fn read_form_and_answer_entry(
         &self,
         actor: &Actor,
         form_id: FormId,
         answer_id: AnswerId,
-    ) -> Result<Allowed<AnswerEntry, Read>, Error> {
+    ) -> Result<(Allowed<ActiveForm, Read>, Allowed<AnswerEntry, Read>), Error> {
         let form = self
             .active_form_repository
             .get(form_id)
@@ -97,11 +97,13 @@ impl<
             .ok_or(FormNotFound)?
             .try_read(actor.clone())?;
 
-        self.answer_entry_repository
+        let answer = self
+            .answer_entry_repository
             .get(&form, answer_id)
             .await?
-            .ok_or(AnswerNotFound)
-            .map_err(Into::into)
+            .ok_or(AnswerNotFound)?;
+
+        Ok((form, answer))
     }
 
     pub async fn post_message<N: Notificator>(
@@ -115,9 +117,10 @@ impl<
     ) -> Result<(), Error> {
         super::submission::authorize_form_submission(actor.clone(), restriction_repository).await?;
         let actor_user = Actor::from(actor.clone());
-        let form_answer = self
-            .read_answer_entry(&actor_user, form_id, answer_id)
+        let (form, form_answer) = self
+            .read_form_and_answer_entry(&actor_user, form_id, answer_id)
             .await?;
+        let form_title = form.title().to_owned().into_inner().into_inner();
 
         let message = Message::new(*actor.id(), message_body);
         let message_id = message.id().to_string();
@@ -145,6 +148,7 @@ impl<
             publisher.publish(ApplicationEvent::MessageCreated {
                 actor: ApplicationActor::from(actor),
                 form_id: form_id.to_string(),
+                form_title,
                 answer_id: answer_id.to_string(),
                 message_id,
                 body: message_body,
@@ -203,8 +207,8 @@ impl<
         answer_id: AnswerId,
     ) -> Result<Vec<MessageWithSender>, Error> {
         let actor_user = Actor::from(actor.clone());
-        let form_answer = self
-            .read_answer_entry(&actor_user, form_id, answer_id)
+        let (_, form_answer) = self
+            .read_form_and_answer_entry(&actor_user, form_id, answer_id)
             .await?;
 
         let messages = self
@@ -238,8 +242,8 @@ impl<
         body: Option<MessageBody>,
     ) -> Result<(), Error> {
         let actor_user = Actor::from(actor.clone());
-        let form_answer = self
-            .read_answer_entry(&actor_user, form_id, answer_id)
+        let (form, form_answer) = self
+            .read_form_and_answer_entry(&actor_user, form_id, answer_id)
             .await?;
 
         if let Some(body) = body {
@@ -265,6 +269,7 @@ impl<
                 publisher.publish(ApplicationEvent::MessageUpdated {
                     actor: ApplicationActor::from(actor),
                     form_id: form_id.to_string(),
+                    form_title: form.title().to_owned().into_inner().into_inner(),
                     answer_id: answer_id.to_string(),
                     message_id: message_id.to_string(),
                     body: body_for_event,
@@ -283,8 +288,8 @@ impl<
         message_id: &MessageId,
     ) -> Result<(), Error> {
         let actor_user = Actor::from(actor.clone());
-        let form_answer = self
-            .read_answer_entry(&actor_user, form_id, answer_id)
+        let (form, form_answer) = self
+            .read_form_and_answer_entry(&actor_user, form_id, answer_id)
             .await?;
 
         let thread = self
@@ -308,6 +313,7 @@ impl<
             publisher.publish(ApplicationEvent::MessageDeleted {
                 actor: ApplicationActor::from(actor),
                 form_id: form_id.to_string(),
+                form_title: form.title().to_owned().into_inner().into_inner(),
                 answer_id: answer_id.to_string(),
                 message_id: message_id.to_string(),
                 body: message_body,
@@ -325,8 +331,8 @@ impl<
         request: PageRequest<MessageHistoryPagePosition>,
     ) -> Result<Page<Allowed<MessageHistoryEntry, Read>, MessageHistoryPagePosition>, Error> {
         let actor_user = Actor::from(actor.clone());
-        let form_answer = self
-            .read_answer_entry(&actor_user, form_id, answer_id)
+        let (_, form_answer) = self
+            .read_form_and_answer_entry(&actor_user, form_id, answer_id)
             .await?;
         let thread = self
             .message_thread_repository


### PR DESCRIPTION
## 概要
- フォーム作成・更新・アーカイブ・復元、回答投稿、コメント/メッセージ投稿など、Discord Webhook 通知の埋め込みタイトルが「フォームが作成されました」のように主語を持たず、フィールドにはフォームID・実行者ID・回答ID・コメントID・メッセージIDといった内部IDがそのまま並んでいて読みにくかった
- タイトルを「「フォーム名」が作成されました」のように対象（フォーム名）を主語にする形へ統一。コメント・メッセージイベントにも `form_title` を持たせて同じ形式にした
- リンクURLで該当ページへ遷移できれば十分なため、フォームID・実行者ID・回答ID・コメントID・メッセージIDをフィールドから削除
- フォーム別 Discord 回答Webhookの既定タイトル（回答タイトル未設定時）も「「フォーム名」への回答」とし、フォーム名がわかるようにした

## 確認事項
- `cargo build --workspace` / `cargo test --workspace --lib` が通ることを確認
- `makers pretty`（clippy -D warnings / rustfmt）を実行し、警告なし
- `global_discord_webhook.rs` にタイトル文言とID非表示を検証するテストを追加

## 補足
- `CommentCreated`/`MessageCreated` 系イベントに `form_title` フィールドを追加したため、`ApplicationEvent` のバリアント定義が変わっている（外部APIには影響なし、内部イベントのみ）

🤖 Generated with Claude Code