### PR TITLE
回答関連Webhookのタイトルを回答名に変更

### DIFF
--- a/server/presentation/src/api/global_discord_webhook.rs
+++ b/server/presentation/src/api/global_discord_webhook.rs
@@ -139,7 +139,7 @@ pub(crate) fn message_from_event(
     let frontend = frontend_url.trim_end_matches('/');
     let event_suffix = operation_display_name(&event);
 
-    let (form_title, link_url, fields) = match event {
+    let (title, link_url, fields) = match event {
         ApplicationEvent::FormCreated {
             actor,
             form_id,
@@ -194,7 +194,7 @@ pub(crate) fn message_from_event(
         ApplicationEvent::CommentCreated {
             actor,
             form_id,
-            form_title,
+            answer_title,
             answer_id,
             comment_id,
             content,
@@ -202,7 +202,7 @@ pub(crate) fn message_from_event(
         | ApplicationEvent::CommentUpdated {
             actor,
             form_id,
-            form_title,
+            answer_title,
             answer_id,
             comment_id,
             content,
@@ -210,7 +210,7 @@ pub(crate) fn message_from_event(
         | ApplicationEvent::CommentDeleted {
             actor,
             form_id,
-            form_title,
+            answer_title,
             answer_id,
             comment_id,
             content,
@@ -222,12 +222,16 @@ pub(crate) fn message_from_event(
                 vec![DiscordWebhookField::new("内容".to_string(), content, false)],
             ]
             .concat();
-            (form_title, link_url, fields)
+            (
+                answer_title.unwrap_or_else(|| "（タイトルなし）".to_string()),
+                link_url,
+                fields,
+            )
         }
         ApplicationEvent::MessageCreated {
             actor,
             form_id,
-            form_title,
+            answer_title,
             answer_id,
             message_id,
             body,
@@ -235,7 +239,7 @@ pub(crate) fn message_from_event(
         | ApplicationEvent::MessageUpdated {
             actor,
             form_id,
-            form_title,
+            answer_title,
             answer_id,
             message_id,
             body,
@@ -243,7 +247,7 @@ pub(crate) fn message_from_event(
         | ApplicationEvent::MessageDeleted {
             actor,
             form_id,
-            form_title,
+            answer_title,
             answer_id,
             message_id,
             body,
@@ -255,13 +259,17 @@ pub(crate) fn message_from_event(
                 vec![DiscordWebhookField::new("内容".to_string(), body, false)],
             ]
             .concat();
-            (form_title, link_url, fields)
+            (
+                answer_title.unwrap_or_else(|| "（タイトルなし）".to_string()),
+                link_url,
+                fields,
+            )
         }
     };
 
     DiscordWebhookMessage {
         discord_webhook_url,
-        title: format!("「{form_title}」{event_suffix}"),
+        title: format!("「{title}」{event_suffix}"),
         link_url,
         fields,
     }
@@ -283,7 +291,7 @@ fn operation_name(event: &ApplicationEvent) -> &'static str {
     }
 }
 
-/// メッセージタイトルは `「フォーム名」{接尾辞}` の形で組み立てる。
+/// メッセージタイトルは `「対象名」{接尾辞}` の形で組み立てる。
 fn operation_display_name(event: &ApplicationEvent) -> &'static str {
     match event {
         ApplicationEvent::FormCreated { .. } => "が作成されました",
@@ -334,7 +342,7 @@ mod tests {
                     account_id: Some("account-id".to_string()),
                 },
                 form_id: "form-id".to_string(),
-                form_title: "Form".to_string(),
+                answer_title: Some("Answer".to_string()),
                 answer_id: "answer-id".to_string(),
                 comment_id: "comment-id".to_string(),
                 content: "content".to_string(),
@@ -343,7 +351,7 @@ mod tests {
             "https://portal.example.com/",
         );
 
-        assert_eq!(message.title, "「Form」にコメントが投稿されました");
+        assert_eq!(message.title, "「Answer」にコメントが投稿されました");
         assert!(message.fields.iter().all(|field| {
             ![
                 "フォームID",
@@ -370,7 +378,7 @@ mod tests {
                     account_id: Some("account-id".to_string()),
                 },
                 form_id: "form-id".to_string(),
-                form_title: "Form".to_string(),
+                answer_title: None,
                 answer_id: "answer-id".to_string(),
                 message_id: "message-id".to_string(),
                 body: "body".to_string(),
@@ -382,6 +390,10 @@ mod tests {
         assert_eq!(
             message.link_url,
             "https://portal.example.com/forms/form-id/answers/answer-id?messageId=message-id"
+        );
+        assert_eq!(
+            message.title,
+            "「（タイトルなし）」にメッセージが投稿されました"
         );
     }
 

--- a/server/usecase/src/application_event.rs
+++ b/server/usecase/src/application_event.rs
@@ -80,7 +80,7 @@ pub enum ApplicationEvent {
     CommentCreated {
         actor: ApplicationActor,
         form_id: String,
-        form_title: String,
+        answer_title: Option<String>,
         answer_id: String,
         comment_id: String,
         content: String,
@@ -88,7 +88,7 @@ pub enum ApplicationEvent {
     CommentUpdated {
         actor: ApplicationActor,
         form_id: String,
-        form_title: String,
+        answer_title: Option<String>,
         answer_id: String,
         comment_id: String,
         content: String,
@@ -96,7 +96,7 @@ pub enum ApplicationEvent {
     CommentDeleted {
         actor: ApplicationActor,
         form_id: String,
-        form_title: String,
+        answer_title: Option<String>,
         answer_id: String,
         comment_id: String,
         content: String,
@@ -104,7 +104,7 @@ pub enum ApplicationEvent {
     MessageCreated {
         actor: ApplicationActor,
         form_id: String,
-        form_title: String,
+        answer_title: Option<String>,
         answer_id: String,
         message_id: String,
         body: String,
@@ -112,7 +112,7 @@ pub enum ApplicationEvent {
     MessageUpdated {
         actor: ApplicationActor,
         form_id: String,
-        form_title: String,
+        answer_title: Option<String>,
         answer_id: String,
         message_id: String,
         body: String,
@@ -120,7 +120,7 @@ pub enum ApplicationEvent {
     MessageDeleted {
         actor: ApplicationActor,
         form_id: String,
-        form_title: String,
+        answer_title: Option<String>,
         answer_id: String,
         message_id: String,
         body: String,

--- a/server/usecase/src/forms/comment.rs
+++ b/server/usecase/src/forms/comment.rs
@@ -168,6 +168,11 @@ impl<
         let (form, answer) = self
             .readable_form_and_answer(&Actor::from(actor.clone()), form_id, answer_id)
             .await?;
+        let answer_title = answer
+            .title()
+            .clone()
+            .into_inner()
+            .map(|title| title.into_inner());
         let thread = self
             .comment_thread_repository
             .get_for_answer(&form, answer)
@@ -177,7 +182,6 @@ impl<
             .create_comment(content)?;
         let comment_id = comment.comment_id().to_string();
         let content = comment.content().to_owned().into_inner().into_inner();
-        let form_title = form.title().to_owned().into_inner().into_inner();
         self.comment_thread_repository
             .create(&form, comment)
             .await?;
@@ -185,7 +189,7 @@ impl<
             publisher.publish(ApplicationEvent::CommentCreated {
                 actor: ApplicationActor::from(actor),
                 form_id: form_id.to_string(),
-                form_title,
+                answer_title,
                 answer_id: answer_id.to_string(),
                 comment_id,
                 content,
@@ -221,6 +225,11 @@ impl<
             let (form, answer) = self
                 .readable_form_and_answer(&Actor::from(actor.clone()), form_id, answer_id)
                 .await?;
+            let answer_title = answer
+                .title()
+                .clone()
+                .into_inner()
+                .map(|title| title.into_inner());
             let thread = self
                 .comment_thread_repository
                 .get_with_comments_for_answer(&form, answer)
@@ -238,7 +247,6 @@ impl<
             }
             let content = updated.content().to_owned().into_inner().into_inner();
             let comment_id = updated.comment_id().to_string();
-            let form_title = form.title().to_owned().into_inner().into_inner();
             self.comment_thread_repository
                 .update(&form, updated, Utc::now())
                 .await?;
@@ -246,7 +254,7 @@ impl<
                 publisher.publish(ApplicationEvent::CommentUpdated {
                     actor: ApplicationActor::from(actor),
                     form_id: form_id.to_string(),
-                    form_title,
+                    answer_title,
                     answer_id: answer_id.to_string(),
                     comment_id,
                     content,
@@ -266,6 +274,11 @@ impl<
         let (form, answer) = self
             .readable_form_and_answer(&Actor::from(actor.clone()), form_id, answer_id)
             .await?;
+        let answer_title = answer
+            .title()
+            .clone()
+            .into_inner()
+            .map(|title| title.into_inner());
         let thread = self
             .comment_thread_repository
             .get_with_comments_for_answer(&form, answer)
@@ -279,7 +292,6 @@ impl<
             .to_owned()
             .into_inner()
             .into_inner();
-        let form_title = form.title().to_owned().into_inner().into_inner();
         self.comment_thread_repository
             .delete(&form, comment)
             .await?;
@@ -287,7 +299,7 @@ impl<
             publisher.publish(ApplicationEvent::CommentDeleted {
                 actor: ApplicationActor::from(actor),
                 form_id: form_id.to_string(),
-                form_title,
+                answer_title,
                 answer_id: answer_id.to_string(),
                 comment_id: comment_id.to_string(),
                 content,

--- a/server/usecase/src/forms/message.rs
+++ b/server/usecase/src/forms/message.rs
@@ -117,10 +117,14 @@ impl<
     ) -> Result<(), Error> {
         super::submission::authorize_form_submission(actor.clone(), restriction_repository).await?;
         let actor_user = Actor::from(actor.clone());
-        let (form, form_answer) = self
+        let (_, form_answer) = self
             .read_form_and_answer_entry(&actor_user, form_id, answer_id)
             .await?;
-        let form_title = form.title().to_owned().into_inner().into_inner();
+        let answer_title = form_answer
+            .title()
+            .clone()
+            .into_inner()
+            .map(|title| title.into_inner());
 
         let message = Message::new(*actor.id(), message_body);
         let message_id = message.id().to_string();
@@ -148,7 +152,7 @@ impl<
             publisher.publish(ApplicationEvent::MessageCreated {
                 actor: ApplicationActor::from(actor),
                 form_id: form_id.to_string(),
-                form_title,
+                answer_title,
                 answer_id: answer_id.to_string(),
                 message_id,
                 body: message_body,
@@ -242,9 +246,14 @@ impl<
         body: Option<MessageBody>,
     ) -> Result<(), Error> {
         let actor_user = Actor::from(actor.clone());
-        let (form, form_answer) = self
+        let (_, form_answer) = self
             .read_form_and_answer_entry(&actor_user, form_id, answer_id)
             .await?;
+        let answer_title = form_answer
+            .title()
+            .clone()
+            .into_inner()
+            .map(|title| title.into_inner());
 
         if let Some(body) = body {
             let thread = self
@@ -269,7 +278,7 @@ impl<
                 publisher.publish(ApplicationEvent::MessageUpdated {
                     actor: ApplicationActor::from(actor),
                     form_id: form_id.to_string(),
-                    form_title: form.title().to_owned().into_inner().into_inner(),
+                    answer_title,
                     answer_id: answer_id.to_string(),
                     message_id: message_id.to_string(),
                     body: body_for_event,
@@ -288,9 +297,14 @@ impl<
         message_id: &MessageId,
     ) -> Result<(), Error> {
         let actor_user = Actor::from(actor.clone());
-        let (form, form_answer) = self
+        let (_, form_answer) = self
             .read_form_and_answer_entry(&actor_user, form_id, answer_id)
             .await?;
+        let answer_title = form_answer
+            .title()
+            .clone()
+            .into_inner()
+            .map(|title| title.into_inner());
 
         let thread = self
             .message_thread_repository
@@ -313,7 +327,7 @@ impl<
             publisher.publish(ApplicationEvent::MessageDeleted {
                 actor: ApplicationActor::from(actor),
                 form_id: form_id.to_string(),
-                form_title: form.title().to_owned().into_inner().into_inner(),
+                answer_title,
                 answer_id: answer_id.to_string(),
                 message_id: message_id.to_string(),
                 body: message_body,
@@ -797,9 +811,12 @@ https://example.com/forms/{form_id}/answers/{answer_id}?messageId={message_id}"
     }
 
     #[tokio::test]
-    async fn message_cud_publishes_saved_body_and_skips_empty_or_equal_updates() {
+    async fn message_cud_publishes_answer_title_and_saved_body_and_skips_empty_or_equal_updates() {
         let user = user();
         let (form, answer) = form_and_answer(&user);
+        let answer = answer.with_title(AnswerTitle::new(Some(
+            "回答タイトル".to_string().try_into().unwrap(),
+        )));
         let form_id = *form.id();
         let answer_id = *answer.id();
         let mut repositories = FormUseCaseTestRepositories::with_active_forms(vec![form]);
@@ -855,10 +872,27 @@ https://example.com/forms/{form_id}/answers/{answer_id}?messageId={message_id}"
         assert!(matches!(
             events.as_slice(),
             [
-                ApplicationEvent::MessageCreated { body: created, .. },
-                ApplicationEvent::MessageUpdated { body: updated, .. },
-                ApplicationEvent::MessageDeleted { body: deleted, .. }
-            ] if created == "original" && updated == "updated" && deleted == "updated"
+                ApplicationEvent::MessageCreated {
+                    answer_title: created_title,
+                    body: created,
+                    ..
+                },
+                ApplicationEvent::MessageUpdated {
+                    answer_title: updated_title,
+                    body: updated,
+                    ..
+                },
+                ApplicationEvent::MessageDeleted {
+                    answer_title: deleted_title,
+                    body: deleted,
+                    ..
+                }
+            ] if created_title.as_deref() == Some("回答タイトル")
+                && updated_title.as_deref() == Some("回答タイトル")
+                && deleted_title.as_deref() == Some("回答タイトル")
+                && created == "original"
+                && updated == "updated"
+                && deleted == "updated"
         ));
     }
 


### PR DESCRIPTION
## 概要
- Issue #1329 に対応し、コメント・メッセージの作成／更新／削除通知でフォーム名ではなく回答タイトルを表示します。
- 回答タイトルがない場合は「（タイトルなし）」を表示します。
- フォーム操作と回答投稿通知、既存のリンクやフィールド構成は変更していません。

## 確認事項
- 関連する presentation/usecase テストを実行し、合計8件が成功しました。
- `cargo build` と `cargo fmt --all -- --check` が成功しました。
- `git diff --check` が成功しました。
- コミットフックでビルドと OpenAPI 生成後の `docs/openapi.json` 差分確認が成功しました。

## 補足
- `makers pretty` はキャッシュ・Cargo レジストリ書き込みおよびロック取得の権限制約により完走できませんでした。
- Closes #1329

🤖 Generated with Codex