### PR TITLE
feat: 回答ステータス変更をグローバルWebhookで通知

### DIFF
--- a/server/domain/src/form/answer/mod.rs
+++ b/server/domain/src/form/answer/mod.rs
@@ -24,7 +24,8 @@ pub use settings::{
     AnswerVisibility, DefaultAnswerTitle,
 };
 pub use status::{
-    AnswerStatus, AnswerStatusHistoryEntry, AnswerStatusHistoryId, AnswerStatusHistoryPagePosition,
+    AnswerStatus, AnswerStatusChange, AnswerStatusHistoryEntry, AnswerStatusHistoryId,
+    AnswerStatusHistoryPagePosition,
 };
 pub use title::{
     AnswerTitle, AnswerTitleHistoryEntry, AnswerTitleHistoryId, AnswerTitleHistoryPagePosition,

--- a/server/domain/src/form/answer/status.rs
+++ b/server/domain/src/form/answer/status.rs
@@ -25,6 +25,26 @@ pub enum AnswerStatus {
     COMPLETED,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct AnswerStatusChange {
+    from: AnswerStatus,
+    to: AnswerStatus,
+}
+
+impl AnswerStatusChange {
+    pub fn new(from: AnswerStatus, to: AnswerStatus) -> Option<Self> {
+        (from != to).then_some(Self { from, to })
+    }
+
+    pub fn from(self) -> AnswerStatus {
+        self.from
+    }
+
+    pub fn to(self) -> AnswerStatus {
+        self.to
+    }
+}
+
 impl TryFrom<String> for AnswerStatus {
     type Error = DomainError;
 

--- a/server/domain/src/repository/form/answer_entry_repository.rs
+++ b/server/domain/src/repository/form/answer_entry_repository.rs
@@ -5,8 +5,8 @@ use mockall::automock;
 use crate::{
     form::{
         answer::{
-            AnswerEntry, AnswerId, AnswerPagePosition, AnswerStatus, AnswerStatusHistoryEntry,
-            AnswerStatusHistoryPagePosition, AnswerTitleHistoryEntry,
+            AnswerEntry, AnswerId, AnswerPagePosition, AnswerStatus, AnswerStatusChange,
+            AnswerStatusHistoryEntry, AnswerStatusHistoryPagePosition, AnswerTitleHistoryEntry,
             AnswerTitleHistoryPagePosition,
         },
         models::ActiveForm,
@@ -54,7 +54,7 @@ pub trait AnswerEntryRepository: Send + Sync + 'static {
         &self,
         form: &Allowed<ActiveForm, Update>,
         answer_entry: &Allowed<AnswerEntry, Update>,
-    ) -> Result<(), Error>;
+    ) -> Result<Option<AnswerStatusChange>, Error>;
     async fn history(
         &self,
         answer: &Allowed<AnswerEntry, Read>,

--- a/server/infra/resource/src/database/components.rs
+++ b/server/infra/resource/src/database/components.rs
@@ -22,7 +22,7 @@ use domain::{
         FormSubmissionRestriction,
         answer::{
             AnswerEntry, AnswerId, AnswerLabel, AnswerLabelId, AnswerPagePosition,
-            AnswerPublication, AnswerReference, AnswerRelation, AnswerStatus,
+            AnswerPublication, AnswerReference, AnswerRelation, AnswerStatus, AnswerStatusChange,
             AnswerStatusHistoryPagePosition, AnswerTitleHistoryPagePosition,
         },
         comment::{Comment, CommentHistoryPagePosition, CommentId, DeletedComment},
@@ -150,7 +150,7 @@ pub trait FormAnswerDatabase: Send + Sync {
         answer_entry: &AnswerEntry,
         form_id: FormId,
         updated_by: &AccountUser,
-    ) -> Result<(), InfraError>;
+    ) -> Result<Option<AnswerStatusChange>, InfraError>;
     async fn fetch_status_history(
         &self,
         answer_id: AnswerId,

--- a/server/infra/resource/src/database/forms/answers.rs
+++ b/server/infra/resource/src/database/forms/answers.rs
@@ -5,9 +5,9 @@ use domain::{
     account::models::{AccountUser, Role},
     form::{
         answer::{
-            AnswerAuthor, AnswerEntry, AnswerId, AnswerStatusHistoryPagePosition,
-            AnswerTitleHistoryPagePosition, RedmineImportedAnswerReference, RedmineUserSnapshot,
-            TemporaryAnswerAuthor,
+            AnswerAuthor, AnswerEntry, AnswerId, AnswerStatus, AnswerStatusChange,
+            AnswerStatusHistoryPagePosition, AnswerTitleHistoryPagePosition,
+            RedmineImportedAnswerReference, RedmineUserSnapshot, TemporaryAnswerAuthor,
         },
         models::FormId,
     },
@@ -545,7 +545,7 @@ impl FormAnswerDatabase for ConnectionPool {
         answer_entry: &AnswerEntry,
         form_id: FormId,
         updated_by: &AccountUser,
-    ) -> Result<(), InfraError> {
+    ) -> Result<Option<AnswerStatusChange>, InfraError> {
         let answer_id = answer_entry.id().to_owned().into_inner().to_string();
         let form_id = form_id.into_inner().to_string();
         let redmine_issue_id = validated_redmine_issue_id(answer_entry)?;
@@ -553,7 +553,8 @@ impl FormAnswerDatabase for ConnectionPool {
         let title = <Option<NonEmptyString> as Clone>::clone(&answer_entry.title().to_owned())
             .map(|title| title.into_inner());
         let publication = answer_entry.publication().to_string();
-        let status = answer_entry.status().to_string();
+        let status = *answer_entry.status();
+        let persisted_status = status.to_string();
         let updated_by = updated_by.clone();
 
         self.read_write_transaction(|txn| {
@@ -582,15 +583,22 @@ impl FormAnswerDatabase for ConnectionPool {
                     cause: "answer to update was not found".to_string(),
                 })?;
 
-                if current.status != status {
+                let current_status = AnswerStatus::try_from(current.status.clone()).map_err(
+                    |error| InfraError::Unexpected {
+                        cause: error.to_string(),
+                    },
+                )?;
+                let status_change = AnswerStatusChange::new(current_status, status);
+
+                if let Some(status_change) = status_change {
                     sqlx::query!(
                         r"INSERT INTO form_answer_status_history
                         (id, answer_id, from_status, to_status, changed_by_id, changed_by_name, changed_by_role)
                         VALUES (?, ?, ?, ?, ?, ?, ?)",
                         Uuid::now_v7().to_string(),
                         answer_id,
-                        current.status,
-                        status,
+                        status_change.from().to_string(),
+                        status_change.to().to_string(),
                         updated_by.id().to_string(),
                         updated_by.name(),
                         updated_by.role().to_string(),
@@ -622,7 +630,7 @@ impl FormAnswerDatabase for ConnectionPool {
                     WHERE id = ? AND form_id = ?",
                     title,
                     publication,
-                    status,
+                    persisted_status,
                     answer_id,
                     form_id,
                 )
@@ -639,7 +647,7 @@ impl FormAnswerDatabase for ConnectionPool {
                     .execute(&mut **txn)
                     .await?;
                 }
-                Ok::<_, InfraError>(())
+                Ok::<_, InfraError>(status_change)
             })
         })
         .await

--- a/server/infra/resource/src/repository/form_repository_impls/answer_entry_repository_impl.rs
+++ b/server/infra/resource/src/repository/form_repository_impls/answer_entry_repository_impl.rs
@@ -6,9 +6,9 @@ use domain::{
     auth::Actor,
     form::{
         answer::{
-            AnswerEntry, AnswerId, AnswerPagePosition, AnswerStatus, AnswerStatusHistoryEntry,
-            AnswerStatusHistoryPagePosition, AnswerTitle, AnswerTitleHistoryEntry,
-            AnswerTitleHistoryPagePosition,
+            AnswerEntry, AnswerId, AnswerPagePosition, AnswerStatus, AnswerStatusChange,
+            AnswerStatusHistoryEntry, AnswerStatusHistoryPagePosition, AnswerTitle,
+            AnswerTitleHistoryEntry, AnswerTitleHistoryPagePosition,
         },
         models::ActiveForm,
     },
@@ -198,8 +198,9 @@ where
         &self,
         _form: &Allowed<ActiveForm, Update>,
         answer_entry: &Allowed<AnswerEntry, Update>,
-    ) -> Result<(), Error> {
-        self.client
+    ) -> Result<Option<AnswerStatusChange>, Error> {
+        let status_change = self
+            .client
             .form_answer()
             .update_answer_entry(
                 answer_entry.value(),
@@ -215,7 +216,7 @@ where
                 },
             )
             .await?;
-        Ok(())
+        Ok(status_change)
     }
 
     async fn history(

--- a/server/presentation/src/api/global_discord_webhook.rs
+++ b/server/presentation/src/api/global_discord_webhook.rs
@@ -191,6 +191,36 @@ pub(crate) fn message_from_event(
             .concat();
             (form_title, link_url, fields)
         }
+        ApplicationEvent::AnswerStatusChanged {
+            actor,
+            form_id,
+            answer_title,
+            answer_id,
+            status_change,
+        } => {
+            let link_url = format!("{frontend}/forms/{form_id}/answers/{answer_id}");
+            let fields = [
+                actor_fields(actor),
+                vec![
+                    DiscordWebhookField::new(
+                        "変更前のステータス".to_string(),
+                        status_change.from().to_string(),
+                        true,
+                    ),
+                    DiscordWebhookField::new(
+                        "変更後のステータス".to_string(),
+                        status_change.to().to_string(),
+                        true,
+                    ),
+                ],
+            ]
+            .concat();
+            (
+                answer_title.unwrap_or_else(|| "（タイトルなし）".to_string()),
+                link_url,
+                fields,
+            )
+        }
         ApplicationEvent::CommentCreated {
             actor,
             form_id,
@@ -282,6 +312,7 @@ fn operation_name(event: &ApplicationEvent) -> &'static str {
         ApplicationEvent::FormArchived { .. } => "form_archived",
         ApplicationEvent::FormRestored { .. } => "form_restored",
         ApplicationEvent::AnswerSubmitted { .. } => "answer_submitted",
+        ApplicationEvent::AnswerStatusChanged { .. } => "answer_status_changed",
         ApplicationEvent::CommentCreated { .. } => "comment_created",
         ApplicationEvent::CommentUpdated { .. } => "comment_updated",
         ApplicationEvent::CommentDeleted { .. } => "comment_deleted",
@@ -299,6 +330,7 @@ fn operation_display_name(event: &ApplicationEvent) -> &'static str {
         ApplicationEvent::FormArchived { .. } => "がアーカイブされました",
         ApplicationEvent::FormRestored { .. } => "が復元されました",
         ApplicationEvent::AnswerSubmitted { .. } => "に回答が投稿されました",
+        ApplicationEvent::AnswerStatusChanged { .. } => "の対応ステータスが変更されました",
         ApplicationEvent::CommentCreated { .. } => "にコメントが投稿されました",
         ApplicationEvent::CommentUpdated { .. } => "のコメントが更新されました",
         ApplicationEvent::CommentDeleted { .. } => "のコメントが削除されました",
@@ -311,6 +343,7 @@ fn operation_display_name(event: &ApplicationEvent) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use domain::form::answer::{AnswerStatus, AnswerStatusChange};
 
     #[test]
     fn message_from_event_uses_the_explicit_frontend_url() {
@@ -419,6 +452,73 @@ mod tests {
                 .fields
                 .iter()
                 .all(|field| field.name != "実行者" && field.name != "実行者ID")
+        );
+    }
+
+    #[test]
+    fn answer_status_changed_event_uses_the_answer_title_and_transition_fields() {
+        let message = message_from_event(
+            ApplicationEvent::AnswerStatusChanged {
+                actor: ApplicationActor {
+                    display_name: "administrator".to_string(),
+                    account_id: Some("account-id".to_string()),
+                },
+                form_id: "form-id".to_string(),
+                answer_title: Some("Answer".to_string()),
+                answer_id: "answer-id".to_string(),
+                status_change: AnswerStatusChange::new(
+                    AnswerStatus::UNADDRESSED,
+                    AnswerStatus::IN_PROGRESS,
+                )
+                .unwrap(),
+            },
+            "https://discord.com/api/webhooks/123/token".to_string(),
+            "https://portal.example.com/",
+        );
+
+        assert_eq!(message.title, "「Answer」の対応ステータスが変更されました");
+        assert_eq!(
+            message.link_url,
+            "https://portal.example.com/forms/form-id/answers/answer-id"
+        );
+        assert!(
+            message
+                .fields
+                .iter()
+                .any(|field| { field.name == "実行者" && field.value == "administrator" })
+        );
+        assert!(message.fields.iter().any(|field| {
+            field.name == "変更前のステータス" && field.value == "UNADDRESSED"
+        }));
+        assert!(message.fields.iter().any(|field| {
+            field.name == "変更後のステータス" && field.value == "IN_PROGRESS"
+        }));
+    }
+
+    #[test]
+    fn answer_status_changed_event_uses_the_missing_title_placeholder() {
+        let message = message_from_event(
+            ApplicationEvent::AnswerStatusChanged {
+                actor: ApplicationActor {
+                    display_name: "administrator".to_string(),
+                    account_id: Some("account-id".to_string()),
+                },
+                form_id: "form-id".to_string(),
+                answer_title: None,
+                answer_id: "answer-id".to_string(),
+                status_change: AnswerStatusChange::new(
+                    AnswerStatus::IN_PROGRESS,
+                    AnswerStatus::COMPLETED,
+                )
+                .unwrap(),
+            },
+            "https://discord.com/api/webhooks/123/token".to_string(),
+            "https://portal.example.com/",
+        );
+
+        assert_eq!(
+            message.title,
+            "「（タイトルなし）」の対応ステータスが変更されました"
         );
     }
 }

--- a/server/usecase/src/application_event.rs
+++ b/server/usecase/src/application_event.rs
@@ -1,4 +1,7 @@
-use domain::{account::models::AccountUser, form::answer::TemporaryAnswerAuthor};
+use domain::{
+    account::models::AccountUser,
+    form::answer::{AnswerStatusChange, TemporaryAnswerAuthor},
+};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ApplicationActor {
@@ -76,6 +79,13 @@ pub enum ApplicationEvent {
         form_title: String,
         answer_id: String,
         details: Vec<EventDetail>,
+    },
+    AnswerStatusChanged {
+        actor: ApplicationActor,
+        form_id: String,
+        answer_title: Option<String>,
+        answer_id: String,
+        status_change: AnswerStatusChange,
     },
     CommentCreated {
         actor: ApplicationActor,

--- a/server/usecase/src/forms/answer.rs
+++ b/server/usecase/src/forms/answer.rs
@@ -7,9 +7,10 @@ use domain::{
     form::{
         answer::{
             AnswerAuthor, AnswerAuthorDisclosure, AnswerEntry, AnswerId, AnswerLabel,
-            AnswerPagePosition, AnswerPublication, AnswerStatus, AnswerStatusHistoryEntry,
-            AnswerStatusHistoryPagePosition, AnswerTitle, AnswerTitleHistoryEntry,
-            AnswerTitleHistoryPagePosition, FormAnswerContent, PostedAnswerContents,
+            AnswerPagePosition, AnswerPublication, AnswerStatus, AnswerStatusChange,
+            AnswerStatusHistoryEntry, AnswerStatusHistoryPagePosition, AnswerTitle,
+            AnswerTitleHistoryEntry, AnswerTitleHistoryPagePosition, FormAnswerContent,
+            PostedAnswerContents,
         },
         models::{ActiveForm, FormId},
         service::DefaultAnswerTitleDomainService,
@@ -515,12 +516,14 @@ impl<
         let actor_ref = Actor::from(actor.clone());
         let form = self.read_form(form_id, &actor_ref).await?;
 
-        let form_answer = match (title, publication, status) {
-            (None, None, None) => self
-                .answer_entry_repository
-                .get(&form, answer_id)
-                .await?
-                .ok_or(AnswerNotFound)?,
+        let (form_answer, status_change) = match (title, publication, status) {
+            (None, None, None) => (
+                self.answer_entry_repository
+                    .get(&form, answer_id)
+                    .await?
+                    .ok_or(AnswerNotFound)?,
+                None,
+            ),
             (title, publication, status) => {
                 let form_update = self
                     .active_form_repository
@@ -541,16 +544,31 @@ impl<
                     status,
                 )?;
 
-                self.answer_entry_repository
+                let status_change = self
+                    .answer_entry_repository
                     .update(&form_update, &updated_entry)
                     .await?;
 
-                self.answer_entry_repository
-                    .get(&form, answer_id)
-                    .await?
-                    .ok_or(AnswerNotFound)?
+                (
+                    self.answer_entry_repository
+                        .get(&form, answer_id)
+                        .await?
+                        .ok_or(AnswerNotFound)?,
+                    status_change,
+                )
             }
         };
+
+        if let (Some(publisher), Some(status_change)) =
+            (self.application_event_publisher, status_change)
+        {
+            publisher.publish(answer_status_changed_event(
+                actor,
+                form_id,
+                &form_answer,
+                status_change,
+            ));
+        }
 
         let labels = self
             .answer_label_repository
@@ -634,6 +652,25 @@ fn answer_submitted_event(
         form_title: form.title().as_str().to_owned(),
         answer_id: answer.id().to_string(),
         details: title.into_iter().chain(contents).collect(),
+    }
+}
+
+fn answer_status_changed_event(
+    actor: &AccountUser,
+    form_id: FormId,
+    answer: &Allowed<AnswerEntry, Read>,
+    status_change: AnswerStatusChange,
+) -> ApplicationEvent {
+    ApplicationEvent::AnswerStatusChanged {
+        actor: ApplicationActor::from(actor),
+        form_id: form_id.to_string(),
+        answer_title: answer
+            .title()
+            .to_owned()
+            .into_inner()
+            .map(|title| title.into_inner()),
+        answer_id: answer.id().to_string(),
+        status_change,
     }
 }
 
@@ -1103,6 +1140,138 @@ mod tests {
                 source: DomainError::Forbidden
             })
         ));
+    }
+
+    #[tokio::test]
+    async fn status_change_publishes_the_persisted_transition_with_the_updated_title() {
+        let form = sample_form();
+        let form_id = *form.id();
+        let author = active_user("answer author", Role::StandardUser);
+        let administrator = active_user("administrator", Role::Administrator);
+        let answer = AnswerEntry::new(
+            form_id,
+            AnswerAuthor::AuthenticatedUser(*author.id()),
+            AnswerTitle::default(),
+            PostedAnswerContents::try_new(form.questions().as_slice(), vec![answer_to(&form)])
+                .unwrap(),
+        );
+        let answer_id = *answer.id();
+        let mut repositories = FormUseCaseTestRepositories::with_active_forms(vec![form]);
+        repositories.answer_entry_repository =
+            crate::test_utils::repositories::InMemoryAnswerEntryRepository::new(vec![answer]);
+        repositories.user_repository.save_user(author);
+        let labels = EmptyAnswerLabelRepository;
+        let publisher = RecordingPublisher::default();
+        let usecase = AnswerUseCase {
+            active_form_repository: &repositories.active_form_repository,
+            answer_label_repository: &labels,
+            user_repository: &repositories.user_repository,
+            form_submission_restriction_repository: &repositories
+                .form_submission_restriction_repository,
+            answer_entry_repository: &repositories.answer_entry_repository,
+            discord_answer_webhook_notifier: None,
+            application_event_publisher: Some(&publisher),
+        };
+
+        usecase
+            .update_answer_meta(
+                form_id,
+                answer_id,
+                &administrator,
+                Some(AnswerTitle::new(Some(
+                    NonEmptyString::try_new("Updated answer".to_string()).unwrap(),
+                ))),
+                None,
+                Some(AnswerStatus::IN_PROGRESS),
+            )
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            publisher.events().as_slice(),
+            [ApplicationEvent::AnswerStatusChanged {
+                actor: ApplicationActor { display_name, .. },
+                form_id: event_form_id,
+                answer_title: Some(answer_title),
+                answer_id: event_answer_id,
+                status_change,
+            }] if display_name == "administrator"
+                && event_form_id == &form_id.to_string()
+                && answer_title == "Updated answer"
+                && event_answer_id == &answer_id.to_string()
+                && status_change.from() == AnswerStatus::UNADDRESSED
+                && status_change.to() == AnswerStatus::IN_PROGRESS
+        ));
+    }
+
+    #[tokio::test]
+    async fn updates_without_a_status_transition_do_not_publish_a_status_event() {
+        let form = sample_form();
+        let form_id = *form.id();
+        let author = active_user("answer author", Role::StandardUser);
+        let administrator = active_user("administrator", Role::Administrator);
+        let answer = AnswerEntry::new(
+            form_id,
+            AnswerAuthor::AuthenticatedUser(*author.id()),
+            AnswerTitle::default(),
+            PostedAnswerContents::try_new(form.questions().as_slice(), vec![answer_to(&form)])
+                .unwrap(),
+        );
+        let answer_id = *answer.id();
+        let mut repositories = FormUseCaseTestRepositories::with_active_forms(vec![form]);
+        repositories.answer_entry_repository =
+            crate::test_utils::repositories::InMemoryAnswerEntryRepository::new(vec![answer]);
+        repositories.user_repository.save_user(author);
+        let labels = EmptyAnswerLabelRepository;
+        let publisher = RecordingPublisher::default();
+        let usecase = AnswerUseCase {
+            active_form_repository: &repositories.active_form_repository,
+            answer_label_repository: &labels,
+            user_repository: &repositories.user_repository,
+            form_submission_restriction_repository: &repositories
+                .form_submission_restriction_repository,
+            answer_entry_repository: &repositories.answer_entry_repository,
+            discord_answer_webhook_notifier: None,
+            application_event_publisher: Some(&publisher),
+        };
+
+        usecase
+            .update_answer_meta(
+                form_id,
+                answer_id,
+                &administrator,
+                Some(AnswerTitle::new(Some(
+                    NonEmptyString::try_new("Title only".to_string()).unwrap(),
+                ))),
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        usecase
+            .update_answer_meta(
+                form_id,
+                answer_id,
+                &administrator,
+                None,
+                Some(AnswerPublication::PRIVATE),
+                None,
+            )
+            .await
+            .unwrap();
+        usecase
+            .update_answer_meta(
+                form_id,
+                answer_id,
+                &administrator,
+                None,
+                None,
+                Some(AnswerStatus::UNADDRESSED),
+            )
+            .await
+            .unwrap();
+
+        assert!(publisher.events().is_empty());
     }
 
     #[tokio::test]

--- a/server/usecase/src/test_utils/repositories.rs
+++ b/server/usecase/src/test_utils/repositories.rs
@@ -8,7 +8,7 @@ use domain::{
         FormSubmissionRestriction, FormSubmissionRestrictionHistory, FormSubmissionRestrictionId,
         answer::{
             AnswerEntry, AnswerId, AnswerPagePosition, AnswerPublication, AnswerReference,
-            AnswerRelation, AnswerStatus, AnswerStatusHistoryEntry,
+            AnswerRelation, AnswerStatus, AnswerStatusChange, AnswerStatusHistoryEntry,
             AnswerStatusHistoryPagePosition, AnswerTitleHistoryEntry,
             AnswerTitleHistoryPagePosition, ArchivedAnswerEntry, ReadableAnswerRelation,
         },
@@ -422,14 +422,16 @@ impl AnswerEntryRepository for InMemoryAnswerEntryRepository {
         &self,
         _form: &Allowed<ActiveForm, Update>,
         answer_entry: &Allowed<AnswerEntry, Update>,
-    ) -> Result<(), Error> {
+    ) -> Result<Option<AnswerStatusChange>, Error> {
         let mut answers = self.answers.lock().unwrap();
         if let Some(stored_answer) = answers
             .iter_mut()
             .find(|stored| *stored.id() == *answer_entry.id())
         {
+            let status_change =
+                AnswerStatusChange::new(*stored_answer.status(), *answer_entry.status());
             *stored_answer = answer_entry.value().clone();
-            Ok(())
+            Ok(status_change)
         } else {
             Err(not_found_error("AnswerEntry", answer_entry.id()))
         }


### PR DESCRIPTION
## 概要
- 回答ステータスが実際に変更された場合だけ、グローバル Discord webhook へ通知します。
- DB トランザクションで確定した変更前後のステータスをイベントに含め、回答タイトルと操作者を通知します。

Closes #1327

## 確認事項
- makers pretty: nextest 271件成功（1件スキップ）、doc test、Clippy、rustfmt が成功
- cargo build、関連 crate のテスト、git diff --check が成功
- 回答タイトルあり・なし、変更前後ステータス、同値更新・タイトルのみ・公開状態のみの更新を確認
- DB 更新失敗時や既存の通知経路を壊していないことを確認

## 補足
- 既存の application event と同じ best-effort 配送を使用します。Discord への実送信は環境依存のため未確認です。

🤖 Generated with Codex